### PR TITLE
fix: restore blog editorial layout

### DIFF
--- a/src/components/blog/BlogFeedItem.astro
+++ b/src/components/blog/BlogFeedItem.astro
@@ -119,7 +119,10 @@ const issue = typeof index === 'number' ? String(index).padStart(2, '0') : '';
     font-weight: 700;
   }
 
-  .feed-body { min-width: 0; }
+  .feed-body {
+    min-width: 0;
+    padding-inline-end: clamp(20px, 4vw, 28px);
+  }
 
   .feed-meta {
     display: flex;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import LayoutV4 from '../../layouts/LayoutV4.astro';
+import BlogTOC from '../../components/blog/BlogTOC.astro';
 import { fetchBlogPost, fetchBlogListing } from '../../utils/getBlogData';
 import { blogImageUrl, blogPostImageUrl } from '../../utils/blogHelpers';
 import { addHeadingIds, getCategoryLabel, formatBlogDate, extractFaqSchema } from '../../utils/blogUtils';
@@ -31,7 +32,7 @@ const normalizeArticleContent = (html: string): string => {
 };
 
 const normalizedContent = normalizeArticleContent(post.contenido || '');
-const { html: contentHtml } = await addHeadingIds(normalizedContent);
+const { html: contentHtml, headings } = await addHeadingIds(normalizedContent);
 const faqSchema = extractFaqSchema(contentHtml);
 const imgUrl = blogPostImageUrl(post);
 const socialImg = post.social_image ? blogImageUrl(post.social_image) : imgUrl;
@@ -155,6 +156,8 @@ const heroSecondaryLabel = isArcaPost ? 'Relevamiento UMSA' : 'Ver servicios';
   <section class="article-page">
 
     <div class="article-layout">
+      <BlogTOC headings={headings} title={articleTitle} />
+
       <article class="article-body">
 
         <nav class="breadcrumbs" aria-label="Navegación">
@@ -251,7 +254,11 @@ const heroSecondaryLabel = isArcaPost ? 'Relevamiento UMSA' : 'Ver servicios';
   }
 
   .article-layout {
-    max-width: 820px;
+    display: grid;
+    grid-template-columns: minmax(176px, 220px) minmax(0, 820px);
+    gap: clamp(28px, 4.8vw, 64px);
+    align-items: start;
+    max-width: 1120px;
     margin: 0 auto;
   }
 
@@ -259,7 +266,7 @@ const heroSecondaryLabel = isArcaPost ? 'Relevamiento UMSA' : 'Ver servicios';
   .article-body {
     min-width: 0;
     max-width: 820px;
-    margin: 0 auto;
+    margin: 0;
   }
 
   /* Breadcrumbs */
@@ -670,13 +677,15 @@ const heroSecondaryLabel = isArcaPost ? 'Relevamiento UMSA' : 'Ver servicios';
   :global(.prose tr:last-child td) { border-bottom: none; }
   :global(.prose tr:nth-child(even) td) { background: #fafafa; }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1023px) {
     .article-layout {
-      max-width: 760px;
+      display: block;
+      max-width: 820px;
     }
 
     .article-body {
       max-width: 100%;
+      margin: 0 auto;
     }
   }
 
