### PR TITLE
Fix production PM2 restart cwd

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -137,7 +137,10 @@ jobs:
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            pm2 delete astro-ultimamilla 2>/dev/null; pm2 start ecosystem.config.cjs
+            cd ${{ env.DEPLOY_PATH }}
+            pm2 delete astro-app 2>/dev/null || true
+            pm2 delete astro-ultimamilla 2>/dev/null || true
+            pm2 start ecosystem.config.cjs
             pm2 save
 
       - name: Health check


### PR DESCRIPTION
## Summary
- Run PM2 restart from the deployed path so the production ecosystem file is used
- Delete the stale astro-app process before starting astro-ultimamilla

## Verification
- Restored production manually with the same cwd/process sequence
- Confirmed homepage returns 200
- Confirmed /estilo/design.md and /estilo/design,md return 200 text/markdown with X-Robots-Tag noindex,nofollow