### PR TITLE
fix(arca): read form data directly — no more false 'complete el formulario' error

### DIFF
--- a/src/pages/plantilla-arca.astro
+++ b/src/pages/plantilla-arca.astro
@@ -411,10 +411,14 @@ const keywords =
           }
         }
 
-        if (!window.lastFormData) {
-          window.showResult('error', 'Por favor completa el formulario');
+        // Leer datos directamente del formulario (no depender de eventos change)
+        var form = document.querySelector('#formulario-arca');
+        if (!form) {
+          window.showResult('error', 'Formulario no encontrado');
           return;
         }
+        var formData = new FormData(form);
+        window.lastFormData = Object.fromEntries(formData);
 
         btnGenerate.disabled = true;
 


### PR DESCRIPTION
## Summary

Hotfix for ARCA form: the "complete el formulario" error showed even when all fields were filled, because the click handler depended on a cached `window.lastFormData` that only gets set on blur (`change` event). Now reads form data directly via `FormData`.

Merged to develop via PR #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)