### PR TITLE
fix: remove package ambiguity from services copy

### DIFF
--- a/src/data/serviceVisualSystem.ts
+++ b/src/data/serviceVisualSystem.ts
@@ -22,7 +22,7 @@ export const serviceVisualSystem: Record<number, ServiceVisualSpec> = {
     image: '/uploads/antecedentes/0021d14f-3f8a-4e39-9a03-dad7c8681c0d.jpg',
     imageAlt: 'Sala técnica con racks de comunicaciones y cableado estructurado',
     icon: 'network',
-    signal: 'traza de paquetes'
+    signal: 'traza de red'
   },
   102: {
     serviceId: 102,


### PR DESCRIPTION
## Cambio
- Cambia la señal visible de Redes de 'traza de paquetes' a 'traza de red' para evitar ambigüedad con Producto/CCTV AI.

## Validacion
- rg sin matches para la frase ambigua en src.
- npx jest __tests__/visualInformationHubContracts.test.js __tests__/cctvAiProductContract.test.js --config=jest.config.cjs --runInBand
- npm run build