### PR TITLE
fix: avoid Cloudflare email obfuscation rewrites

### DIFF
--- a/__tests__/emailObfuscationContracts.test.js
+++ b/__tests__/emailObfuscationContracts.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = process.cwd();
+
+const ssrHtmlSources = [
+  'src/components/v4/FooterV4.astro',
+  'src/pages/contacto.astro',
+  'src/pages/privacidad.astro',
+  'src/pages/terminos.astro',
+  'src/pages/antecedentes/[id]/[slug].astro',
+  'src/pages/antecedentes/_[slug].astro',
+  'src/pages/servicios/[id]/[slug].astro',
+];
+
+describe('Email obfuscation contracts', () => {
+  test('public SSR body sources do not expose literal mailto addresses that trigger Cloudflare email rewrite', () => {
+    for (const relativePath of ssrHtmlSources) {
+      const source = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+      expect(source).not.toMatch(/mailto:[^"'\s>]*@ultimamilla\.com\.ar/i);
+    }
+  });
+
+  test('public SSR body sources route visible UMSA email links through the client-side EmailLink component', () => {
+    const footer = fs.readFileSync(path.join(repoRoot, 'src/components/v4/FooterV4.astro'), 'utf8');
+    const contacto = fs.readFileSync(path.join(repoRoot, 'src/pages/contacto.astro'), 'utf8');
+
+    expect(footer).toContain("import EmailLink from '../common/EmailLink.astro'");
+    expect(footer).toContain('<EmailLink');
+    expect(contacto).toContain("import EmailLink from '../components/common/EmailLink.astro'");
+    expect(contacto).toContain('<EmailLink');
+  });
+
+  test('public service CTAs do not render literal email addresses as visible body text', () => {
+    const serviceDetail = fs.readFileSync(path.join(repoRoot, 'src/pages/servicios/[id]/[slug].astro'), 'utf8');
+
+    expect(serviceDetail).not.toContain('secondaryButtonText="contacto@ultimamilla.com.ar"');
+    expect(serviceDetail).not.toMatch(/>\s*contacto@ultimamilla\.com\.ar\s*</i);
+  });
+
+  test('case detail email CTA keeps its visible action label when routed through EmailLink', () => {
+    const caseDetail = fs.readFileSync(path.join(repoRoot, 'src/pages/antecedentes/[id]/[slug].astro'), 'utf8');
+
+    expect(caseDetail).toMatch(/<EmailLink[^>]*>\s*<span[\s\S]*?Enviar email\s*<\/EmailLink>/);
+  });
+});

--- a/__tests__/geoLayer.test.ts
+++ b/__tests__/geoLayer.test.ts
@@ -186,8 +186,12 @@ describe('GEO layer', () => {
 
   test('keeps the shared footer crawler-friendly on GEO pages', () => {
     const footer = fs.readFileSync(path.join(repoRoot, 'src/components/v4/FooterV4.astro'), 'utf8');
+    const emailLink = fs.readFileSync(path.join(repoRoot, 'src/components/common/EmailLink.astro'), 'utf8');
 
-    expect(footer).toContain('href="/contacto"');
+    expect(footer).toContain("import EmailLink from '../common/EmailLink.astro'");
+    expect(footer).toContain('<EmailLink');
+    expect(emailLink).toContain("hrefFallback = '/contacto'");
+    expect(emailLink).toContain('href={hrefFallback}');
     expect(footer).not.toContain('href="mailto:contacto@ultimamilla.com.ar"');
   });
 });

--- a/src/components/common/EmailLink.astro
+++ b/src/components/common/EmailLink.astro
@@ -1,0 +1,67 @@
+---
+interface Props {
+  user?: string;
+  domain?: string;
+  subject?: string;
+  label?: string;
+  hrefFallback?: string;
+  class?: string;
+}
+
+const {
+  user = 'contacto',
+  domain = 'ultimamilla.com.ar',
+  subject = '',
+  label,
+  hrefFallback = '/contacto',
+  class: className = '',
+} = Astro.props;
+
+const hasSlot = Astro.slots.has('default');
+---
+
+<a
+  href={hrefFallback}
+  class:list={[className]}
+  data-um-email-link
+  data-email-user={user}
+  data-email-domain={domain}
+  data-email-subject={subject}
+  aria-label={`Escribir a ${user} arroba ${domain}`}
+>
+  {hasSlot ? (
+    <slot />
+  ) : label ? (
+    label
+  ) : (
+    <>
+      <span>{user}</span><span aria-hidden="true">&#64;</span><span>{domain}</span>
+    </>
+  )}
+</a>
+
+<script is:inline>
+  (() => {
+    if (window.__umEmailLinkReady) return;
+    window.__umEmailLinkReady = true;
+
+    const hydrateEmailLinks = () => {
+      document.querySelectorAll('[data-um-email-link]').forEach((link) => {
+        const user = link.getAttribute('data-email-user') || '';
+        const domain = link.getAttribute('data-email-domain') || '';
+        const subject = link.getAttribute('data-email-subject') || '';
+        if (!user || !domain) return;
+
+        const address = `${user}@${domain}`;
+        const query = subject ? `?subject=${encodeURIComponent(subject)}` : '';
+        link.setAttribute('href', `mailto:${address}${query}`);
+      });
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hydrateEmailLinks, { once: true });
+    } else {
+      hydrateEmailLinks();
+    }
+  })();
+</script>

--- a/src/components/v4/CTASection.astro
+++ b/src/components/v4/CTASection.astro
@@ -28,8 +28,8 @@
  *   descripcion="Contáctenos para relevar alcance, riesgos y próximos pasos"
  *   primaryButtonText="Solicitar relevamiento"
  *   primaryButtonUrl="/contacto"
- *   secondaryButtonText="contacto@ultimamilla.com.ar"
- *   secondaryButtonUrl="mailto:contacto@ultimamilla.com.ar"
+ *   secondaryButtonText="Escribir por email"
+ *   secondaryButtonUrl="/contacto"
  *   secondaryButtonIcon="mail"
  * />
  */

--- a/src/components/v4/FooterV4.astro
+++ b/src/components/v4/FooterV4.astro
@@ -7,6 +7,8 @@
  * - Copyright dinámico
  */
 
+import EmailLink from '../common/EmailLink.astro';
+
 const currentYear = new Date().getFullYear();
 
 // Footer navigation sections
@@ -126,9 +128,7 @@ const socialLinks = [
             <svg class="w-5 h-5 text-um-primary-light shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
             </svg>
-            <a href="/contacto" class="transition-colors">
-              contacto@ultimamilla.com.ar
-            </a>
+            <EmailLink class="transition-colors" />
           </li>
         </ul>
       </div>

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -7,6 +7,7 @@
 import LayoutV4 from '../../../layouts/LayoutV4.astro';
 import EvidenceCaseRow from '../../../components/um/EvidenceCaseRow.astro';
 import UMButton from '../../../components/um/UMButton.astro';
+import EmailLink from '../../../components/common/EmailLink.astro';
 import { generateSlug } from '../../../utils/slugUtils.js';
 import { getServicioById } from '../../../utils/directusHelpers';
 import { getServiceIdFromArea } from '../../../data/areaToServiceMap.js';
@@ -617,14 +618,14 @@ const antecedenteStructuredData = {
               </span>
               Solicitar relevamiento
             </a>
-            <a href="mailto:contacto@ultimamilla.com.ar">
+            <EmailLink label="Enviar email">
               <span class="case-cta-card__action-icon" aria-hidden="true">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                 </svg>
               </span>
               Enviar email
-            </a>
+            </EmailLink>
           </div>
         </div>
       </div>

--- a/src/pages/antecedentes/_[slug].astro
+++ b/src/pages/antecedentes/_[slug].astro
@@ -5,6 +5,7 @@
  */
 
 import LayoutV4 from '../../layouts/LayoutV4.astro';
+import EmailLink from '../../components/common/EmailLink.astro';
 import { generateSlug } from '../../utils/slugUtils.js';
 import { getFixedImage } from '../../utils/imageFixer.js';
 import { getServicioById, getProductos } from '../../utils/directusHelpers';
@@ -454,12 +455,12 @@ const metaDescription = (antecedente.Descripcion || '').replace(/<[^>]+>/g, '').
               </svg>
               Solicitar Cotización
             </a>
-            <a href="mailto:contacto@ultimamilla.com.ar" class="flex items-center justify-center gap-2 bg-white/20 text-white font-semibold py-3 sm:py-3.5 px-4 sm:px-5 rounded-lg border border-white/30 hover:bg-white/30 transition-colors min-h-[44px] text-base sm:text-base">
+            <EmailLink label="Enviar Email" class="flex items-center justify-center gap-2 bg-white/20 text-white font-semibold py-3 sm:py-3.5 px-4 sm:px-5 rounded-lg border border-white/30 hover:bg-white/30 transition-colors min-h-[44px] text-base sm:text-base">
               <svg class="w-4 sm:w-[18px] h-4 sm:h-[18px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
               </svg>
               Enviar Email
-            </a>
+            </EmailLink>
           </div>
         </div>
       </div>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -3,6 +3,7 @@ import LayoutV4 from '../layouts/LayoutV4.astro';
 import MetricStrip from '../components/um/MetricStrip.astro';
 import UMButton from '../components/um/UMButton.astro';
 import SectionHeader from '../components/um/SectionHeader.astro';
+import EmailLink from '../components/common/EmailLink.astro';
 import { resolveReplicaH1 } from '../utils/replicaProdCopy';
 import { getAntecedentesCountShort } from '../utils/verifiedProof';
 
@@ -53,7 +54,7 @@ const structuredData = {
 
         <div class="contact-dossier__actions" aria-label="Acciones principales de contacto">
           <UMButton href="#contactForm" class="contact-primary-cta">Solicitar diagnóstico</UMButton>
-          <UMButton href="mailto:contacto@ultimamilla.com.ar" variant="secondary">Escribir por email</UMButton>
+          <EmailLink class="um-btn-secondary" label="Escribir por email" />
         </div>
 
         <MetricStrip
@@ -110,7 +111,7 @@ const structuredData = {
             Mensaje enviado. Vamos a responder por email con próximos pasos.
           </div>
           <div id="errorMessage" class="form-message error hidden" role="alert">
-            No se pudo enviar. Revisá los datos o escribí a contacto@ultimamilla.com.ar.
+            No se pudo enviar. Revisá los datos o usá el canal de email.
           </div>
         </form>
       </article>
@@ -181,7 +182,7 @@ const structuredData = {
           Redes, seguridad electrónica, telecomunicaciones, software operativo, soporte y energía
           para organizaciones que necesitan continuidad.
         </p>
-        <a href="mailto:contacto@ultimamilla.com.ar">contacto@ultimamilla.com.ar</a>
+        <EmailLink />
       </aside>
     </div>
   </section>

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -1,5 +1,6 @@
 ---
 import LayoutV4 from '../layouts/LayoutV4.astro';
+import EmailLink from '../components/common/EmailLink.astro';
 
 const updatedAt = '31 de mayo de 2026';
 ---
@@ -41,7 +42,7 @@ const updatedAt = '31 de mayo de 2026';
       <article>
         <h2>Contacto</h2>
         <p>
-          Para solicitar corrección o eliminación de una consulta enviada, escribir a <a href="mailto:contacto@ultimamilla.com.ar">contacto@ultimamilla.com.ar</a>.
+          Para solicitar corrección o eliminación de una consulta enviada, escribir a <EmailLink />.
         </p>
       </article>
     </div>

--- a/src/pages/servicios/[id]/[slug].astro
+++ b/src/pages/servicios/[id]/[slug].astro
@@ -18,6 +18,7 @@ import ProductCard from '../../../components/v4/ProductCard.astro';
 import CTASection from '../../../components/v4/CTASection.astro';
 import SectionHeader from '../../../components/um/SectionHeader.astro';
 import UMButton from '../../../components/um/UMButton.astro';
+import EmailLink from '../../../components/common/EmailLink.astro';
 
 import { generateSlug } from '../../../utils/slugUtils.js';
 import { getServicioById } from '../../../utils/directusHelpers';
@@ -377,9 +378,7 @@ const iconPaths = {
               <UMButton href="/contacto" class="service-info-primary">
                 Solicitar diagnóstico
               </UMButton>
-              <a href="mailto:contacto@ultimamilla.com.ar" class="service-info-secondary">
-                contacto@ultimamilla.com.ar
-              </a>
+              <EmailLink class="service-info-secondary" />
             </div>
           </div>
 
@@ -443,8 +442,8 @@ const iconPaths = {
     descripcion="Revisamos sitio, riesgos, dependencias y objetivo operativo antes de proponer una solución."
     primaryButtonText="Solicitar diagnóstico"
     primaryButtonUrl="/contacto"
-    secondaryButtonText="contacto@ultimamilla.com.ar"
-    secondaryButtonUrl="mailto:contacto@ultimamilla.com.ar"
+    secondaryButtonText="Escribir por email"
+    secondaryButtonUrl="/contacto"
     secondaryButtonIcon="mail"
     backgroundImage={serviceImage}
   />

--- a/src/pages/terminos.astro
+++ b/src/pages/terminos.astro
@@ -1,5 +1,6 @@
 ---
 import LayoutV4 from '../layouts/LayoutV4.astro';
+import EmailLink from '../components/common/EmailLink.astro';
 
 const updatedAt = '31 de mayo de 2026';
 ---
@@ -41,7 +42,7 @@ const updatedAt = '31 de mayo de 2026';
       <article>
         <h2>Canal de contacto</h2>
         <p>
-          Para consultas comerciales, documentación o pedidos institucionales, escribir a <a href="mailto:contacto@ultimamilla.com.ar">contacto@ultimamilla.com.ar</a> o usar el formulario de contacto.
+          Para consultas comerciales, documentación o pedidos institucionales, escribir a <EmailLink /> o usar el formulario de contacto.
         </p>
       </article>
     </div>


### PR DESCRIPTION
## Summary
- Replace visible public email links with an EmailLink component that keeps /contacto as crawler-safe fallback and hydrates mailto client-side.
- Remove literal body mailto/contacto@ patterns from footer, contact, legal, service and case CTAs to prevent Cloudflare email-decode injection.
- Keep structured SEO/GEO email data intact in JSON-LD.

## Validation
- npm test -- --runInBand
- npm run build
- npm run lint (0 errors, existing legacy warnings)
- Local preview HTML checks for /, /contacto, /privacidad, /terminos, /servicios/101/infraestructura-de-redes-cableado-fibra-optica-radioenlaces and /antecedentes/3064/desarrollo-de-software-y-digitalizacion-de-procesos-para-el-gobierno-de-la-provincia-de-mendoza: no cdn-cgi, __cf_email__, email-decode or literal mailto:contacto@ultimamilla.com.ar