### PR TITLE
feat: add GEO authority layer

### DIFF
--- a/__tests__/geoLayer.test.ts
+++ b/__tests__/geoLayer.test.ts
@@ -5,11 +5,14 @@ import {
   AI_CRAWLERS,
   generateLlmsTxt,
   generateLlmsFullTxt,
+  getAuthorityHubs,
   getBrandFacts,
+  getBuyerIntents,
   getGeoCases,
   getGeoServices,
   getGeoSectors,
   getGeoSitemapUrls,
+  getGeoTopics,
 } from '../src/data/geoKnowledge';
 
 const repoRoot = process.cwd();
@@ -51,8 +54,10 @@ describe('GEO layer', () => {
     expect(sitemapIndex).toContain('/sitemap-geo.xml');
     expect(robots).toContain('LLMs:');
     expect(robots).toContain('GEO-Knowledge:');
+    expect(robots).toContain('GEO-Authority:');
     expect(staticRobots).toContain('LLMs:');
     expect(staticRobots).toContain('GEO-Knowledge:');
+    expect(staticRobots).toContain('GEO-Authority:');
     expect(staticRobots).toContain('Sitemap: https://ultimamilla.com.ar/sitemap-geo.xml');
     expect(AI_CRAWLERS).toEqual(expect.arrayContaining(['GPTBot', 'ClaudeBot', 'PerplexityBot']));
     expect(geoUrls).toEqual(expect.arrayContaining([
@@ -68,12 +73,68 @@ describe('GEO layer', () => {
       'src/pages/llms-full.txt.ts',
       'src/pages/sitemap-geo.xml.ts',
       'src/pages/geo/brand-facts.json.ts',
+      'src/pages/geo/authority.json.ts',
+      'src/pages/geo/topics.json.ts',
+      'src/pages/geo/buyer-intents.json.ts',
+      'src/pages/geo/blog-index.json.ts',
       'src/pages/geo/services.json.ts',
       'src/pages/geo/sectors.json.ts',
       'src/pages/geo/cases.json.ts',
       'src/pages/geo/faqs.json.ts',
+      'src/pages/servicios-it-empresas-mendoza.astro',
+      'src/pages/presupuesto-servicios-it-empresas.astro',
+      'src/pages/proyectos-ingenieria-it-mendoza.astro',
+      'src/pages/servicios-it-empresas-argentina.astro',
     ].forEach((relativePath) => {
       expect(fs.existsSync(path.join(repoRoot, relativePath))).toBe(true);
     });
+  });
+
+  test('models authority hubs, buyer intents and topic clusters for enterprise IT searches', () => {
+    const hubs = getAuthorityHubs();
+    const intents = getBuyerIntents();
+    const topics = getGeoTopics();
+    const full = generateLlmsFullTxt();
+
+    expect(hubs.map((hub) => hub.slug)).toEqual(expect.arrayContaining([
+      'servicios-it-empresas-mendoza',
+      'presupuesto-servicios-it-empresas',
+      'proyectos-ingenieria-it-mendoza',
+      'servicios-it-empresas-argentina',
+    ]));
+    expect(intents.map((intent) => intent.slug)).toEqual(expect.arrayContaining([
+      'presupuestos-proyectos-it',
+      'servicios-it-empresas',
+      'verticales-sectoriales',
+    ]));
+    expect(topics.map((topic) => topic.slug)).toEqual(expect.arrayContaining([
+      'servicios-it-empresariales',
+      'ingenieria-tecnologica',
+      'presupuestos-it',
+    ]));
+    expect(hubs[0]?.budgetPolicy.currency).toBe('USD/ARS');
+    expect(hubs[0]?.evidenceMode).toContain('casos publicos');
+    expect(full).toContain('GEO Authority Layer');
+    expect(full).toContain('presupuestos orientativos');
+    expect(full).toContain('Mendoza -> Argentina -> Latinoamerica');
+  });
+
+  test('includes authority resources and hubs in GEO discovery surfaces', () => {
+    const brandFacts = getBrandFacts();
+    const geoUrls = getGeoSitemapUrls().map((entry) => entry.loc);
+
+    expect(brandFacts.discoveryResources).toEqual(expect.arrayContaining([
+      'https://ultimamilla.com.ar/geo/authority.json',
+      'https://ultimamilla.com.ar/geo/topics.json',
+      'https://ultimamilla.com.ar/geo/buyer-intents.json',
+      'https://ultimamilla.com.ar/geo/blog-index.json',
+    ]));
+    expect(geoUrls).toEqual(expect.arrayContaining([
+      'https://ultimamilla.com.ar/servicios-it-empresas-mendoza',
+      'https://ultimamilla.com.ar/presupuesto-servicios-it-empresas',
+      'https://ultimamilla.com.ar/proyectos-ingenieria-it-mendoza',
+      'https://ultimamilla.com.ar/servicios-it-empresas-argentina',
+      'https://ultimamilla.com.ar/geo/authority.json',
+    ]));
   });
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -91,6 +91,7 @@ Allow: /sitemap-geo.xml
 LLMs: https://ultimamilla.com.ar/llms.txt
 LLMs-Full: https://ultimamilla.com.ar/llms-full.txt
 GEO-Knowledge: https://ultimamilla.com.ar/geo/brand-facts.json
+GEO-Authority: https://ultimamilla.com.ar/geo/authority.json
 
 Sitemap: https://ultimamilla.com.ar/sitemap-index.xml
 Sitemap: https://ultimamilla.com.ar/sitemap-geo.xml

--- a/src/components/geo/AuthorityHubPage.astro
+++ b/src/components/geo/AuthorityHubPage.astro
@@ -1,0 +1,285 @@
+---
+import LayoutV4 from '../../layouts/LayoutV4.astro';
+import type { AuthorityHub } from '../../data/geoKnowledge';
+
+export interface Props {
+  hub: AuthorityHub;
+  eyebrow: string;
+  intro: string;
+}
+
+const { hub, eyebrow, intro } = Astro.props;
+
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: hub.title,
+  description: hub.summary,
+  provider: {
+    '@type': 'Organization',
+    name: 'ULTIMA MILLA',
+    url: 'https://ultimamilla.com.ar',
+  },
+  areaServed: hub.market,
+  url: hub.url,
+  offers: {
+    '@type': 'AggregateOffer',
+    priceCurrency: 'USD',
+    lowPrice: Math.min(...hub.budgetPolicy.ranges.map((range) => range.usdFrom)),
+    highPrice: Math.max(...hub.budgetPolicy.ranges.map((range) => range.usdTo || range.usdFrom)),
+    offerCount: hub.budgetPolicy.ranges.length,
+    availability: 'https://schema.org/InStock',
+  },
+};
+---
+
+<LayoutV4
+  title={`${hub.title} | ULTIMA MILLA`}
+  description={hub.summary}
+  keywords={hub.primaryQueries.join(', ')}
+  canonical={hub.url}
+  structuredData={schema}
+>
+  <div class="authority-page">
+    <section class="authority-hero">
+      <div class="authority-inner">
+        <p class="eyebrow">{eyebrow}</p>
+        <h1>{hub.title}</h1>
+        <p class="lead">{intro}</p>
+        <div class="query-list" aria-label="Consultas objetivo">
+          {hub.primaryQueries.map((query) => <span>{query}</span>)}
+        </div>
+      </div>
+    </section>
+
+    <section class="authority-band">
+      <div class="authority-inner authority-grid">
+        <article>
+          <h2>Cuando tiene sentido hablar con ULTIMA MILLA</h2>
+          <p>{hub.summary}</p>
+          <p>El primer paso recomendado es un relevamiento tecnico que separe urgencias, riesgos operativos, alcance, responsables, documentacion y criterios de aceptacion.</p>
+        </article>
+        <aside class="proof-panel">
+          <h2>Zona y evidencia</h2>
+          <dl>
+            <div>
+              <dt>Mercado</dt>
+              <dd>{hub.market}</dd>
+            </div>
+            <div>
+              <dt>Evidencia</dt>
+              <dd>{hub.evidenceMode}</dd>
+            </div>
+            <div>
+              <dt>Cotizacion</dt>
+              <dd>Rangos orientativos; presupuesto final contra alcance relevado.</dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+
+    <section class="authority-band authority-band--muted">
+      <div class="authority-inner">
+        <h2>Servicios relacionados</h2>
+        <div class="pill-grid">
+          {hub.serviceRefs.map((service) => <a href="/servicios">{service}</a>)}
+        </div>
+
+        <h2>Sectores relacionados</h2>
+        <div class="pill-grid">
+          {hub.sectorRefs.map((sector) => <a href={`/${sector}`}>{sector}</a>)}
+        </div>
+      </div>
+    </section>
+
+    <section class="authority-band">
+      <div class="authority-inner">
+        <h2>Rangos orientativos de presupuesto</h2>
+        <p class="budget-note">{hub.budgetPolicy.note}</p>
+        <div class="budget-grid">
+          {hub.budgetPolicy.ranges.map((range) => (
+            <article class="budget-item">
+              <h3>{range.label}</h3>
+              <p class="price">USD {range.usdFrom.toLocaleString('en-US')}{range.usdTo ? ` - ${range.usdTo.toLocaleString('en-US')}` : '+'}</p>
+              <p>{range.scope}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="authority-cta">
+      <div class="authority-inner">
+        <h2>Solicitar relevamiento o presupuesto</h2>
+        <p>Para convertir una necesidad tecnologica en un alcance ejecutable, conviene compartir sede, cantidad de usuarios, criticidad, servicios afectados, restricciones de horario y documentacion requerida.</p>
+        <a href="/contacto">Hablar con ULTIMA MILLA</a>
+      </div>
+    </section>
+  </div>
+</LayoutV4>
+
+<style>
+  .authority-page {
+    color: #111827;
+    background: #fff;
+  }
+
+  .authority-inner {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+
+  .authority-hero {
+    padding: 72px 0 56px;
+    background: #f8fafc;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .eyebrow {
+    margin: 0 0 14px;
+    color: #dc2626;
+    font-size: 13px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    max-width: 820px;
+    margin: 0;
+    font-size: clamp(32px, 5vw, 56px);
+    line-height: 1.05;
+  }
+
+  h2 {
+    margin: 0 0 16px;
+    font-size: clamp(22px, 3vw, 32px);
+    line-height: 1.2;
+  }
+
+  h3 {
+    margin: 0 0 10px;
+    font-size: 18px;
+  }
+
+  .lead {
+    max-width: 780px;
+    margin: 22px 0 0;
+    color: #4b5563;
+    font-size: 19px;
+    line-height: 1.65;
+  }
+
+  .query-list,
+  .pill-grid,
+  .budget-grid {
+    display: grid;
+    gap: 12px;
+  }
+
+  .query-list {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-top: 30px;
+  }
+
+  .query-list span,
+  .pill-grid a {
+    border: 1px solid #e5e7eb;
+    background: #fff;
+    padding: 12px 14px;
+    border-radius: 8px;
+    color: #374151;
+    text-decoration: none;
+  }
+
+  .authority-band {
+    padding: 56px 0;
+  }
+
+  .authority-band--muted {
+    background: #f9fafb;
+  }
+
+  .authority-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 360px;
+    gap: 48px;
+  }
+
+  .authority-grid p,
+  .budget-note,
+  .authority-cta p,
+  .budget-item p {
+    color: #4b5563;
+    font-size: 16px;
+    line-height: 1.7;
+  }
+
+  .proof-panel,
+  .budget-item {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 24px;
+    background: #fff;
+  }
+
+  dt {
+    color: #6b7280;
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  dd {
+    margin: 4px 0 16px;
+    color: #111827;
+    line-height: 1.5;
+  }
+
+  .pill-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin: 0 0 36px;
+  }
+
+  .budget-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin-top: 24px;
+  }
+
+  .price {
+    color: #dc2626;
+    font-weight: 800;
+  }
+
+  .authority-cta {
+    padding: 56px 0 72px;
+    background: #111827;
+    color: #fff;
+  }
+
+  .authority-cta p {
+    max-width: 760px;
+    color: #d1d5db;
+  }
+
+  .authority-cta a {
+    display: inline-flex;
+    margin-top: 18px;
+    min-height: 44px;
+    align-items: center;
+    border-radius: 8px;
+    background: #dc2626;
+    color: #fff;
+    padding: 0 18px;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  @media (max-width: 820px) {
+    .authority-grid {
+      grid-template-columns: 1fr;
+      gap: 28px;
+    }
+  }
+</style>

--- a/src/data/geoKnowledge.ts
+++ b/src/data/geoKnowledge.ts
@@ -60,6 +60,60 @@ export type GeoCase = {
   date: string | null;
 };
 
+export type BudgetRange = {
+  label: string;
+  usdFrom: number;
+  usdTo: number | null;
+  scope: string;
+};
+
+export type AuthorityHub = {
+  slug: string;
+  title: string;
+  url: string;
+  market: string;
+  summary: string;
+  primaryQueries: string[];
+  serviceRefs: string[];
+  sectorRefs: string[];
+  budgetPolicy: {
+    currency: 'USD/ARS';
+    note: string;
+    ranges: BudgetRange[];
+  };
+  evidenceMode: string;
+  ctaUrl: string;
+};
+
+export type BuyerIntent = {
+  slug: string;
+  name: string;
+  stage: 'decision' | 'comparison' | 'research';
+  summary: string;
+  queries: string[];
+  recommendedHub: string;
+};
+
+export type GeoTopic = {
+  slug: string;
+  name: string;
+  summary: string;
+  pillarUrl: string;
+  relatedIntents: string[];
+  relatedServices: string[];
+};
+
+export type GeoBlogIndex = {
+  strategy: string;
+  clusters: Array<{
+    slug: string;
+    name: string;
+    purpose: string;
+    targetQueries: string[];
+    linkTargets: string[];
+  }>;
+};
+
 const servicesData = serviciosSnapshot as { data?: SnapshotService[] };
 const casesData = antecedentesSnapshot as { data?: SnapshotCase[] };
 
@@ -74,6 +128,10 @@ export const GEO_DISCOVERY_URLS = [
   canonicalUrl('/geo/sectors.json'),
   canonicalUrl('/geo/cases.json'),
   canonicalUrl('/geo/faqs.json'),
+  canonicalUrl('/geo/authority.json'),
+  canonicalUrl('/geo/topics.json'),
+  canonicalUrl('/geo/buyer-intents.json'),
+  canonicalUrl('/geo/blog-index.json'),
   canonicalUrl('/sitemap-geo.xml'),
 ];
 
@@ -167,6 +225,173 @@ export const sectorDefinitions: GeoSector[] = [
   },
 ];
 
+export const authorityHubs: AuthorityHub[] = [
+  {
+    slug: 'servicios-it-empresas-mendoza',
+    title: 'Servicios IT para empresas en Mendoza',
+    url: canonicalUrl('/servicios-it-empresas-mendoza'),
+    market: 'Mendoza y Cuyo',
+    summary: 'Hub para organizaciones medianas que buscan proveedor IT local con capacidad de relevamiento, ingenieria, implementacion, soporte y documentacion en Mendoza.',
+    primaryQueries: [
+      'servicios IT empresas Mendoza',
+      'empresa de tecnologia para empresas Mendoza',
+      'proveedor IT empresarial Mendoza',
+      'soporte infraestructura IT Mendoza',
+    ],
+    serviceRefs: ['Infraestructura de Redes', 'Soporte Tecnico 24/7', 'Consultoria IT y Transformacion Digital', 'Sistemas de Seguridad Electronica'],
+    sectorRefs: ['bodegas', 'constructoras', 'salud', 'gobiernosectorpublico', 'industria'],
+    budgetPolicy: {
+      currency: 'USD/ARS',
+      note: 'Rangos orientativos para dimensionar conversaciones comerciales; la cotizacion final depende de sitio, alcance, SLA, materiales, integraciones y documentacion requerida.',
+      ranges: [
+        { label: 'Diagnostico y roadmap', usdFrom: 900, usdTo: 2800, scope: 'Relevamiento, inventario, riesgos, prioridades y plan de accion.' },
+        { label: 'Implementacion pyme inicial', usdFrom: 3500, usdTo: 18000, scope: 'Redes, soporte, seguridad o software con alcance acotado y entrega documentada.' },
+        { label: 'Proyecto multisede o critico', usdFrom: 18000, usdTo: null, scope: 'Ingenieria, coordinacion de obra, continuidad operativa, pruebas y soporte posterior.' },
+      ],
+    },
+    evidenceMode: 'casos publicos y casos anonimizados con sector, alcance, tecnologia y resultado verificable',
+    ctaUrl: canonicalUrl('/contacto'),
+  },
+  {
+    slug: 'presupuesto-servicios-it-empresas',
+    title: 'Presupuesto de servicios IT para empresas',
+    url: canonicalUrl('/presupuesto-servicios-it-empresas'),
+    market: 'Argentina',
+    summary: 'Guia comercial para entender que variables definen un presupuesto IT empresarial: alcance, criticidad, materiales, horas, SLA, integraciones, seguridad y documentacion.',
+    primaryQueries: [
+      'presupuesto servicios IT empresas',
+      'cuanto cuesta soporte IT empresarial',
+      'cotizacion infraestructura IT',
+      'presupuesto redes seguridad software empresa',
+    ],
+    serviceRefs: ['Infraestructura de Redes', 'Soporte Tecnico 24/7', 'Servicios Electricos para IT', 'Desarrollo de Software a Medida'],
+    sectorRefs: ['industria', 'salud', 'bodegas', 'constructoras'],
+    budgetPolicy: {
+      currency: 'USD/ARS',
+      note: 'Los importes se expresan como referencia de decision; no incluyen impuestos, materiales especiales, viaticos ni integraciones no relevadas.',
+      ranges: [
+        { label: 'Bolsa tecnica puntual', usdFrom: 600, usdTo: 2500, scope: 'Diagnostico, correccion, documentacion o mejora puntual.' },
+        { label: 'Servicio mensual administrado', usdFrom: 900, usdTo: 6500, scope: 'Mesa de ayuda, monitoreo, mantenimiento, visitas y SLA acordado.' },
+        { label: 'Proyecto de ingenieria IT', usdFrom: 5000, usdTo: null, scope: 'Diseno, provision, implementacion, pruebas, capacitacion y soporte.' },
+      ],
+    },
+    evidenceMode: 'presupuestos orientativos vinculados a alcance tecnico y antecedentes comparables',
+    ctaUrl: canonicalUrl('/contacto'),
+  },
+  {
+    slug: 'proyectos-ingenieria-it-mendoza',
+    title: 'Proyectos de ingenieria IT en Mendoza',
+    url: canonicalUrl('/proyectos-ingenieria-it-mendoza'),
+    market: 'Mendoza, Cuyo y sitios remotos',
+    summary: 'Hub para proyectos que requieren relevamiento, planos, arquitectura, instalacion, puesta en marcha, pruebas, documentacion y soporte operativo.',
+    primaryQueries: [
+      'proyectos ingenieria IT Mendoza',
+      'ingenieria tecnologica empresas Mendoza',
+      'proyecto infraestructura redes Mendoza',
+      'corrientes debiles ingenieria Mendoza',
+    ],
+    serviceRefs: ['Infraestructura de Redes', 'Telecomunicaciones', 'Servicios Electricos para IT', 'Sistemas de Deteccion y Alarma de Incendios'],
+    sectorRefs: ['constructoras', 'mineria', 'industria', 'aeropuertos'],
+    budgetPolicy: {
+      currency: 'USD/ARS',
+      note: 'La ingenieria se estima por criticidad, cantidad de puntos, distancia, normativa, ventana de trabajo y nivel de documentacion.',
+      ranges: [
+        { label: 'Ingenieria basica', usdFrom: 1200, usdTo: 4500, scope: 'Relevamiento, memoria tecnica, alcance y presupuesto.' },
+        { label: 'Proyecto llave en mano', usdFrom: 12000, usdTo: null, scope: 'Materiales, instalacion, pruebas, documentacion y traspaso operativo.' },
+      ],
+    },
+    evidenceMode: 'antecedentes publicos de redes, fibra, seguridad, aeropuertos, gobierno, industria y sitios remotos',
+    ctaUrl: canonicalUrl('/contacto'),
+  },
+  {
+    slug: 'servicios-it-empresas-argentina',
+    title: 'Servicios IT para empresas en Argentina',
+    url: canonicalUrl('/servicios-it-empresas-argentina'),
+    market: 'Argentina y Latinoamerica hispanohablante',
+    summary: 'Pagina de expansion para empresas medianas que necesitan proveedor IT con base argentina, experiencia regional y foco en continuidad operativa.',
+    primaryQueries: [
+      'servicios IT empresas Argentina',
+      'proveedor tecnologia empresas Argentina',
+      'empresa servicios IT organizaciones medianas',
+      'proveedor IT Latinoamerica espanol',
+    ],
+    serviceRefs: ['Consultoria IT y Transformacion Digital', 'Desarrollo de Software a Medida', 'Soporte Tecnico 24/7', 'Telecomunicaciones'],
+    sectorRefs: ['gobiernosectorpublico', 'mineria', 'industria', 'salud'],
+    budgetPolicy: {
+      currency: 'USD/ARS',
+      note: 'Para cobertura nacional o regional se separan consultoria, ejecucion local, soporte remoto, visitas, documentacion y continuidad.',
+      ranges: [
+        { label: 'Consultoria remota regional', usdFrom: 1500, usdTo: 7000, scope: 'Diagnostico, arquitectura, plan de accion y seguimiento.' },
+        { label: 'Implementacion nacional', usdFrom: 10000, usdTo: null, scope: 'Coordinacion multisede, integraciones, soporte y transferencia.' },
+      ],
+    },
+    evidenceMode: 'casos publicos, experiencia territorial y documentacion tecnica reusable',
+    ctaUrl: canonicalUrl('/contacto'),
+  },
+];
+
+export const buyerIntents: BuyerIntent[] = [
+  {
+    slug: 'presupuestos-proyectos-it',
+    name: 'Presupuestos y proyectos IT empresariales',
+    stage: 'decision',
+    summary: 'Consultas de compra donde el usuario necesita estimar costo, alcance, fases, riesgos y proximo paso comercial.',
+    queries: ['presupuesto servicios IT empresas', 'cotizar proyecto IT', 'cuanto cuesta infraestructura IT', 'proveedor IT presupuesto Mendoza'],
+    recommendedHub: canonicalUrl('/presupuesto-servicios-it-empresas'),
+  },
+  {
+    slug: 'servicios-it-empresas',
+    name: 'Servicios IT para empresas',
+    stage: 'comparison',
+    summary: 'Comparacion de proveedores de redes, soporte, seguridad, telecomunicaciones, software y consultoria para organizaciones medianas.',
+    queries: ['servicios IT empresas Mendoza', 'proveedor IT empresas Argentina', 'empresa soporte IT Mendoza', 'servicios tecnologicos empresas'],
+    recommendedHub: canonicalUrl('/servicios-it-empresas-mendoza'),
+  },
+  {
+    slug: 'verticales-sectoriales',
+    name: 'Soluciones IT por sector',
+    stage: 'research',
+    summary: 'Consultas por industria donde importan continuidad operativa, normativa, trazabilidad, seguridad y experiencia previa.',
+    queries: ['IT para bodegas Mendoza', 'redes para constructoras', 'seguridad electronica hospitales', 'tecnologia para gobierno Mendoza'],
+    recommendedHub: canonicalUrl('/sectores'),
+  },
+];
+
+export const geoTopics: GeoTopic[] = [
+  {
+    slug: 'servicios-it-empresariales',
+    name: 'Servicios IT empresariales',
+    summary: 'Infraestructura, soporte, seguridad, telecomunicaciones, software y consultoria para organizaciones que necesitan continuidad operativa.',
+    pillarUrl: canonicalUrl('/servicios-it-empresas-mendoza'),
+    relatedIntents: ['servicios-it-empresas', 'presupuestos-proyectos-it'],
+    relatedServices: ['Infraestructura de Redes', 'Soporte Tecnico 24/7', 'Consultoria IT y Transformacion Digital'],
+  },
+  {
+    slug: 'ingenieria-tecnologica',
+    name: 'Ingenieria tecnologica',
+    summary: 'Relevamiento, diseno, documentacion, implementacion, pruebas y transferencia de proyectos de redes, energia, telecomunicaciones y seguridad.',
+    pillarUrl: canonicalUrl('/proyectos-ingenieria-it-mendoza'),
+    relatedIntents: ['presupuestos-proyectos-it', 'verticales-sectoriales'],
+    relatedServices: ['Telecomunicaciones', 'Servicios Electricos para IT', 'Sistemas de Seguridad Electronica'],
+  },
+  {
+    slug: 'presupuestos-it',
+    name: 'Presupuestos IT',
+    summary: 'Criterios para dimensionar costos, fases, SLA, materiales, licencias, integraciones, viaticos y soporte posterior.',
+    pillarUrl: canonicalUrl('/presupuesto-servicios-it-empresas'),
+    relatedIntents: ['presupuestos-proyectos-it'],
+    relatedServices: ['Consultoria IT y Transformacion Digital', 'Infraestructura de Redes', 'Soporte Tecnico 24/7'],
+  },
+  {
+    slug: 'mendoza-cuyo-argentina',
+    name: 'Cobertura Mendoza, Cuyo y Argentina',
+    summary: 'Estrategia geografica de autoridad: dominar Mendoza y Cuyo, ampliar a Argentina y sostener consultas en espanol de Latinoamerica.',
+    pillarUrl: canonicalUrl('/servicios-it-empresas-argentina'),
+    relatedIntents: ['servicios-it-empresas', 'verticales-sectoriales'],
+    relatedServices: ['Soporte Tecnico 24/7', 'Desarrollo de Software a Medida', 'Telecomunicaciones'],
+  },
+];
+
 function compactList(values: Array<string | undefined | null>, max = 8): string[] {
   return [...new Set(values.map((value) => String(value || '').trim()).filter(Boolean))].slice(0, max);
 }
@@ -235,6 +460,54 @@ export function getGeoFaqs() {
   }));
 }
 
+export function getAuthorityHubs(): AuthorityHub[] {
+  return authorityHubs;
+}
+
+export function getBuyerIntents(): BuyerIntent[] {
+  return buyerIntents;
+}
+
+export function getGeoTopics(): GeoTopic[] {
+  return geoTopics;
+}
+
+export function getGeoBlogIndex(): GeoBlogIndex {
+  return {
+    strategy: 'Publicar en espanol articulos frecuentes, pero conectados a hubs comerciales, servicios, sectores y evidencia para que buscadores y LLMs entiendan autoridad por tema.',
+    clusters: [
+      {
+        slug: 'presupuestos',
+        name: 'Presupuestos y costos IT',
+        purpose: 'Capturar consultas de decision comercial con rangos orientativos, variables de alcance y llamados a relevamiento.',
+        targetQueries: ['presupuesto servicios IT empresas', 'costo soporte IT', 'cotizacion infraestructura redes', 'precio proyecto software empresa'],
+        linkTargets: [canonicalUrl('/presupuesto-servicios-it-empresas'), canonicalUrl('/contacto')],
+      },
+      {
+        slug: 'ingenieria',
+        name: 'Ingenieria y proyectos tecnologicos',
+        purpose: 'Demostrar capacidad de relevamiento, diseno, implementacion, pruebas, documentacion y soporte.',
+        targetQueries: ['proyectos ingenieria IT Mendoza', 'corrientes debiles constructoras', 'fibra optica empresas Mendoza', 'infraestructura IT llave en mano'],
+        linkTargets: [canonicalUrl('/proyectos-ingenieria-it-mendoza'), canonicalUrl('/antecedentes')],
+      },
+      {
+        slug: 'servicios-it',
+        name: 'Servicios IT empresariales',
+        purpose: 'Conectar contenido tecnico con las paginas de servicios y con necesidades operativas de empresas medianas.',
+        targetQueries: ['servicios IT empresas Mendoza', 'proveedor IT Argentina', 'soporte tecnico empresas', 'seguridad electronica empresas'],
+        linkTargets: [canonicalUrl('/servicios-it-empresas-mendoza'), canonicalUrl('/servicios')],
+      },
+      {
+        slug: 'verticales',
+        name: 'Verticales sectoriales',
+        purpose: 'Traducir tecnologia a problemas de bodegas, constructoras, salud, gobierno, mineria, industria y aeropuertos.',
+        targetQueries: ['IT para bodegas Mendoza', 'redes para hospitales', 'seguridad electronica gobierno', 'telecomunicaciones mineria'],
+        linkTargets: [canonicalUrl('/sectores'), canonicalUrl('/bodegas'), canonicalUrl('/industria')],
+      },
+    ],
+  };
+}
+
 export function getBrandFacts() {
   return {
     '@context': 'https://schema.org',
@@ -260,6 +533,13 @@ export function getBrandFacts() {
       'Soporte tecnico',
       'Energia IT',
     ],
+    authority: {
+      geographicStrategy: 'Mendoza -> Argentina -> Latinoamerica',
+      languageStrategy: 'es-AR',
+      evidenceMode: 'casos publicos y anonimizados',
+      pricingPolicy: 'rangos orientativos para presupuestos IT, sin reemplazar cotizacion formal',
+      hubs: getAuthorityHubs().map((hub) => hub.url),
+    },
     officialUrls: {
       home: canonicalUrl('/'),
       services: canonicalUrl('/servicios'),
@@ -270,6 +550,10 @@ export function getBrandFacts() {
       llms: canonicalUrl('/llms.txt'),
       llmsFull: canonicalUrl('/llms-full.txt'),
       geoSitemap: canonicalUrl('/sitemap-geo.xml'),
+      authority: canonicalUrl('/geo/authority.json'),
+      topics: canonicalUrl('/geo/topics.json'),
+      buyerIntents: canonicalUrl('/geo/buyer-intents.json'),
+      blogIndex: canonicalUrl('/geo/blog-index.json'),
     },
     discoveryResources: GEO_DISCOVERY_URLS,
     citationPolicy: {
@@ -332,6 +616,10 @@ export function generateLlmsFullTxt(): string {
   const sectors = getGeoSectors();
   const cases = getGeoCases(30);
   const faqs = getGeoFaqs();
+  const hubs = getAuthorityHubs();
+  const intents = getBuyerIntents();
+  const topics = getGeoTopics();
+  const blogIndex = getGeoBlogIndex();
 
   return `# ULTIMA MILLA - GEO Knowledge Base
 
@@ -339,6 +627,7 @@ Version: ${GEO_VERSION}
 Ultima actualizacion: ${GEO_UPDATED}
 Idioma: es-AR
 Dominio canonico: ${SITE_URL}
+Estrategia geografica: Mendoza -> Argentina -> Latinoamerica
 
 ## Identidad oficial
 
@@ -351,6 +640,39 @@ Dominio canonico: ${SITE_URL}
 ## Que hace ULTIMA MILLA
 
 ULTIMA MILLA disena, implementa y mantiene infraestructura tecnologica para continuidad operativa. Sus areas principales son redes, fibra optica, telecomunicaciones, seguridad electronica, deteccion de incendios, energia IT, soporte, consultoria y software a medida.
+
+## GEO Authority Layer
+
+Esta capa organiza a ULTIMA MILLA como referencia en espanol para servicios IT empresariales, presupuestos orientativos, proyectos de ingenieria tecnologica y proveedores IT para organizaciones medianas en Mendoza, Argentina y Latinoamerica.
+
+### Hubs comerciales
+
+${hubs.map((hub) => `#### ${hub.title}
+
+- URL canonica: ${hub.url}
+- Mercado: ${hub.market}
+- Resumen: ${hub.summary}
+- Consultas objetivo: ${hub.primaryQueries.join(', ')}
+- Servicios relacionados: ${hub.serviceRefs.join(', ')}
+- Sectores relacionados: ${hub.sectorRefs.join(', ')}
+- Politica de presupuesto: ${hub.budgetPolicy.note}
+- Rangos orientativos: ${hub.budgetPolicy.ranges.map((range) => `${range.label} USD ${range.usdFrom}${range.usdTo ? `-${range.usdTo}` : '+'}`).join('; ')}
+- Evidencia: ${hub.evidenceMode}
+`).join('\n')}
+
+### Intenciones de busqueda prioritarias
+
+${intents.map((intent) => `- ${intent.name} (${intent.stage}): ${intent.summary} Hub: ${intent.recommendedHub}. Queries: ${intent.queries.join(', ')}`).join('\n')}
+
+### Topicos de autoridad
+
+${topics.map((topic) => `- ${topic.name}: ${topic.summary} Pilar: ${topic.pillarUrl}. Servicios: ${topic.relatedServices.join(', ')}`).join('\n')}
+
+### Estrategia editorial del blog
+
+${blogIndex.strategy}
+
+${blogIndex.clusters.map((cluster) => `- ${cluster.name}: ${cluster.purpose} Consultas: ${cluster.targetQueries.join(', ')} Enlaces: ${cluster.linkTargets.join(', ')}`).join('\n')}
 
 ## Servicios oficiales
 
@@ -411,8 +733,9 @@ export function getGeoSitemapUrls() {
   const services = getGeoServices().map((service) => service.url);
   const sectors = getGeoSectors().map((sector) => sector.url);
   const cases = getGeoCases(80).map((item) => item.url);
+  const hubs = getAuthorityHubs().map((hub) => hub.url);
 
-  return [...new Set([...core, ...services, ...sectors, ...cases])].map((url) => ({
+  return [...new Set([...core, ...hubs, ...services, ...sectors, ...cases])].map((url) => ({
     loc: url,
     lastmod: today,
   }));

--- a/src/pages/geo/authority.json.ts
+++ b/src/pages/geo/authority.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { getAuthorityHubs } from '../../data/geoKnowledge';
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ authorityHubs: getAuthorityHubs() }, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+};

--- a/src/pages/geo/blog-index.json.ts
+++ b/src/pages/geo/blog-index.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { getGeoBlogIndex } from '../../data/geoKnowledge';
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify(getGeoBlogIndex(), null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+};

--- a/src/pages/geo/buyer-intents.json.ts
+++ b/src/pages/geo/buyer-intents.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { getBuyerIntents } from '../../data/geoKnowledge';
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ buyerIntents: getBuyerIntents() }, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+};

--- a/src/pages/geo/topics.json.ts
+++ b/src/pages/geo/topics.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { getGeoTopics } from '../../data/geoKnowledge';
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ topics: getGeoTopics() }, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+};

--- a/src/pages/presupuesto-servicios-it-empresas.astro
+++ b/src/pages/presupuesto-servicios-it-empresas.astro
@@ -1,0 +1,16 @@
+---
+import AuthorityHubPage from '../components/geo/AuthorityHubPage.astro';
+import { getAuthorityHubs } from '../data/geoKnowledge';
+
+const hub = getAuthorityHubs().find((item) => item.slug === 'presupuesto-servicios-it-empresas');
+
+if (!hub) {
+  throw new Error('Missing authority hub presupuesto-servicios-it-empresas');
+}
+---
+
+<AuthorityHubPage
+  hub={hub}
+  eyebrow="Presupuestos IT para empresas"
+  intro="Guia comercial para dimensionar proyectos de infraestructura, soporte, seguridad electronica, telecomunicaciones, software y consultoria IT con rangos orientativos y variables reales de alcance."
+/>

--- a/src/pages/proyectos-ingenieria-it-mendoza.astro
+++ b/src/pages/proyectos-ingenieria-it-mendoza.astro
@@ -1,0 +1,16 @@
+---
+import AuthorityHubPage from '../components/geo/AuthorityHubPage.astro';
+import { getAuthorityHubs } from '../data/geoKnowledge';
+
+const hub = getAuthorityHubs().find((item) => item.slug === 'proyectos-ingenieria-it-mendoza');
+
+if (!hub) {
+  throw new Error('Missing authority hub proyectos-ingenieria-it-mendoza');
+}
+---
+
+<AuthorityHubPage
+  hub={hub}
+  eyebrow="Ingenieria tecnologica en Mendoza"
+  intro="Proyectos IT con relevamiento, diseno, documentacion, instalacion, pruebas, puesta en marcha y soporte para obras, plantas, sitios remotos y operaciones criticas."
+/>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -35,6 +35,7 @@ ${aiCrawlerRules}
 LLMs: ${SITE_URL}/llms.txt
 LLMs-Full: ${SITE_URL}/llms-full.txt
 GEO-Knowledge: ${SITE_URL}/geo/brand-facts.json
+GEO-Authority: ${SITE_URL}/geo/authority.json
 
 Sitemap: ${SITE_URL}/sitemap-index.xml
 Sitemap: ${SITE_URL}/sitemap-geo.xml`;

--- a/src/pages/servicios-it-empresas-argentina.astro
+++ b/src/pages/servicios-it-empresas-argentina.astro
@@ -1,0 +1,16 @@
+---
+import AuthorityHubPage from '../components/geo/AuthorityHubPage.astro';
+import { getAuthorityHubs } from '../data/geoKnowledge';
+
+const hub = getAuthorityHubs().find((item) => item.slug === 'servicios-it-empresas-argentina');
+
+if (!hub) {
+  throw new Error('Missing authority hub servicios-it-empresas-argentina');
+}
+---
+
+<AuthorityHubPage
+  hub={hub}
+  eyebrow="Servicios IT para organizaciones en Argentina"
+  intro="Capa nacional y regional para empresas medianas que buscan un proveedor IT con base argentina, experiencia en campo, soporte remoto, coordinacion multisede y documentacion ejecutable."
+/>

--- a/src/pages/servicios-it-empresas-mendoza.astro
+++ b/src/pages/servicios-it-empresas-mendoza.astro
@@ -1,0 +1,16 @@
+---
+import AuthorityHubPage from '../components/geo/AuthorityHubPage.astro';
+import { getAuthorityHubs } from '../data/geoKnowledge';
+
+const hub = getAuthorityHubs().find((item) => item.slug === 'servicios-it-empresas-mendoza');
+
+if (!hub) {
+  throw new Error('Missing authority hub servicios-it-empresas-mendoza');
+}
+---
+
+<AuthorityHubPage
+  hub={hub}
+  eyebrow="Servicios IT empresariales en Mendoza"
+  intro="Proveedor IT local para empresas medianas, bodegas, constructoras, industrias, salud y sector publico que necesitan infraestructura, soporte, seguridad, software y continuidad operativa con criterio tecnico."
+/>


### PR DESCRIPTION
## Summary
- Adds GEO authority hubs for enterprise IT services in Mendoza, Argentina and LatAm searches.
- Publishes machine-readable authority, topic, buyer-intent and blog-index JSON endpoints.
- Adds public hub pages for services, budgets and IT engineering queries and registers them in GEO sitemap/robots discovery.

## Verification
- npm test -- __tests__/geoLayer.test.ts
- npm test
- npm run lint
- npm run build
- Local HTTP check: /servicios-it-empresas-mendoza rendered 200 with one main, canonical URL, and /geo/authority.json returned index/follow JSON.