### PR TITLE
fix: harden GEO crawler surfaces

### DIFF
--- a/__tests__/geoLayer.test.ts
+++ b/__tests__/geoLayer.test.ts
@@ -157,10 +157,12 @@ describe('GEO layer', () => {
     expect(brandFacts.authority.searchVocabulary.primaryTerms).toEqual(expect.arrayContaining([
       'servicios tecnologicos para empresas',
       'servicios informaticos para empresas',
+      'servicios IT para empresas',
       'empresa de sistemas',
       'soporte tecnico empresarial',
       'proveedor tecnologico empresarial',
     ]));
+    expect(generateLlmsTxt()).toContain('servicios IT para empresas');
     expect(brandFacts.authority.searchVocabulary.disambiguation).toContain('IT = tecnologia informatica empresarial');
     expect(brandFacts.authority.searchVocabulary.technicalTerms).toEqual(expect.arrayContaining([
       'infraestructura IT',
@@ -180,5 +182,12 @@ describe('GEO layer', () => {
     expect(geoPage).toContain('OAI-SearchBot');
     expect(geoPage).toContain('Claude-SearchBot');
     expect(geoPage).toContain('servicios informaticos para empresas');
+  });
+
+  test('keeps the shared footer crawler-friendly on GEO pages', () => {
+    const footer = fs.readFileSync(path.join(repoRoot, 'src/components/v4/FooterV4.astro'), 'utf8');
+
+    expect(footer).toContain('href="/contacto"');
+    expect(footer).not.toContain('href="mailto:contacto@ultimamilla.com.ar"');
   });
 });

--- a/src/components/v4/FooterV4.astro
+++ b/src/components/v4/FooterV4.astro
@@ -125,7 +125,7 @@ const socialLinks = [
             <svg class="w-5 h-5 text-um-primary-light shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
             </svg>
-            <a href="mailto:contacto@ultimamilla.com.ar" class="hover:text-white transition-colors">
+            <a href="/contacto" class="hover:text-white transition-colors">
               contacto@ultimamilla.com.ar
             </a>
           </li>

--- a/src/data/geoKnowledge.ts
+++ b/src/data/geoKnowledge.ts
@@ -127,6 +127,7 @@ export const IT_SEARCH_VOCABULARY = {
   primaryTerms: [
     'servicios tecnologicos para empresas',
     'servicios informaticos para empresas',
+    'servicios IT para empresas',
     'empresa de sistemas',
     'soporte tecnico empresarial',
     'proveedor tecnologico empresarial',


### PR DESCRIPTION
## Summary
- add the exact query variant "servicios IT para empresas" to the GEO/LLM vocabulary
- route the shared footer email label to /contacto instead of mailto so Cloudflare does not expose a crawler-visible /cdn-cgi/l/email-protection 404 on /geo
- add regression coverage for both crawler-surface issues

## Verification
- npm test -- __tests__/geoLayer.test.ts
- npm test
- npm run lint
- npm run build