### PR TITLE
deploy: remove services package ambiguity

### DIFF
--- a/src/data/serviceVisualSystem.ts
+++ b/src/data/serviceVisualSystem.ts
@@ -22,7 +22,7 @@ export const serviceVisualSystem: Record<number, ServiceVisualSpec> = {
     image: '/uploads/antecedentes/0021d14f-3f8a-4e39-9a03-dad7c8681c0d.jpg',
     imageAlt: 'Sala técnica con racks de comunicaciones y cableado estructurado',
     icon: 'network',
-    signal: 'traza de paquetes'
+    signal: 'traza de red'
   },
   102: {
     serviceId: 102,


### PR DESCRIPTION
## Produccion
Despliega un microcopy de servicios para evitar ambigüedad con Producto/CCTV AI.

## Cambio
- Redes: 'traza de paquetes' -> 'traza de red'.

## Validacion
- PR #83 checks completos: Lint & Format, Build Verification, Run Tests, PR Summary Comment.
- Local: contratos visuales/producto y build.