### PR TITLE
fix(arca): read form data directly — no more false 'complete el formulario' error

### DIFF
--- a/src/pages/plantilla-arca.astro
+++ b/src/pages/plantilla-arca.astro
@@ -411,10 +411,14 @@ const keywords =
           }
         }
 
-        if (!window.lastFormData) {
-          window.showResult('error', 'Por favor completa el formulario');
+        // Leer datos directamente del formulario (no depender de eventos change)
+        var form = document.querySelector('#formulario-arca');
+        if (!form) {
+          window.showResult('error', 'Formulario no encontrado');
           return;
         }
+        var formData = new FormData(form);
+        window.lastFormData = Object.fromEntries(formData);
 
         btnGenerate.disabled = true;
 


### PR DESCRIPTION
## Summary

Fixes "Error al Generar Factura - Por favor completa el formulario" appearing even when all form fields are filled.

**Root cause:** The click handler used `window.lastFormData`, which is only populated when a `change` event fires on a form field. Text inputs only fire `change` on blur. If the user fills all fields without triggering blur (e.g., autofill, template load, or clicking the button while still on the last field), `lastFormData` stays null.

**Fix:** Read form data directly from `#formulario-arca` using `FormData` in the click handler instead of depending on the cached event value.

## Test plan

- [ ] Fill all fields and click "Generar Factura" without blurring the last field — preview should appear, not the error
- [ ] Browser autofill all fields and generate — same
- [ ] Template load + generate — same
- [ ] Normal fill with tab between fields — regression: should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)