### PR TITLE
fix: update production smoke test for current theme

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -175,36 +175,56 @@ jobs:
       - name: Smoke test - verify content integrity
         run: |
           HOMEPAGE=$(curl -sL https://ultimamilla.com.ar)
+          BLOG=$(curl -sL https://ultimamilla.com.ar/blog)
+          ANTECEDENTES=$(curl -sL https://ultimamilla.com.ar/antecedentes)
           ERRORS=0
 
-          # 1. Service images can use either Directus /assets/ URLs OR local /images/ paths
-          DIRECTUS_IMGS=$(echo "$HOMEPAGE" | grep -oE 'src="/assets/[a-f0-9-]{36}[^"]*"' | wc -l)
-          LOCAL_IMGS=$(echo "$HOMEPAGE" | grep -oE 'src="/images/services/[^"]*"' | wc -l)
-          TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))
-
-          if [ "$TOTAL_IMGS" -lt 4 ]; then
-            echo "❌ Only $TOTAL_IMGS service images found (expected >= 4)"
-            echo "   Directus: $DIRECTUS_IMGS, Local: $LOCAL_IMGS"
+          # 1. Current theme must emit apex canonical and brand content
+          if ! echo "$HOMEPAGE" | grep -Eq 'href="https://ultimamilla\.com\.ar/?"'; then
+            echo "❌ Homepage canonical does not point to apex domain"
             ERRORS=$((ERRORS + 1))
           else
-            echo "✅ Service images: $TOTAL_IMGS found (Directus: $DIRECTUS_IMGS, Local: $LOCAL_IMGS)"
+            echo "✅ Homepage canonical points to apex domain"
           fi
 
-          # 2. Hero section must have background images
-          HERO_IMGS=$(echo "$HOMEPAGE" | grep -oE 'hero-image' | wc -l)
-          if [ "$HERO_IMGS" -lt 1 ]; then
-            echo "❌ No hero images found"
+          if echo "$HOMEPAGE" | grep -q 'https://www.ultimamilla.com.ar'; then
+            echo "❌ Homepage leaks www URL"
             ERRORS=$((ERRORS + 1))
           else
-            echo "✅ Hero images: $HERO_IMGS found"
+            echo "✅ Homepage has no www canonical leak"
           fi
 
-          # 3. Check for excessive placeholder images (should be fallbacks only)
-          DEFAULTS=$(echo "$HOMEPAGE" | grep -oE 'src="[^"]*default-background[^"]*"' | wc -l)
-          if [ "$DEFAULTS" -gt 10 ]; then
-            echo "⚠️ WARNING: $DEFAULTS default-background images found (should be fallback only)"
-          elif [ "$DEFAULTS" -gt 0 ]; then
-            echo "✅ $DEFAULTS placeholder images found (acceptable as fallback)"
+          if ! echo "$HOMEPAGE" | grep -q 'ULTIMA MILLA'; then
+            echo "❌ Homepage missing brand content"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✅ Homepage brand content present"
+          fi
+
+          # 2. Directus-backed public collections must render real entries
+          BLOG_LINKS=$(echo "$BLOG" | grep -oE 'href="/blog/[^"]+"' | wc -l)
+          ANTE_LINKS=$(echo "$ANTECEDENTES" | grep -oE 'href="/antecedentes/[0-9]+/[^"]+"' | wc -l)
+
+          if [ "$BLOG_LINKS" -lt 1 ]; then
+            echo "❌ Blog has no rendered article links"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✅ Blog article links: $BLOG_LINKS"
+          fi
+
+          if [ "$ANTE_LINKS" -lt 1 ]; then
+            echo "❌ Antecedentes has no rendered Directus case links"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✅ Antecedentes case links: $ANTE_LINKS"
+          fi
+
+          # 3. Avoid obvious empty/mock states on public collection pages
+          if echo "$BLOG$ANTECEDENTES" | grep -qiE 'No hay artículos publicados aún|Lorem ipsum|mock|dummy'; then
+            echo "❌ Public collection pages expose empty/mock content"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✅ Public collection pages do not expose empty/mock content"
           fi
 
           if [ "$ERRORS" -gt 0 ]; then

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -12,12 +12,18 @@ describe('Production runtime configuration contracts', () => {
     expect(fn.indexOf("processEnv('DIRECTUS_ADMIN_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_ADMIN_TOKEN'));
   });
 
-  test('production smoke test accepts deployed local service visuals', () => {
+  test('production smoke test validates current theme content and Directus-backed collections', () => {
     const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
 
-    expect(workflow).toContain('LOCAL_IMGS=');
-    expect(workflow).toContain('src="/images/services/[^"]*"');
-    expect(workflow).toContain('TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))');
+    expect(workflow).toContain('HOMEPAGE=$(curl -sL https://ultimamilla.com.ar)');
+    expect(workflow).toContain('BLOG=$(curl -sL https://ultimamilla.com.ar/blog)');
+    expect(workflow).toContain('ANTECEDENTES=$(curl -sL https://ultimamilla.com.ar/antecedentes)');
+    expect(workflow).toContain('grep -Eq');
+    expect(workflow).toContain('Homepage canonical points to apex domain');
+    expect(workflow).toContain('BLOG_LINKS=');
+    expect(workflow).toContain('ANTE_LINKS=');
+    expect(workflow).not.toContain('hero-image');
+    expect(workflow).not.toContain('TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))');
   });
 
   test('production health check matches the live apex canonical redirect policy', () => {


### PR DESCRIPTION
## Summary
- replace legacy homepage image smoke checks with current theme checks
- validate apex canonical, no www leak, brand content, blog links, antecedentes links, and no obvious empty/mock collection state

## Validation
- npm test -- --runInBand __tests__/runtimeConfigContracts.test.js
- production temporary smoke counters from VPS: brand=1, blog_links=30, ante_links=15, www_leaks=0, mock_empty=0
