### PR TITLE
ci: Add production deploy workflow (dry-run mode)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,49 @@
+name: Deploy ultimamilla.com.ar to Production
+
+on:
+  push:
+    branches: [main]
+
+env:
+  DRY_RUN: true  # Cambiar a 'false' cuando se apruebe migración
+
+jobs:
+  deploy-astro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Build Astro Site
+        run: |
+          npm ci
+          npm run build
+
+      - name: Package Site
+        run: |
+          cd dist
+          tar czf /tmp/ultimamilla-deploy.tar.gz .
+
+      - name: Upload to VPS
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: /tmp/ultimamilla-deploy.tar.gz
+          target: /tmp/
+
+      - name: Deploy Astro Site (Dry-Run)
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            export DRY_RUN=${{ env.DRY_RUN }}
+            bash /opt/scripts-cicd/deploy_ultimamilla.sh


### PR DESCRIPTION
## 🚀 CI/CD Production Deploy - Fase 4

Adds GitHub Actions workflow for automated deployment to production.

### Features
- ✅ Build Astro in GitHub Actions (frees VPS resources)
- ✅ Atomic deploy with releases + symlink
- ✅ Automatic rollback on health check failure
- ✅ **DRY_RUN=true** (safe mode, does not touch production)

### Testing
Merging this PR will trigger the workflow in dry-run mode.

**Part of**: Multi-Project CI/CD Plan - Zero Cost