### PR TITLE
ci: retry production ssh keyscan

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -95,7 +95,11 @@ jobs:
       - name: Add server to known hosts
         run: |
           mkdir -p ~/.ssh
-          ssh-keyscan -H 23.105.176.45 >> ~/.ssh/known_hosts
+          for attempt in 1 2 3; do
+            ssh-keyscan -T 30 -H 23.105.176.45 >> ~/.ssh/known_hosts && break
+            if [ "$attempt" = "3" ]; then exit 1; fi
+            sleep 10
+          done
 
       - name: Deploy to server via rsync
         run: |


### PR DESCRIPTION
## Summary\n- Increase ssh-keyscan timeout in production deploy\n- Retry known_hosts population up to 3 times before failing\n\n## Context\nProduction deploy for 7b14c84 passed build/test but failed before rsync on ssh-keyscan timeout. This keeps deployment in GitHub Actions and only hardens the SSH known_hosts step.