### PR TITLE
fix(seo): redirect /seguridad → /seguridad-electronica 301

### DIFF
--- a/src/pages/seguridad.astro
+++ b/src/pages/seguridad.astro
@@ -1,0 +1,9 @@
+---
+/**
+ * seguridad.astro → Redirect permanente a /seguridad-electronica
+ * Ambas páginas servían contenido idéntico. La versión canonical es
+ * seguridad-electronica (unified Directus template).
+ */
+
+return Astro.redirect('/seguridad-electronica', 301);
+---


### PR DESCRIPTION
## Summary\n- Converts /seguridad into a 301 permanent redirect to /seguridad-electronica\n- Eliminates duplicate content (both pages served identical content)\n- /seguridad-electronica is the canonical version with the unified Directus template\n\n## Test plan\n- [ ] Visit /seguridad → 301 redirect to /seguridad-electronica\n- [ ] Visit /seguridad-electronica → loads normally\n- [ ] Sitemap already lists /seguridad-electronica (not /seguridad)\n- [ ] No internal links point to /seguridad