### PR TITLE
Fix inline Markdown headings in blog HTML

### DIFF
--- a/__tests__/blogMixedMarkdownContracts.test.js
+++ b/__tests__/blogMixedMarkdownContracts.test.js
@@ -11,4 +11,14 @@ describe('Blog mixed Markdown rendering contracts', () => {
     expect(source).toContain('.use(remarkParse)');
     expect(source.indexOf('if (hasHtml && !hasMarkdownBlocks)')).toBeLessThan(source.indexOf('.use(remarkParse)'));
   });
+
+  test('renderer repairs literal Markdown headings already compacted inside HTML paragraphs', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/utils/editorialContent.ts'), 'utf8');
+
+    expect(source).toContain('function fixLiteralMarkdownHeadingsInParagraph');
+    expect(source).toContain('headingRegex');
+    expect(source).toContain('htmlBlockFromLiteralMarkdown');
+    expect(source).toContain('.replace(/<p>([\\s\\S]*?)<\\/p>/gi');
+    expect(source).toContain('return `<ul>${items.map((item) => `<li>${item}</li>`).join(\'\')}</ul>`;');
+  });
 });

--- a/src/utils/editorialContent.ts
+++ b/src/utils/editorialContent.ts
@@ -205,10 +205,49 @@ export function sanitizeServiceBulletList(items: string[] = []): string[] {
 }
 
 /** CMS a veces entrega HTML con `**negrita**` sin parsear — lo normalizamos. */
+function htmlBlockFromLiteralMarkdown(text: string): string {
+  const clean = text.trim();
+  if (!clean) return '';
+
+  if (/^-\s+/.test(clean)) {
+    const items = clean
+      .replace(/^-\s+/, '')
+      .split(/\s+-\s+/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (items.length > 0) {
+      return `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>`;
+    }
+  }
+
+  return `<p>${clean}</p>`;
+}
+
+function fixLiteralMarkdownHeadingsInParagraph(inner: string): string {
+  if (!/\s##\s+/.test(inner)) return `<p>${inner}</p>`;
+
+  const headingRegex = /\s##\s+(.{1,140}?)(?=\s+(?:El|La|Los|Las|Un|Una|En|Si|Cuando|Cada|Zammad|FleetDM|OpenWISP|Caddy|ARCA|ENACOM|Grafana|PostGIS|LibreNMS|GitHub)\s+[a-záéíóúñ]|\s+-\s+<a\b|$)/g;
+  const blocks: string[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = headingRegex.exec(inner)) !== null) {
+    const before = inner.slice(cursor, match.index);
+    blocks.push(htmlBlockFromLiteralMarkdown(before));
+    blocks.push(`<h2>${match[1].trim()}</h2>`);
+    cursor = match.index + match[0].length;
+  }
+
+  blocks.push(htmlBlockFromLiteralMarkdown(inner.slice(cursor)));
+  return blocks.filter(Boolean).join('');
+}
+
 export function fixLiteralMarkdownInHtml(html: string): string {
   return String(html || '')
     .replace(/\*\*([^*<]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/(?<![\w/])__([^_<]+)__(?![\w/])/g, '<strong>$1</strong>');
+    .replace(/(?<![\w/])__([^_<]+)__(?![\w/])/g, '<strong>$1</strong>')
+    .replace(/<p>([\s\S]*?)<\/p>/gi, (_match, inner) => fixLiteralMarkdownHeadingsInParagraph(inner));
 }
 
 export async function markdownToHtml(markdown: string): Promise<string> {


### PR DESCRIPTION
## Summary
- split literal Markdown headings that Directus has compacted inside HTML paragraphs
- convert final inline Markdown bullet runs into semantic lists
- keep the repair scoped to paragraph HTML that actually contains literal heading markers

## Verification
- npm test -- __tests__/blogMixedMarkdownContracts.test.js --runInBand
- npm run typecheck
- npm run lint (0 errors, existing legacy warnings)
- npm run build
- npm test -- --runInBand