### PR TITLE
ci: upgrade official actions to Node 24 releases

### DIFF
--- a/.github/workflows/apply-www-canonical-nginx.yml
+++ b/.github/workflows/apply-www-canonical-nginx.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/cleanup-nginx-enabled-backups.yml
+++ b/.github/workflows/cleanup-nginx-enabled-backups.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/install-llm-nginx-logging.yml
+++ b/.github/workflows/install-llm-nginx-logging.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup SSH key
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const lintResult = '${{ needs.lint.result }}';

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for better caching
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true  # No bloquear por ahora
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true  # Don't fail build if storage quota exceeded
         with:
           name: dist-build
@@ -72,11 +72,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download build artifacts
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: dist-build

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -20,6 +20,25 @@ describe('Production runtime configuration contracts', () => {
     }
   });
 
+  test('GitHub workflows use official actions releases that target Node 24', () => {
+    const workflowsDir = path.join(process.cwd(), '.github/workflows');
+    const allWorkflows = fs.readdirSync(workflowsDir)
+      .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+      .map((file) => fs.readFileSync(path.join(workflowsDir, file), 'utf8'))
+      .join('\n');
+
+    expect(allWorkflows).not.toContain('actions/checkout@v4');
+    expect(allWorkflows).not.toContain('actions/setup-node@v4');
+    expect(allWorkflows).not.toContain('actions/upload-artifact@v4');
+    expect(allWorkflows).not.toContain('actions/download-artifact@v4');
+    expect(allWorkflows).not.toContain('actions/github-script@v7');
+    expect(allWorkflows).toContain('actions/checkout@v6');
+    expect(allWorkflows).toContain('actions/setup-node@v6');
+    expect(allWorkflows).toContain('actions/upload-artifact@v7');
+    expect(allWorkflows).toContain('actions/download-artifact@v8');
+    expect(allWorkflows).toContain('actions/github-script@v8');
+  });
+
   test('Directus token resolution prefers PM2 runtime env over build-time public tokens', () => {
     const source = fs.readFileSync(path.join(process.cwd(), 'src/config/runtime.ts'), 'utf8');
     const fn = source.match(/export function getDirectusToken\(\): string \{([\s\S]*?)\n\}/)?.[1] || '';


### PR DESCRIPTION
## Summary
- upgrades official GitHub Actions references to Node 24-target releases
- includes checkout v6, setup-node v6, upload-artifact v7, download-artifact v8, and github-script v8
- adds a runtime contract so legacy Node 20 official action refs do not re-enter workflows

## Validation
- npm test -- runtimeConfigContracts.test.js --runInBand
- npm test -- --runInBand
- git diff --check

Base is master because this is a production CI/CD hotfix and develop is stale against the deployed branch.