### PR TITLE
fix: export SMTP secrets during production restart

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -138,14 +138,13 @@ jobs:
           host: 23.105.176.45
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: SMTP_HOST,SMTP_PORT,SMTP_USER,SMTP_PASS,SMTP_FROM
           script: |
             cd ${{ env.DEPLOY_PATH }}
-            export SMTP_HOST="$SMTP_HOST"
-            export SMTP_PORT="$SMTP_PORT"
-            export SMTP_USER="$SMTP_USER"
-            export SMTP_PASS="$SMTP_PASS"
-            export SMTP_FROM="$SMTP_FROM"
+            export SMTP_HOST='${{ secrets.SMTP_HOST }}'
+            export SMTP_PORT='${{ secrets.SMTP_PORT }}'
+            export SMTP_USER='${{ secrets.SMTP_USER }}'
+            export SMTP_PASS='${{ secrets.SMTP_PASS }}'
+            export SMTP_FROM='${{ secrets.SMTP_FROM }}'
             pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env
             pm2 save
 

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -37,7 +37,10 @@ describe('Production runtime configuration contracts', () => {
     expect(workflow).toContain('SMTP_PORT: ${{ secrets.SMTP_PORT }}');
     expect(workflow).toContain('SMTP_USER: ${{ secrets.SMTP_USER }}');
     expect(workflow).toContain('SMTP_PASS: ${{ secrets.SMTP_PASS }}');
-    expect(workflow).toContain('envs: SMTP_HOST,SMTP_PORT,SMTP_USER,SMTP_PASS,SMTP_FROM');
+    expect(workflow).toContain("export SMTP_HOST='${{ secrets.SMTP_HOST }}'");
+    expect(workflow).toContain("export SMTP_PORT='${{ secrets.SMTP_PORT }}'");
+    expect(workflow).toContain("export SMTP_USER='${{ secrets.SMTP_USER }}'");
+    expect(workflow).toContain("export SMTP_PASS='${{ secrets.SMTP_PASS }}'");
     expect(workflow).toContain('pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env');
   });
 });


### PR DESCRIPTION
## Summary
- export SMTP secrets explicitly in the remote production restart script before PM2 reloads the Astro process
- keep the runtime configuration contract covered by Jest so contact form SMTP config cannot silently disappear from PM2

## Validation
- npm test -- --runInBand __tests__/runtimeConfigContracts.test.js
- git diff --check
- npm run build
- npm run lint (0 errors, legacy warnings remain)

## Notes
- This is needed because the prior ssh-action env forwarding did not appear in PM2 runtime env after deploy.
- The existing canonical health check may still fail until the www/apex redirect policy is corrected at the edge.