### PR TITLE
fix: canonicalize blog internal links

### DIFF
--- a/__tests__/visualInformationHubContracts.test.js
+++ b/__tests__/visualInformationHubContracts.test.js
@@ -272,6 +272,18 @@ describe('Information hub visual contracts', () => {
     expect(blogSingle).not.toContain('article-commercial-fold');
   });
 
+  test('blog single canonicalizes internal production links inside article content', () => {
+    const blogSingle = read('src/pages/blog/[slug].astro');
+    const normalizeStart = blogSingle.indexOf('const normalizeArticleContent');
+    const normalizeEnd = blogSingle.indexOf('const normalizedContent');
+    const normalizer = blogSingle.slice(normalizeStart, normalizeEnd);
+
+    expect(normalizer).toContain("const canonicalizedHtml = (html || '').replace");
+    expect(normalizer).toContain('replace(/https?:');
+    expect(normalizer).toContain('ultimamilla');
+    expect(normalizer).toContain('siteUrl');
+  });
+
   test('blog single H1 keeps the complete editorial title instead of truncating with ellipsis', () => {
     const blogSingle = read('src/pages/blog/[slug].astro');
     const titleBuilderStart = blogSingle.indexOf('const buildArticleTitle');

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -8,6 +8,7 @@ import { isReplicaIdenticalCopy, resolveReplicaH1 } from '../../utils/replicaPro
 
 const slug = Astro.params.slug || '';
 const post = await fetchBlogPost(slug);
+const siteUrl = 'https://www.ultimamilla.com.ar';
 
 if (!post) {
   return Astro.redirect('/blog');
@@ -25,10 +26,12 @@ const normalizeArticleContent = (html: string): string => {
     'Cómo Empezar: Tres Caminos': 'Cómo empezar',
   };
 
+  const canonicalizedHtml = (html || '').replace(/https?:\/\/(?:www\.)?ultimamilla\.com\.ar/gi, siteUrl);
+
   return Object.entries(replacements).reduce((acc, [from, to]) => {
     const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return acc.replace(new RegExp(`(<h[2-3][^>]*>)\\s*${escaped}\\s*(<\\/h[2-3]>)`, 'gi'), `$1${to}$2`);
-  }, html || '');
+  }, canonicalizedHtml);
 };
 
 const normalizedContent = normalizeArticleContent(post.contenido || '');
@@ -53,7 +56,6 @@ const idx = allRecent.findIndex(p => p.slug === slug);
 const prevPost = idx > 0 ? allRecent[idx - 1] : null;
 const nextPost = idx < allRecent.length - 1 ? allRecent[idx + 1] : null;
 
-const siteUrl = 'https://www.ultimamilla.com.ar';
 const articleUrl = `${siteUrl}/blog/${slug}`;
 const wordCount = contentHtml.replace(/<[^>]+>/g, ' ').split(/\s+/).filter(Boolean).length;
 


### PR DESCRIPTION
## Cambios
- Normaliza links internos del cuerpo de notas de blog desde apex o www hacia https://www.ultimamilla.com.ar antes del render.
- Agrega contrato visual para evitar que vuelva a filtrarse el dominio apex dentro del contenido de las single.

## Motivo
El crawler post-deploy detectó notas con status 200 y canonical correcto, pero con links internos en el HTML apuntando a https://ultimamilla.com.ar. Esto evita fuga SEO interna sin tocar contenido Directus manualmente.

## Validaciones locales
- npm run typecheck
- npm test -- --runInBand __tests__/visualInformationHubContracts.test.js __tests__/seoUrl.test.ts
- npm run build