### PR TITLE
fix: align antecedentes queries with Directus schema

### DIFF
--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -301,15 +301,13 @@ export async function getAntecedentesPorServicio(servicioId: number, limit: numb
           'servicios_relacionados.Servicios_id': { _eq: servicioId }
         },
         limit,
-        sort: ['-destacado', '-orden', '-Fecha', '-id'],
+        sort: ['-Fecha', '-id'],
         fields: [
           'id',
           'Titulo',
           'Descripcion',
           'Imagen',
-          'slug',
-          'destacado',
-          'orden'
+          'slug'
         ]
       })
     );
@@ -534,11 +532,9 @@ export async function getAllAntecedentes(): Promise<AntecedenteV4[]> {
           'Unidad_de_negocio',
           'Fecha',
           'Presupuesto',
-          'original_id',
-          'destacado',
-          'orden'
+          'original_id'
         ],
-        sort: ['-destacado', '-orden', '-Fecha', '-id'],
+        sort: ['-Fecha', '-id'],
         limit: -1
       })
     );
@@ -549,10 +545,7 @@ export async function getAllAntecedentes(): Promise<AntecedenteV4[]> {
     try {
       const snapshot = await import('../data/snapshots/antecedentes.json');
       const items = (snapshot.data || snapshot.default?.data || []) as AntecedenteV4[];
-      // Sort snapshot data the same way: destacados first, then by orden, then by date
       return items.sort((a, b) => {
-        if ((b.destacado ? 1 : 0) !== (a.destacado ? 1 : 0)) return (b.destacado ? 1 : 0) - (a.destacado ? 1 : 0);
-        if ((b.orden || 0) !== (a.orden || 0)) return (b.orden || 0) - (a.orden || 0);
         return (b.Fecha || '').localeCompare(a.Fecha || '');
       });
     } catch { return []; }

--- a/src/utils/sectoresHelpers.ts
+++ b/src/utils/sectoresHelpers.ts
@@ -175,8 +175,8 @@ export async function getAntecedentesForSector(
     const client = getClient();
     const allAntecedentes = await client.request(
       readItems('Antecedentes', {
-        fields: ['id', 'Titulo', 'Cliente', 'Descripcion', 'Area', 'Imagen', 'Fecha', 'Unidad_de_negocio', 'destacado', 'orden'],
-        sort: ['-destacado', '-orden', '-Fecha', '-id'],
+        fields: ['id', 'Titulo', 'Cliente', 'Descripcion', 'Area', 'Imagen', 'Fecha', 'Unidad_de_negocio'],
+        sort: ['-Fecha', '-id'],
         limit: 500
       })
     );


### PR DESCRIPTION
## Summary
- stop requesting unavailable Antecedentes fields `destacado` and `orden`
- sort Antecedentes queries by existing production fields `Fecha` and `id`
- reduce sector/listing fallback to snapshots when Directus is healthy

## Validation
- `npm run typecheck`
- `npm run lint` (0 errors, legacy warnings only)
- `npm run build`
- `npm run audit:css`
- production Directus check: Servicios, Antecedentes, and blog_posts reachable internally with token

## Remaining production blockers
- Cloudflare still redirects `www.ultimamilla.com.ar -> ultimamilla.com.ar`, so canonical cutover is not complete
- root disk on VPS remains critical at 100% use with under 500 MB free
