### PR TITLE
fix: use GET for canonical health checks

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -141,18 +141,18 @@ jobs:
           echo "Waiting 15s for app to start..."
           sleep 15
 
-          WWW_HEADERS=$(curl -4 -sSI --max-time 20 https://www.ultimamilla.com.ar/ || true)
-          APEX_HEADERS=$(curl -4 -sSI --max-time 20 https://ultimamilla.com.ar/ || true)
+          WWW_CHECK=$(curl -4 -sS -o /dev/null --max-time 20 \
+            -w "%{http_code} %{redirect_url}" \
+            https://www.ultimamilla.com.ar/ || true)
+          APEX_CHECK=$(curl -4 -sS -o /dev/null --max-time 20 \
+            -w "%{http_code} %{redirect_url}" \
+            https://ultimamilla.com.ar/ || true)
 
-          echo "--- www headers ---"
-          echo "$WWW_HEADERS"
-          echo "--- apex headers ---"
-          echo "$APEX_HEADERS"
+          echo "www check: $WWW_CHECK"
+          echo "apex check: $APEX_CHECK"
 
-          if echo "$WWW_HEADERS" | grep -Eq '^HTTP/[0-9.]+ 200' && \
-             ! echo "$WWW_HEADERS" | grep -Eiq '^location:' && \
-             echo "$APEX_HEADERS" | grep -Eq '^HTTP/[0-9.]+ 30(1|8)' && \
-             echo "$APEX_HEADERS" | grep -Eiq '^location: https://www\.ultimamilla\.com\.ar/'; then
+          if echo "$WWW_CHECK" | grep -Eq '^200[[:space:]]*$' && \
+             echo "$APEX_CHECK" | grep -Eq '^30(1|8)[[:space:]]+https://www\.ultimamilla\.com\.ar/'; then
             echo "✅ Canonical health check passed: www serves 200 and apex redirects to www"
           else
             echo "❌ Canonical health check failed"

--- a/scripts/ops/apply-www-canonical-nginx.sh
+++ b/scripts/ops/apply-www-canonical-nginx.sh
@@ -182,26 +182,22 @@ else
 fi
 
 check_public_routing() {
-  local www_headers apex_headers
-  www_headers="$(curl -4 -sSI --max-time 20 https://www.ultimamilla.com.ar/ || true)"
-  apex_headers="$(curl -4 -sSI --max-time 20 https://ultimamilla.com.ar/ || true)"
+  local www_check apex_check
+  www_check="$(curl -4 -sS -o /dev/null --max-time 20 -w "%{http_code} %{redirect_url}" https://www.ultimamilla.com.ar/ || true)"
+  apex_check="$(curl -4 -sS -o /dev/null --max-time 20 -w "%{http_code} %{redirect_url}" https://ultimamilla.com.ar/ || true)"
 
-  printf '%s\n%s\n' '--- www headers ---' "$www_headers"
-  printf '%s\n%s\n' '--- apex headers ---' "$apex_headers"
+  printf 'www check: %s\n' "$www_check"
+  printf 'apex check: %s\n' "$apex_check"
 
-  if ! printf '%s\n' "$www_headers" | grep -Eq '^HTTP/[0-9.]+ 200'; then
+  if ! printf '%s\n' "$www_check" | grep -Eq '^200[[:space:]]*$'; then
     log "Expected www.ultimamilla.com.ar to return 200 without redirect"
     return 1
   fi
-  if printf '%s\n' "$www_headers" | grep -Eiq '^location:'; then
-    log "Expected www.ultimamilla.com.ar to avoid Location redirects"
-    return 1
-  fi
-  if ! printf '%s\n' "$apex_headers" | grep -Eq '^HTTP/[0-9.]+ 30(1|8)'; then
+  if ! printf '%s\n' "$apex_check" | grep -Eq '^30(1|8)[[:space:]]+'; then
     log "Expected apex ultimamilla.com.ar to return a permanent redirect"
     return 1
   fi
-  if ! printf '%s\n' "$apex_headers" | grep -Eiq '^location: https://www\.ultimamilla\.com\.ar/'; then
+  if ! printf '%s\n' "$apex_check" | grep -Eq '^30(1|8)[[:space:]]+https://www\.ultimamilla\.com\.ar/'; then
     log "Expected apex Location header to point to https://www.ultimamilla.com.ar/"
     return 1
   fi


### PR DESCRIPTION
## Summary
- switches production canonical health checks from HEAD to GET without following redirects
- updates the Nginx canonical workflow post-check the same way

## Why
The deployed Astro SSR app can become unavailable after HEAD-based checks in this environment. The production run exposed this while validating the Cloudflare/Nginx canonical issue. GET checks preserve the same canonical assertions without triggering that failure mode.

## Validation
- bash -n scripts/ops/apply-www-canonical-nginx.sh
- production restored after freeing cache space: local GET 200, public apex GET 200

## Remaining blocker
Cloudflare still redirects https://www.ultimamilla.com.ar/ to https://ultimamilla.com.ar/ before origin. There are no Cloudflare secrets/variables in this repo, so the edge rule must be changed in Cloudflare or credentials must be added for a versioned workflow.