### PR TITLE
Fix production runtime Directus env priority

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -168,21 +168,23 @@ jobs:
           HOMEPAGE=$(curl -sL https://www.ultimamilla.com.ar)
           ERRORS=0
 
-          # 1. Service images can use either Directus /assets/ URLs OR local /images/ paths
+          # 1. Visual assets can use Directus /assets/, local service images, or
+          #    the White Dossier upload-backed evidence/hero system.
           DIRECTUS_IMGS=$(echo "$HOMEPAGE" | grep -oE 'src="/assets/[a-f0-9-]{36}[^"]*"' | wc -l)
           LOCAL_IMGS=$(echo "$HOMEPAGE" | grep -oE 'src="/images/services/[^"]*"' | wc -l)
-          TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))
+          UPLOAD_IMGS=$(echo "$HOMEPAGE" | grep -oE 'src="/uploads/(antecedentes|hero)/[^"]*"' | wc -l)
+          TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS + UPLOAD_IMGS))
 
           if [ "$TOTAL_IMGS" -lt 4 ]; then
-            echo "❌ Only $TOTAL_IMGS service images found (expected >= 4)"
-            echo "   Directus: $DIRECTUS_IMGS, Local: $LOCAL_IMGS"
+            echo "❌ Only $TOTAL_IMGS visual images found (expected >= 4)"
+            echo "   Directus: $DIRECTUS_IMGS, Local services: $LOCAL_IMGS, Uploads: $UPLOAD_IMGS"
             ERRORS=$((ERRORS + 1))
           else
-            echo "✅ Service images: $TOTAL_IMGS found (Directus: $DIRECTUS_IMGS, Local: $LOCAL_IMGS)"
+            echo "✅ Visual images: $TOTAL_IMGS found (Directus: $DIRECTUS_IMGS, Local services: $LOCAL_IMGS, Uploads: $UPLOAD_IMGS)"
           fi
 