@@ -720,10 +729,6 @@ const heroSecondaryLabel = isArcaPost ? 'Relevamiento UMSA' : 'Ver servicios';
     .author-row {
       align-items: flex-start;
       margin-bottom: 22px;
-    }
-
-    .hero-figure {
-      margin-bottom: 32px;
     }
 
     .post-nav {

--- a/src/pages/blog/categoria/[cat].astro
+++ b/src/pages/blog/categoria/[cat].astro
@@ -3,8 +3,7 @@ import LayoutV4 from '../../../layouts/LayoutV4.astro';
 import BlogFeedItem from '../../../components/blog/BlogFeedItem.astro';
 import BlogPagination from '../../../components/blog/BlogPagination.astro';
 import { fetchBlogListing } from '../../../utils/getBlogData';
-import { blogPostImageAlt, blogPostImageUrl } from '../../../utils/blogHelpers';
-import { formatBlogDate, getCategoryLabel } from '../../../utils/blogUtils';
+import { getCategoryLabel } from '../../../utils/blogUtils';
 
 const VALID_CATS = ['noticias', 'proyectos', 'tecnico', 'tecnologia', 'empresa'];
 const cat = Astro.params.cat || '';
@@ -17,18 +16,10 @@ const PAGE_SIZE = 10;
 const page = Number(Astro.url.searchParams.get('page') || '1');
 const { posts, total } = await fetchBlogListing(page, PAGE_SIZE, cat);
 const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-const [hero, ...feedPosts] = posts;
-const archivePosts = feedPosts;
+const archivePosts = posts;
 const catLabel = getCategoryLabel(cat);
 const categoryLead = `${total} lectura${total !== 1 ? 's' : ''} de ${catLabel.toLowerCase()} ordenada${total !== 1 ? 's' : ''} por fecha, imagen y contexto técnico.`;
 const categoryTitle = `${catLabel}: decisiones IT con evidencia`;
-const heroImgUrl = hero ? blogPostImageUrl(hero) : '';
-const heroImgAlt = hero ? blogPostImageAlt(hero) : '';
-const heroCategory = hero ? getCategoryLabel(hero.categoria) : '';
-const heroDate = hero ? formatBlogDate(hero.fecha_publicacion) : '';
-const heroExcerpt = hero?.resumen
-  ? `${hero.resumen.substring(0, 190)}${hero.resumen.length > 190 ? '…' : ''}`
-  : '';
 
 const siteUrl = 'https://ultimamilla.com.ar';
 const catUrl = `${siteUrl}/blog/categoria/${cat}`;
@@ -113,7 +104,7 @@ const schema = {
   <main class="blog-cat">
     <div class="blog-container">
 
-      <header class:list={['blog-header', { 'blog-header--single': !hero }]}>
+      <header class="blog-header">
         <div class="blog-header__copy">
           <nav class="blog-breadcrumb" aria-label="Navegación">
             <a href="/" class="bc-link">ULTIMA MILLA</a>
@@ -131,22 +122,6 @@ const schema = {
           </div>
         </div>
 
-        {hero && (
-          <article class="blog-header__feature" aria-label="Lectura destacada">
-            <a href={`/blog/${hero.slug}`} class="blog-header__feature-media" aria-label={`Leer ${hero.titulo}`}>
-              <img src={heroImgUrl} alt={heroImgAlt} loading="eager" decoding="async" />
-            </a>
-            <div class="blog-header__feature-body">
-              <span class="blog-header__feature-kicker">Lectura de {catLabel}</span>
-              <p class="blog-header__feature-meta">{heroCategory} · {hero.tiempo_lectura} min · {heroDate}</p>
-              <h2>
-                <a href={`/blog/${hero.slug}`}>{hero.titulo}</a>
-              </h2>
-              <p>{heroExcerpt}</p>
-              <a href={`/blog/${hero.slug}`} class="blog-header__feature-link">Leer artículo</a>
-            </div>
-          </article>
-        )}
       </header>
 
       {archivePosts.length > 0 && (
@@ -156,7 +131,7 @@ const schema = {
             <p>Artículos ordenados para revisar decisiones, riesgos y alcance dentro de este eje técnico.</p>
           </div>
           <div class="feed">
-            {archivePosts.map((post, idx) => <BlogFeedItem post={post} index={idx + 4} />)}
+            {archivePosts.map((post, idx) => <BlogFeedItem post={post} index={idx + 1} />)}
           </div>
         </section>
       )}
@@ -191,18 +166,13 @@ const schema = {
 
   .blog-header {
     display: grid;
-    grid-template-columns: minmax(0, 0.48fr) minmax(420px, 0.52fr);
-    gap: clamp(34px, 5vw, 72px);
+    grid-template-columns: minmax(0, 780px);
     align-items: start;
-    margin: 0 calc(-1 * clamp(16px, 3vw, 24px)) clamp(20px, 3vw, 34px);
-    padding: clamp(32px, 4vw, 52px) clamp(16px, 3vw, 24px) clamp(28px, 3.6vw, 44px);
+    margin: 0 0 clamp(22px, 3vw, 36px);
+    padding: clamp(32px, 4vw, 52px) 0 clamp(28px, 3.6vw, 44px);
     background: var(--skin-section, #ffffff);
     color: var(--skin-text, #111111);
-    border-bottom: 0;
-  }
-
-  .blog-header--single {
-    grid-template-columns: minmax(0, 760px);
+    border-bottom: 1px solid rgba(17, 17, 17, 0.12);
   }
 
   .blog-breadcrumb {
@@ -270,94 +240,6 @@ const schema = {
     color: #111111;
   }
 
-  .blog-header__feature {
-    display: grid;
-    grid-template-columns: minmax(170px, 0.46fr) minmax(0, 0.54fr);
-    gap: clamp(18px, 2.6vw, 30px);
-    align-items: center;
-    min-width: 0;
-  }
-
-  .blog-header__feature-media {
-    display: block;
-    min-height: clamp(260px, 23vw, 348px);
-    background: #f3f5f7;
-    overflow: hidden;
-    text-decoration: none;
-  }
-
-  .blog-header__feature-media img {
-    width: 100%;
-    height: 100%;
-    min-height: clamp(260px, 23vw, 348px);
-    object-fit: cover;
-    display: block;
-    color: transparent;
-  }
-
-  .blog-header__feature-body {
-    min-width: 0;
-    padding-bottom: 2px;
-  }
-
-  .blog-header__feature-kicker {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-    color: #111111;
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .blog-header__feature-kicker::before {
-    content: "";
-    width: 30px;
-    height: 2px;
-    background: var(--um-red);
-  }
-
-  .blog-header__feature-meta,
-  .blog-header__feature-body > p {
-    margin: 0 0 14px;
-    color: #5f6874;
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    line-height: 1.64;
-  }
-
-  .blog-header__feature-body h2 {
-    margin: 0 0 12px;
-    color: #111111;
-    font-family: var(--um-font-display);
-    font-size: clamp(1.5rem, 2.12vw, 2rem);
-    font-weight: 600;
-    line-height: 1.12;
-    letter-spacing: 0;
-    overflow-wrap: anywhere;
-    text-wrap: balance;
-  }
-
-  .blog-header__feature-body h2 a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .blog-header__feature-body h2 a:hover,
-  .blog-header__feature-link:hover {
-    color: var(--um-red);
-  }
-
-  .blog-header__feature-link {
-    display: inline-flex;
-    color: var(--um-red);
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    font-weight: 700;
-    text-decoration: none;
-  }
-
   .blog-archive {
     margin-top: clamp(26px, 4vw, 48px);
   }
@@ -413,7 +295,7 @@ const schema = {
 
   @media (max-width: 820px) {
     .blog-cat {
-      padding-inline: 16px;
+      padding-inline: 0;
     }
 
     .blog-container {
@@ -423,7 +305,6 @@ const schema = {
 
     .blog-header {
       grid-template-columns: 1fr;
-      gap: 28px;
       padding: 28px 0 24px;
     }
 
@@ -437,19 +318,5 @@ const schema = {
       gap: 12px;
     }
 
-    .blog-header__feature {
-      grid-template-columns: 1fr;
-      gap: 18px;
-    }
-
-    .blog-header__feature-media,
-    .blog-header__feature-media img {
-      min-height: 220px;
-    }
-
-    .blog-header__feature-body h2 {
-      font-size: clamp(1.38rem, 5.4vw, 1.68rem);
-      line-height: 1.14;
-    }
   }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,8 +4,6 @@ import BlogFeedItem from '../../components/blog/BlogFeedItem.astro';
 import BlogPagination from '../../components/blog/BlogPagination.astro';
 import SectionHeader from '../../components/um/SectionHeader.astro';
 import { fetchBlogListing } from '../../utils/getBlogData';
-import { blogPostImageAlt, blogPostImageUrl } from '../../utils/blogHelpers';
-import { formatBlogDate, getCategoryLabel } from '../../utils/blogUtils';
 import { resolveReplicaH1 } from '../../utils/replicaProdCopy';
 import { getAntecedentesCountExactPhrase } from '../../utils/verifiedProof';
 
@@ -15,16 +13,7 @@ const PAGE_SIZE = 10;
 const page = Number(Astro.url.searchParams.get('page') || '1');
 const { posts, total } = await fetchBlogListing(page, PAGE_SIZE);
 const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-
-const [hero, ...feedPosts] = posts;
-const archivePosts = feedPosts;
-const heroImgUrl = hero ? blogPostImageUrl(hero) : '';
-const heroImgAlt = hero ? blogPostImageAlt(hero) : '';
-const heroCategory = hero ? getCategoryLabel(hero.categoria) : '';
-const heroDate = hero ? formatBlogDate(hero.fecha_publicacion) : '';
-const heroExcerpt = hero?.resumen
-  ? `${hero.resumen.substring(0, 190)}${hero.resumen.length > 190 ? '…' : ''}`
-  : '';
+const archivePosts = posts;
 
 const siteUrl = 'https://ultimamilla.com.ar';
 const canonicalUrl = page === 1 ? `${siteUrl}/blog` : `${siteUrl}/blog?page=${page}`;
@@ -95,33 +84,17 @@ const schema = {
           </div>
         </div>
 
-        {hero && (
-          <article class="blog-header__feature" aria-label="Lectura destacada">
-            <a href={`/blog/${hero.slug}`} class="blog-header__feature-media" aria-label={`Leer ${hero.titulo}`}>
-              <img src={heroImgUrl} alt={heroImgAlt} loading="eager" decoding="async" />
-            </a>
-            <div class="blog-header__feature-body">
-              <span class="blog-header__feature-kicker">Lectura reciente</span>
-              <p class="blog-header__feature-meta">{heroCategory} · {hero.tiempo_lectura} min · {heroDate}</p>
-              <h2>
-                <a href={`/blog/${hero.slug}`}>{hero.titulo}</a>
-              </h2>
-              <p>{heroExcerpt}</p>
-              <a href={`/blog/${hero.slug}`} class="blog-header__feature-link">Leer artículo</a>
-            </div>
-          </article>
-        )}
       </header>
 
       {archivePosts.length > 0 && (
         <section class="blog-archive" aria-label="Archivo documental">
           <SectionHeader
             class="archive-head"
-            title="Archivo documental"
+            title="Últimas notas"
             text="Lecturas ordenadas por fecha, imagen y contexto para evaluar riesgos, alcance y decisiones técnicas sin pasos intermedios."
           />
           <div class="feed">
-            {archivePosts.map((post, idx) => <BlogFeedItem post={post} index={idx + 4} />)}
+            {archivePosts.map((post, idx) => <BlogFeedItem post={post} index={idx + 1} />)}
           </div>
         </section>
       )}
@@ -157,10 +130,9 @@ const schema = {
   .blog-header {
     display: grid;
     grid-template-columns: 1fr;
-    gap: clamp(30px, 4.6vw, 48px);
     align-items: start;
-    margin: 0 calc(-1 * clamp(16px, 3vw, 24px)) clamp(20px, 3vw, 34px);
-    padding: clamp(38px, 4.8vw, 60px) clamp(16px, 3vw, 24px) clamp(32px, 4vw, 52px);
+    margin: 0 0 clamp(22px, 3vw, 36px);
+    padding: clamp(38px, 4.8vw, 60px) 0 clamp(30px, 3.4vw, 46px);
     background: var(--skin-section, #ffffff);
     color: var(--skin-text, #111111);
     border-bottom: 1px solid rgba(17, 17, 17, 0.12);
@@ -278,101 +250,8 @@ const schema = {
     overflow-wrap: anywhere;
   }
 
-  .blog-header__feature {
-    display: grid;
-    grid-template-columns: minmax(320px, 0.48fr) minmax(0, 0.52fr);
-    gap: clamp(24px, 3.4vw, 44px);
-    align-items: center;
-    min-width: 0;
-    padding-top: clamp(24px, 3vw, 34px);
-    border-top: 1px solid rgba(17, 17, 17, 0.14);
-  }
-
-  .blog-header__feature-media {
-    display: block;
-    aspect-ratio: 16 / 10;
-    background: #f3f5f7;
-    overflow: hidden;
-    text-decoration: none;
-  }
-
-  .blog-header__feature-media img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-    color: transparent;
-  }
-
-  .blog-header__feature-body {
-    display: flex;
-    min-height: 0;
-    flex-direction: column;
-    justify-content: center;
-    min-width: 0;
-    padding-bottom: 0;
-  }
-
-  .blog-header__feature-kicker {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-    color: #111111;
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .blog-header__feature-kicker::before {
-    content: "";
-    width: 30px;
-    height: 2px;
-    background: var(--um-red);
-  }
-
-  .blog-header__feature-meta,
-  .blog-header__feature-body > p {
-    margin: 0 0 14px;
-    color: #5f6874;
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    line-height: 1.64;
-  }
-
-  .blog-header__feature-body h2 {
-    margin: 0 0 12px;
-    color: #111111;
-    font-family: var(--um-font-display);
-    font-size: clamp(1.65rem, 2.45vw, 2.32rem);
-    font-weight: 600;
-    line-height: 1.13;
-    letter-spacing: 0;
-    overflow-wrap: anywhere;
-    text-wrap: balance;
-  }
-
-  .blog-header__feature-body h2 a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .blog-header__feature-body h2 a:hover,
-  .blog-header__feature-link:hover {
-    color: var(--um-red);
-  }
-
-  .blog-header__feature-link {
-    display: inline-flex;
-    color: var(--um-red);
-    font-family: var(--um-font-body);
-    font-size: 16px;
-    font-weight: 700;
-    text-decoration: none;
-  }
-
   .blog-archive {
-    margin-top: clamp(34px, 4.6vw, 58px);
+    margin-top: clamp(28px, 4vw, 46px);
   }
 
   .archive-head:global(.um-section-header) {
@@ -414,7 +293,7 @@ const schema = {
 
   .feed {
     margin-top: 0;
-    max-width: 860px;
+    max-width: 920px;
   }
 
   .empty-state {
@@ -427,7 +306,7 @@ const schema = {
 
   @media (max-width: 820px) {
     .blog-index {
-      padding-inline: 16px;
+      padding-inline: 0;
     }
 
     .blog-container {
@@ -436,7 +315,6 @@ const schema = {
     }
 
     .blog-header {
-      gap: 28px;
       padding: 28px 0 24px;
       align-items: start;
     }
@@ -473,25 +351,5 @@ const schema = {
       gap: 12px;
     }
 
-    .blog-header__feature {
-      grid-template-columns: 1fr;
-      gap: 18px;
-      align-items: start;
-      padding-top: 22px;
-    }
-
-    .blog-header__feature-media,
-    .blog-header__feature-media img {
-      min-height: 220px;
-    }
-
-    .blog-header__feature-body {
-      min-height: 0;
-    }
-
-    .blog-header__feature-body h2 {
-      font-size: clamp(1.38rem, 5.4vw, 1.68rem);
-      line-height: 1.14;
-    }
   }
 </style>


### PR DESCRIPTION
## Cambios
- Quita la lectura destacada con imagen de la cabecera de /blog y /blog/categoria para eliminar el banner indebido.
- Restaura el indice lateral en notas single del blog usando los headings ya generados.
- Ajusta el feed de articulos para margen seguro en viewports compactos/moviles.

## Validaciones locales
- npm run typecheck: OK
- npm run lint: 0 errores, 77 warnings legacy
- npm run build: OK
- npm run audit:css: 0 findings
- audit visual strict filtrado a /blog y /blog/categoria/tecnico: 14 checks, 0 failures
- preview local 4322: /blog y categoria sin blog-header__feature; single Zammad con TOC y canonical propio