### PR TITLE
fix: update PM2 env after SMTP export

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -146,6 +146,7 @@ jobs:
             export SMTP_PASS='${{ secrets.SMTP_PASS }}'
             export SMTP_FROM='${{ secrets.SMTP_FROM }}'
             pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env
+            pm2 restart astro-ultimamilla --update-env
             pm2 save
 
       - name: Health check

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -42,5 +42,6 @@ describe('Production runtime configuration contracts', () => {
     expect(workflow).toContain("export SMTP_USER='${{ secrets.SMTP_USER }}'");
     expect(workflow).toContain("export SMTP_PASS='${{ secrets.SMTP_PASS }}'");
     expect(workflow).toContain('pm2 startOrRestart ecosystem.config.cjs --only astro-ultimamilla --update-env');
+    expect(workflow).toContain('pm2 restart astro-ultimamilla --update-env');
   });
 });


### PR DESCRIPTION
## Summary
- restart the existing astro-ultimamilla PM2 process with --update-env after exporting SMTP secrets in the production deploy workflow
- keep a runtime contract asserting that the direct PM2 restart remains present

## Why
The production ecosystem config defines its own env block and is excluded from rsync. The prior startOrRestart step completed successfully, but SMTP variables still did not appear in PM2 runtime env.

## Validation
- npm test -- --runInBand __tests__/runtimeConfigContracts.test.js
- npm run build
- git diff --check