### PR TITLE
ci: upgrade ssh agent action to Node 24

### DIFF
--- a/.github/workflows/apply-www-canonical-nginx.yml
+++ b/.github/workflows/apply-www-canonical-nginx.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/cleanup-nginx-enabled-backups.yml
+++ b/.github/workflows/cleanup-nginx-enabled-backups.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/install-llm-nginx-logging.yml
+++ b/.github/workflows/install-llm-nginx-logging.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -89,7 +89,7 @@ jobs:
           npm run build
 
       - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -39,6 +39,18 @@ describe('Production runtime configuration contracts', () => {
     expect(allWorkflows).toContain('actions/github-script@v8');
   });
 
+  test('GitHub workflows use a Node 24-compatible SSH agent action', () => {
+    const workflowsDir = path.join(process.cwd(), '.github/workflows');
+    const allWorkflows = fs.readdirSync(workflowsDir)
+      .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+      .map((file) => fs.readFileSync(path.join(workflowsDir, file), 'utf8'))
+      .join('\n');
+
+    expect(allWorkflows).not.toContain('webfactory/ssh-agent@v0.9.0');
+    expect(allWorkflows).not.toContain('webfactory/ssh-agent@v0.9.1');
+    expect(allWorkflows).toContain('webfactory/ssh-agent@v0.10.0');
+  });
+
   test('Directus token resolution prefers PM2 runtime env over build-time public tokens', () => {
     const source = fs.readFileSync(path.join(process.cwd(), 'src/config/runtime.ts'), 'utf8');
     const fn = source.match(/export function getDirectusToken\(\): string \{([\s\S]*?)\n\}/)?.[1] || '';


### PR DESCRIPTION
## Summary
- upgrades webfactory/ssh-agent from v0.9.0 to v0.10.0 in deploy and ops workflows
- adds a runtime contract to prevent Node 20 ssh-agent action refs from returning
- closes the remaining GitHub Actions Node.js 20 warning seen after PR #61

## Validation
- npm test -- runtimeConfigContracts.test.js --runInBand
- npm test -- --runInBand
- git diff --check

Base is master because this is a production CI/CD hotfix and develop is stale against the deployed branch.