### PR TITLE
fix(blog): restore blog POST auth — add BLOG_API_USER/PASS to PM2 config

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -7,7 +7,9 @@ module.exports = {
     env: {
       NODE_ENV: 'production',
       PORT: 4321,
-      HOST: '0.0.0.0'
+      HOST: '0.0.0.0',
+      BLOG_API_USER: 'admin@umbot.com.ar',
+      BLOG_API_PASS: 'UmbotAdmin2025!',
     },
     error_file: '/root/.pm2/logs/astro-ultimamilla-error.log',
     out_file: '/root/.pm2/logs/astro-ultimamilla-out.log',


### PR DESCRIPTION
## Summary

The blog POST /api/blog endpoint stopped working because the build
environment (GitHub Actions CI) doesn't have BLOG_API_USER/PASS, unlike the
previous local builds (quick-deploy.sh). The import.meta.env values are
inlined as undefined.

**Root cause:** The variables were never set in any environment config file
(only in local .env for builds). When ARCA deploys switched to CI/CD builds,
the inlined values became undefined.

**Fix:** Add BLOG_API_USER/PASS to ecosystem.config.cjs env block so PM2
injects them at runtime via process.env, which is the primary fallback in
the blog.ts code (process.env.?? import.meta.env).

## Test plan

- [ ] Deploy to production
- [ ] POST to /api/blog with Basic Auth → 201 instead of 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)