### PR TITLE
ci: opt GitHub actions into Node 24 runtime

### DIFF
--- a/.github/workflows/apply-www-canonical-nginx.yml
+++ b/.github/workflows/apply-www-canonical-nginx.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEPLOY_PATH: '/root/fumbling-field'
 
 jobs:

--- a/.github/workflows/cleanup-nginx-enabled-backups.yml
+++ b/.github/workflows/cleanup-nginx-enabled-backups.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEPLOY_PATH: '/root/fumbling-field'
 
 jobs:

--- a/.github/workflows/install-llm-nginx-logging.yml
+++ b/.github/workflows/install-llm-nginx-logging.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEPLOY_PATH: '/root/fumbling-field'
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, develop]
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '18.x'
 
 permissions:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:  # Allow manual triggers
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '18.x'
   DEPLOY_PATH: '/root/fumbling-field'
 

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -2,6 +2,24 @@ const fs = require('fs');
 const path = require('path');
 
 describe('Production runtime configuration contracts', () => {
+  test('GitHub workflows opt JavaScript actions into Node 24 before runner deprecation', () => {
+    const workflowsDir = path.join(process.cwd(), '.github/workflows');
+    const workflowFiles = fs.readdirSync(workflowsDir)
+      .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'));
+
+    const workflowsUsingJavascriptActions = workflowFiles
+      .map((file) => ({
+        file,
+        source: fs.readFileSync(path.join(workflowsDir, file), 'utf8')
+      }))
+      .filter(({ source }) => source.includes('uses: actions/'));
+
+    expect(workflowsUsingJavascriptActions.length).toBeGreaterThan(0);
+    for (const { file, source } of workflowsUsingJavascriptActions) {
+      expect(source).toContain('FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true');
+    }
+  });
+
   test('Directus token resolution prefers PM2 runtime env over build-time public tokens', () => {
     const source = fs.readFileSync(path.join(process.cwd(), 'src/config/runtime.ts'), 'utf8');
     const fn = source.match(/export function getDirectusToken\(\): string \{([\s\S]*?)\n\}/)?.[1] || '';


### PR DESCRIPTION
## Summary
- Opt active workflows that use actions/* into the GitHub JavaScript actions Node 24 runtime.
- Keep Astro build/runtime pinned to NODE_VERSION 18.x.
- Add a contract test so future workflows using actions/* must include the Node 24 opt-in.

## Validation
- npm test -- runtimeConfigContracts.test.js --runInBand
- npm test -- --runInBand
- git diff --check