### PR TITLE
Expose GEO resources in static robots.txt

### DIFF
--- a/__tests__/geoLayer.test.ts
+++ b/__tests__/geoLayer.test.ts
@@ -45,11 +45,15 @@ describe('GEO layer', () => {
   test('adds GEO URLs to sitemap and robots discovery', () => {
     const sitemapIndex = fs.readFileSync(path.join(repoRoot, 'src/pages/sitemap-index.xml.ts'), 'utf8');
     const robots = fs.readFileSync(path.join(repoRoot, 'src/pages/robots.txt.ts'), 'utf8');
+    const staticRobots = fs.readFileSync(path.join(repoRoot, 'public/robots.txt'), 'utf8');
     const geoUrls = getGeoSitemapUrls().map((entry) => entry.loc);
 
     expect(sitemapIndex).toContain('/sitemap-geo.xml');
     expect(robots).toContain('LLMs:');
     expect(robots).toContain('GEO-Knowledge:');
+    expect(staticRobots).toContain('LLMs:');
+    expect(staticRobots).toContain('GEO-Knowledge:');
+    expect(staticRobots).toContain('Sitemap: https://ultimamilla.com.ar/sitemap-geo.xml');
     expect(AI_CRAWLERS).toEqual(expect.arrayContaining(['GPTBot', 'ClaudeBot', 'PerplexityBot']));
     expect(geoUrls).toEqual(expect.arrayContaining([
       'https://ultimamilla.com.ar/llms.txt',

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,4 +10,87 @@ Disallow: /_sectores
 Disallow: /_cli-mobile
 Disallow: /_test-components-v4
 
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+# AI and LLM discovery resources
+User-agent: GPTBot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: ChatGPT-User
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: OAI-SearchBot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: ClaudeBot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Claude-User
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: PerplexityBot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Perplexity-User
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Google-Extended
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Googlebot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Bingbot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: Applebot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+User-agent: DuckAssistBot
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /geo/
+Allow: /sitemap-geo.xml
+
+LLMs: https://ultimamilla.com.ar/llms.txt
+LLMs-Full: https://ultimamilla.com.ar/llms-full.txt
+GEO-Knowledge: https://ultimamilla.com.ar/geo/brand-facts.json
+
 Sitemap: https://ultimamilla.com.ar/sitemap-index.xml
+Sitemap: https://ultimamilla.com.ar/sitemap-geo.xml


### PR DESCRIPTION
## Summary
- Update public/robots.txt so production advertises /llms.txt, /llms-full.txt, /geo/*, and /sitemap-geo.xml
- Extend GEO contract test to cover the static robots file that actually serves production

## Verification
- npm test -- __tests__/geoLayer.test.ts
- Production check before this fix showed /robots.txt was still the static file without GEO lines