### PR TITLE
fix: include core pages in GEO sitemap

### DIFF
--- a/src/pages/sitemap-geo.xml.ts
+++ b/src/pages/sitemap-geo.xml.ts
@@ -12,6 +12,8 @@ type GeoSitemapEntry = {
   changefreq: string;
 };
 
+const coreGeoDiscoveryPaths = ['/servicios', '/sectores', '/antecedentes', '/blog', '/contacto'];
+
 function urlEntry(entry: GeoSitemapEntry, lastmod: string) {
   return `
     <url>
@@ -31,6 +33,11 @@ function generateGeoSitemapXml() {
     ...geoResourceNames.map((resource) => ({
       loc: canonicalUrl(`/geo/${resource}.json`),
       priority: '0.8',
+      changefreq: 'weekly',
+    })),
+    ...coreGeoDiscoveryPaths.map((path) => ({
+      loc: canonicalUrl(path),
+      priority: path === '/servicios' ? '0.95' : '0.9',
       changefreq: 'weekly',
     })),
     ...geoHubRoutes.map((hub) => ({ loc: hub.url, priority: '0.92', changefreq: 'weekly' })),


### PR DESCRIPTION
## Cambios
- Agrega /servicios, /sectores, /antecedentes, /blog y /contacto al sitemap GEO.
- Alinea sitemap-geo.xml con las Core Pages ya declaradas en llms.txt y llms-full.txt.

## Validaciones
- npm run typecheck: OK
- npm run build: OK
- npm run seo:audit -- --base-url http://127.0.0.1:4322 --canonical-base-url https://ultimamilla.com.ar: OK