### PR TITLE
fix: clean enabled nginx backup configs

### DIFF
--- a/.github/workflows/cleanup-nginx-enabled-backups.yml
+++ b/.github/workflows/cleanup-nginx-enabled-backups.yml
@@ -1,0 +1,40 @@
+name: Cleanup Nginx Enabled Backups
+
+on:
+  workflow_dispatch:
+
+env:
+  DEPLOY_PATH: '/root/fumbling-field'
+
+jobs:
+  cleanup:
+    name: Disable enabled Nginx backup files
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://www.ultimamilla.com.ar
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add server to known hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -T 60 -H 23.105.176.45 >> ~/.ssh/known_hosts
+          sort -u ~/.ssh/known_hosts -o ~/.ssh/known_hosts
+
+      - name: Sync ops scripts
+        run: |
+          rsync -avz \
+            scripts/ops/ \
+            root@23.105.176.45:${{ env.DEPLOY_PATH }}/scripts/ops/
+
+      - name: Cleanup Nginx enabled backups
+        run: |
+          ssh root@23.105.176.45 "bash ${{ env.DEPLOY_PATH }}/scripts/ops/cleanup-nginx-enabled-backups.sh"

--- a/__tests__/llmAccessLogging.test.ts
+++ b/__tests__/llmAccessLogging.test.ts
@@ -36,6 +36,8 @@ describe('LLM access logging operations', () => {
     expect(workflow).toContain('scripts/ops/install-llm-nginx-logging.sh');
     expect(logrotate).toContain('/var/log/nginx/ultimamilla-llm-access.log');
     expect(logrotate).toContain('rotate 30');
+    expect(logrotate).toContain('create 0640 nginx root');
+    expect(installer).toContain('chown nginx:root /var/log/nginx/ultimamilla-llm-access.log');
   });
 
   test('reports LLM bot and referral activity from JSON access logs', () => {

--- a/__tests__/nginxOps.test.ts
+++ b/__tests__/nginxOps.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = process.cwd();
+
+describe('Nginx operational cleanup', () => {
+  test('ships a guarded cleanup for backup files accidentally enabled in Nginx', () => {
+    const cleanup = fs.readFileSync(path.join(repoRoot, 'scripts/ops/cleanup-nginx-enabled-backups.sh'), 'utf8');
+    const workflow = fs.readFileSync(path.join(repoRoot, '.github/workflows/cleanup-nginx-enabled-backups.yml'), 'utf8');
+
+    expect(cleanup).toContain('nginx -t');
+    expect(cleanup).toContain('restore_moved_files');
+    expect(cleanup).toContain('systemctl reload nginx');
+    expect(cleanup).toContain('/etc/nginx/sites-enabled');
+    expect(cleanup).toContain('*.backup');
+    expect(cleanup).toContain('*.bak');
+    expect(cleanup).toContain('/etc/nginx/disabled-enabled-backups');
+    expect(workflow).toContain('workflow_dispatch');
+    expect(workflow).toContain('cleanup-nginx-enabled-backups.sh');
+  });
+});

--- a/ops/logrotate.d/ultimamilla-llm-access
+++ b/ops/logrotate.d/ultimamilla-llm-access
@@ -5,7 +5,7 @@
     notifempty
     compress
     delaycompress
-    create 0640 www-data adm
+    create 0640 nginx root
     sharedscripts
     postrotate
         if [ -s /run/nginx.pid ]; then

--- a/scripts/ops/cleanup-nginx-enabled-backups.sh
+++ b/scripts/ops/cleanup-nginx-enabled-backups.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SITES_ENABLED="${SITES_ENABLED:-/etc/nginx/sites-enabled}"
+DISABLED_ROOT="${DISABLED_ROOT:-/etc/nginx/disabled-enabled-backups}"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+DISABLED_DIR="$DISABLED_ROOT/$RUN_ID"
+
+if [ ! -d "$SITES_ENABLED" ]; then
+  echo "Missing Nginx enabled-sites directory: $SITES_ENABLED" >&2
+  exit 1
+fi
+
+if ! nginx -t; then
+  echo "Nginx config is not valid before cleanup; refusing to move files." >&2
+  exit 1
+fi
+
+mkdir -p "$DISABLED_DIR"
+moved=0
+
+restore_moved_files() {
+  if [ "$moved" -eq 0 ]; then
+    return
+  fi
+
+  for item in "$DISABLED_DIR"/*; do
+    [ -e "$item" ] || continue
+    mv "$item" "$SITES_ENABLED/$(basename "$item")"
+  done
+}
+
+for item in "$SITES_ENABLED"/*; do
+  [ -e "$item" ] || continue
+  name="$(basename "$item")"
+
+  case "$name" in
+    *.bak|*.bak.*|*.backup|*.backup.*|*backup*|*.old|*.save)
+      echo "Disabling enabled backup config: $name"
+      mv "$item" "$DISABLED_DIR/$name"
+      moved=$((moved + 1))
+      ;;
+  esac
+done
+
+if ! nginx -t; then
+  echo "Nginx config failed after cleanup; restoring moved files." >&2
+  restore_moved_files
+  nginx -t || true
+  exit 1
+fi
+
+systemctl reload nginx
+
+if [ "$moved" -eq 0 ]; then
+  echo "No enabled backup configs found."
+else
+  echo "Disabled $moved enabled backup config(s)."
+  echo "Moved files to: $DISABLED_DIR"
+fi

--- a/scripts/ops/install-llm-nginx-logging.sh
+++ b/scripts/ops/install-llm-nginx-logging.sh
@@ -45,7 +45,7 @@ restore_previous_files() {
 install -m 0644 "$NGINX_SOURCE" "$NGINX_DEST"
 install -m 0644 "$LOGROTATE_SOURCE" "$LOGROTATE_DEST"
 touch /var/log/nginx/ultimamilla-llm-access.log
-chown www-data:adm /var/log/nginx/ultimamilla-llm-access.log 2>/dev/null || true
+chown nginx:root /var/log/nginx/ultimamilla-llm-access.log 2>/dev/null || true
 chmod 0640 /var/log/nginx/ultimamilla-llm-access.log
 
 if nginx -t; then


### PR DESCRIPTION
## Summary
- add guarded workflow/script to disable backup Nginx configs accidentally left in sites-enabled
- validate nginx before and after moving files, restore automatically on failure, then reload nginx
- align LLM access logrotate ownership with this server's nginx user

## Verification
- bash -n scripts/ops/cleanup-nginx-enabled-backups.sh
- bash -n scripts/ops/install-llm-nginx-logging.sh
- npm test -- __tests__/llmAccessLogging.test.ts __tests__/nginxOps.test.ts
- npm test
- npm run lint
- npm run build

## Production diagnosis
- Duplicate server_name warnings are caused by /etc/nginx/sites-enabled/ultimamilla.com.ar.backup.20260427-081010 and /etc/nginx/sites-enabled/ultimamilla.com.ar.bak being loaded alongside /etc/nginx/sites-enabled/ultimamilla.com.ar.