-          # 2. Hero section must have background images
-          HERO_IMGS=$(echo "$HOMEPAGE" | grep -oE 'hero-image' | wc -l)
+          # 2. Hero section must render the approved White Dossier hero.
+          HERO_IMGS=$(echo "$HOMEPAGE" | grep -oE 'um-home-hero|um-hero-media|/uploads/hero/' | wc -l)
           if [ "$HERO_IMGS" -lt 1 ]; then
             echo "❌ No hero images found"
             ERRORS=$((ERRORS + 1))

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Production runtime configuration contracts', () => {
+  test('Directus token resolution prefers PM2 runtime env over build-time public tokens', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/config/runtime.ts'), 'utf8');
+    const fn = source.match(/export function getDirectusToken\(\): string \{([\s\S]*?)\n\}/)?.[1] || '';
+
+    expect(fn).toContain("processEnv('DIRECTUS_ADMIN_TOKEN')");
+    expect(fn.indexOf("processEnv('DIRECTUS_STATIC_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_STATIC_TOKEN'));
+    expect(fn.indexOf("processEnv('PUBLIC_DIRECTUS_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.PUBLIC_DIRECTUS_TOKEN'));
+    expect(fn.indexOf("processEnv('DIRECTUS_ADMIN_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_ADMIN_TOKEN'));
+  });
+
+  test('production smoke test accepts White Dossier upload-backed visuals', () => {
+    const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
+
+    expect(workflow).toContain('UPLOAD_IMGS=');
+    expect(workflow).toContain('/uploads/(antecedentes|hero)/');
+    expect(workflow).toContain('um-home-hero|um-hero-media|/uploads/hero/');
+  });
+});

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -2,6 +2,10 @@ import { SITE_URL } from './seo';
 
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
 
+function processEnv(name: string): string | undefined {
+  return typeof process !== 'undefined' ? process.env[name] : undefined;
+}
+
 function envFlag(value: string | boolean | undefined): boolean {
   if (typeof value === 'boolean') return value;
   if (!value) return false;
@@ -10,30 +14,27 @@ function envFlag(value: string | boolean | undefined): boolean {
 
 /** Localhost debe comportarse como producción (hybrid, datos CMS, sin mocks de lab). */
 export function isLocalProdReplica(): boolean {
+  const fromProcess = processEnv('UMSA_LOCAL_REPLICA');
   const fromImport = import.meta.env?.UMSA_LOCAL_REPLICA;
-  const fromProcess =
-    typeof process !== 'undefined' ? process.env['UMSA_LOCAL_REPLICA'] : undefined;
   return envFlag(fromImport) || envFlag(fromProcess);
 }
 
 export function getDirectusInternalUrl(): string {
+  const fromProcess = processEnv('DIRECTUS_INTERNAL_URL');
   const fromImport = import.meta.env?.DIRECTUS_INTERNAL_URL;
-  const fromProcess =
-    typeof process !== 'undefined' ? process.env['DIRECTUS_INTERNAL_URL'] : undefined;
-  const publicUrl = import.meta.env?.PUBLIC_DIRECTUS_URL;
+  const publicUrl = processEnv('PUBLIC_DIRECTUS_URL') || import.meta.env?.PUBLIC_DIRECTUS_URL;
   return fromProcess || fromImport || publicUrl || 'http://localhost:8055';
 }
 
 export function getDirectusToken(): string {
   const token =
+    processEnv('DIRECTUS_STATIC_TOKEN') ||
+    processEnv('PUBLIC_DIRECTUS_TOKEN') ||
+    processEnv('DIRECTUS_ADMIN_TOKEN') ||
     import.meta.env?.DIRECTUS_STATIC_TOKEN ||
     import.meta.env?.PUBLIC_DIRECTUS_TOKEN ||
     import.meta.env?.DIRECTUS_ADMIN_TOKEN ||
-    (typeof process !== 'undefined'
-      ? process.env['DIRECTUS_STATIC_TOKEN'] ||
-        process.env['PUBLIC_DIRECTUS_TOKEN'] ||
-        process.env['DIRECTUS_ADMIN_TOKEN']
-      : '');
+    '';
 
   if (token) return token;
 
@@ -53,16 +54,14 @@ export function getDirectusToken(): string {
 /** URL pública para canonical/OG: prod real en réplica, localhost en dev normal. */
 export function getPublicSiteUrl(): string {
   if (isLocalProdReplica()) return SITE_URL;
-  return import.meta.env?.PUBLIC_SITE_URL || 'http://localhost:4321';
+  return processEnv('PUBLIC_SITE_URL') || import.meta.env?.PUBLIC_SITE_URL || 'http://localhost:4321';
 }
 
 /** Blog: en réplica, fallback a HTML de producción (no mock estático). */
 export function allowPublicBlogFallback(): boolean {
   if (isLocalProdReplica()) return true;
   if (import.meta.env?.DEV) return true;
-  return envFlag(
-    typeof process !== 'undefined' ? process.env['UMSA_USE_PUBLIC_BLOG_FALLBACK'] : undefined,
-  );
+  return envFlag(processEnv('UMSA_USE_PUBLIC_BLOG_FALLBACK'));
 }
 
 export function allowMockBlogFallback(): boolean {


### PR DESCRIPTION
## Objetivo

Fix-forward del deploy de produccion posterior al rollout UMSA White Dossier.

El deploy de `b8974d61` paso build, rsync, npm install, restart PM2 y healthcheck, pero fallo en el smoke test. La investigacion mostro dos causas:

- Falso negativo del smoke: el nuevo theme usa `/uploads/hero`, `/uploads/antecedentes`, `um-home-hero` y `um-hero-media`; el workflow seguia buscando `src="/images/services"` y `hero-image`.
- Blog vacio en produccion: el bundle priorizaba tokens Directus inyectados en build sobre `process.env`. Ese token build-time estaba vencido, mientras que PM2 tiene `DIRECTUS_ADMIN_TOKEN` valido.

## Cambios

- `src/config/runtime.ts`: prioriza variables runtime de `process.env` antes que `import.meta.env` para Directus y public site URL.
- `.github/workflows/production-deploy.yml`: actualiza el smoke test para aceptar el sistema visual White Dossier.
- `__tests__/runtimeConfigContracts.test.js`: agrega contrato para no volver a invertir prioridad de tokens ni romper el smoke del theme.

## Validaciones locales

- `npm test -- __tests__/runtimeConfigContracts.test.js --runInBand`: OK
- `npm run typecheck`: OK
- `npm run lint`: OK, 0 errores, warnings legacy
- `npm run build`: OK
- `npm test`: OK, 20 suites, 193 tests
- `git diff --check`: OK

## Nota

No se edito el servidor manualmente. Este fix debe desplegarse por GitHub Actions al mergear a `master`.
