### PR TITLE
fix: restart production pm2 app from deploy path

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -133,7 +133,8 @@ jobs:
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            pm2 delete astro-ultimamilla 2>/dev/null; pm2 start ecosystem.config.cjs
+            cd ${{ env.DEPLOY_PATH }}
+            pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env
             pm2 save
 
       - name: Health check


### PR DESCRIPTION
## Summary
- restart astro-ultimamilla from the configured deploy path during production deploy
- replace delete/start with pm2 startOrRestart using --only astro-ultimamilla and --update-env
- avoid leaving the site without the PM2 app when the canonical health check fails

## Validation
- git diff --check
- production incident evidence: deploy #49 deleted astro-ultimamilla; manual pm2 start ecosystem.config.cjs --only astro-ultimamilla recovered apex 200

## Remaining blocker
Cloudflare still redirects www.ultimamilla.com.ar to apex, so the canonical health check will continue to fail until the edge rule is changed.
