### PR TITLE
ci: harden production ssh keyscan retry

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -95,11 +95,16 @@ jobs:
       - name: Add server to known hosts
         run: |
           mkdir -p ~/.ssh
-          for attempt in 1 2 3; do
-            ssh-keyscan -T 30 -H 23.105.176.45 >> ~/.ssh/known_hosts && break
-            if [ "$attempt" = "3" ]; then exit 1; fi
-            sleep 10
+          for attempt in 1 2 3 4 5 6 7 8; do
+            echo "ssh-keyscan attempt $attempt/8"
+            if ssh-keyscan -T 60 -H 23.105.176.45 >> ~/.ssh/known_hosts; then
+              sort -u ~/.ssh/known_hosts -o ~/.ssh/known_hosts
+              exit 0
+            fi
+            sleep 30
           done
+          echo "Unable to reach production SSH host for keyscan after 8 attempts"
+          exit 1
 
       - name: Deploy to server via rsync
         run: |


### PR DESCRIPTION
## Summary
- Increase production ssh-keyscan retry window to tolerate transient SSH/network stalls.
- Deduplicate known_hosts after a successful keyscan.

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-deploy.yml'); puts 'yaml ok'"