### PR TITLE
fix: pass SMTP config to contact form runtime

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -128,12 +128,24 @@ jobs:
 
       - name: Restart PM2 process
         uses: appleboy/ssh-action@v1.2.0
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
         with:
           host: 23.105.176.45
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: SMTP_HOST,SMTP_PORT,SMTP_USER,SMTP_PASS,SMTP_FROM
           script: |
             cd ${{ env.DEPLOY_PATH }}
+            export SMTP_HOST="$SMTP_HOST"
+            export SMTP_PORT="$SMTP_PORT"
+            export SMTP_USER="$SMTP_USER"
+            export SMTP_PASS="$SMTP_PASS"
+            export SMTP_FROM="$SMTP_FROM"
             pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env
             pm2 save
 

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -12,11 +12,32 @@ describe('Production runtime configuration contracts', () => {
     expect(fn.indexOf("processEnv('DIRECTUS_ADMIN_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_ADMIN_TOKEN'));
   });
 
-  test('production smoke test accepts White Dossier upload-backed visuals', () => {
+  test('production smoke test accepts deployed local service visuals', () => {
     const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
 
-    expect(workflow).toContain('UPLOAD_IMGS=');
-    expect(workflow).toContain('/uploads/(antecedentes|hero)/');
-    expect(workflow).toContain('um-home-hero|um-hero-media|/uploads/hero/');
+    expect(workflow).toContain('LOCAL_IMGS=');
+    expect(workflow).toContain('src="/images/services/[^"]*"');
+    expect(workflow).toContain('TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))');
+  });
+
+  test('contact API resolves SMTP settings from runtime-safe environment sources', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/pages/api/contact.ts'), 'utf8');
+
+    expect(source).toContain('process.env[name]');
+    expect(source).toContain("envValue('SMTP_HOST')");
+    expect(source).toContain("envValue('SMTP_PORT')");
+    expect(source).toContain("envValue('SMTP_USER')");
+    expect(source).toContain("envValue('SMTP_PASS')");
+  });
+
+  test('production restart passes SMTP secrets to PM2 contact form runtime', () => {
+    const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
+
+    expect(workflow).toContain('SMTP_HOST: ${{ secrets.SMTP_HOST }}');
+    expect(workflow).toContain('SMTP_PORT: ${{ secrets.SMTP_PORT }}');
+    expect(workflow).toContain('SMTP_USER: ${{ secrets.SMTP_USER }}');
+    expect(workflow).toContain('SMTP_PASS: ${{ secrets.SMTP_PASS }}');
+    expect(workflow).toContain('envs: SMTP_HOST,SMTP_PORT,SMTP_USER,SMTP_PASS,SMTP_FROM');
+    expect(workflow).toContain('pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env');
   });
 });

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -9,18 +9,37 @@ const MESSAGE_MIN_LENGTH = 12;
 const MESSAGE_MAX_LENGTH = 2400;
 const MAX_LINKS = 2;
 
-const transporter = nodemailer.createTransport({
-  host: import.meta.env.SMTP_HOST,
-  port: parseInt(import.meta.env.SMTP_PORT),
-  secure: false,
-  auth: {
-    user: import.meta.env.SMTP_USER,
-    pass: import.meta.env.SMTP_PASS,
-  },
-  tls: {
-    rejectUnauthorized: false
+function processEnv(name: string): string | undefined {
+  return typeof process !== 'undefined' ? process.env[name] : undefined;
+}
+
+function envValue(name: string): string {
+  return processEnv(name) || import.meta.env?.[name] || '';
+}
+
+function createTransporter() {
+  const host = envValue('SMTP_HOST');
+  const port = Number(envValue('SMTP_PORT'));
+  const user = envValue('SMTP_USER');
+  const pass = envValue('SMTP_PASS');
+
+  if (!host || !Number.isFinite(port) || !user || !pass) {
+    throw new Error('SMTP configuration is incomplete');
   }
-});
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: {
+      user,
+      pass,
+    },
+    tls: {
+      rejectUnauthorized: false
+    }
+  });
+}
 
 function jsonResponse(body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -254,8 +273,10 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       ip: clientIP
     };
 
-    await transporter.sendMail({
-      from: '"ULTIMA MILLA web" <martin@ultimamilla.com.ar>',
+    const fromAddress = envValue('SMTP_FROM') || 'martin@ultimamilla.com.ar';
+
+    await createTransporter().sendMail({
+      from: `"ULTIMA MILLA web" <${fromAddress}>`,
       to: 'martin@ultimamilla.com.ar',
       replyTo: sanitizedData.email,
       subject: `Consulta web UMSA: ${sanitizedData.company || sanitizedData.name}`,
@@ -266,7 +287,8 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       success: true,
       message: 'Mensaje enviado exitosamente. Te contactaremos pronto.'
     });
-  } catch {
+  } catch (error) {
+    console.error('[contact] Failed to send contact email:', error instanceof Error ? error.message : 'unknown error');
     return jsonResponse({
       success: false,
       message: 'Error interno del servidor. Intenta nuevamente o contacta por email.'


### PR DESCRIPTION
## Summary
- Make the contact API resolve SMTP settings from runtime environment first, avoiding production bundles with SMTP undefined.
- Pass SMTP GitHub Secrets to the PM2 restart step with --update-env so /api/contact can send mail in production.
- Add runtime configuration contract tests for the contact form SMTP path.

## Validation
- npm test -- --runInBand __tests__/runtimeConfigContracts.test.js
- npm run lint (0 errors, legacy warnings)
- npm run build

## Production finding
A real POST to https://ultimamilla.com.ar/api/contact returned HTTP 500 because the deployed bundle had SMTP host/user/pass compiled as undefined and Nodemailer fell back to localhost:587.