### PR TITLE
feat: add contextual contact modal

### DIFF
--- a/__tests__/contactModalContract.test.js
+++ b/__tests__/contactModalContract.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = process.cwd();
+const read = (file) => fs.readFileSync(path.join(repoRoot, file), 'utf8');
+
+describe('global contact modal contract', () => {
+  test('LayoutV4 renders the contextual contact modal globally', () => {
+    const layout = read('src/layouts/LayoutV4.astro');
+
+    expect(layout).toContain("import ContactModal from '../components/um/ContactModal.astro'");
+    expect(layout).toContain('<ContactModal />');
+  });
+
+  test('contact modal keeps the visible form simple and sends context invisibly', () => {
+    const modal = read('src/components/um/ContactModal.astro');
+    const formSource = modal.slice(
+      modal.indexOf('<form id="umContactModalForm"'),
+      modal.indexOf('</form>') + '</form>'.length
+    );
+
+    const visibleFieldNames = Array.from(formSource.matchAll(/<(?:input|textarea|select)\b[^>]*\sname="([^"]+)"/g))
+      .map((match) => match[1])
+      .filter((name) => ![
+        'website',
+        'contact_phone',
+        'startedAt',
+        'formVariant',
+        'contactProof',
+        'originPath',
+        'originTitle',
+        'originLabel',
+        'originIntent',
+        'originHref',
+      ].includes(name));
+
+    expect(visibleFieldNames).toEqual(['name', 'email', 'company', 'message']);
+    expect(modal).toContain('role="dialog"');
+    expect(modal).toContain('aria-modal="true"');
+    expect(modal).toContain('data-contact-context');
+    expect(modal).toContain('data-contact-prompt');
+    expect(modal).toContain('contactHref(source)');
+  });
+
+  test('contact API preserves invisible antispam and contextual email metadata', () => {
+    const api = read('src/pages/api/contact.ts');
+
+    expect(api).toContain('const duplicateMap = new Map<string, number>();');
+    expect(api).toContain('hasInvalidModalProof(data)');
+    expect(api).toContain('trimString(data.originPath');
+    expect(api).toContain('Contexto de origen');
+    expect(api).toContain('trimString(data.contact_phone');
+  });
+});

--- a/scripts/contact-modal-qa.mjs
+++ b/scripts/contact-modal-qa.mjs
@@ -1,0 +1,271 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+const baseUrl = process.env.UMSA_BASE_URL || 'http://127.0.0.1:4331';
+const chromeBin = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const port = 9571 + Math.floor(Math.random() * 300);
+const profile = `/tmp/um-contact-modal-profile-${port}`;
+const outDir = '/private/tmp/um-contact-modal-shots';
+mkdirSync(outDir, { recursive: true });
+
+function cleanup() {
+  spawnSync('pkill', ['-f', profile], { stdio: 'ignore' });
+}
+
+cleanup();
+const chrome = spawn(chromeBin, [
+  `--remote-debugging-port=${port}`,
+  `--user-data-dir=${profile}`,
+  '--headless=new',
+  '--disable-gpu',
+  '--no-first-run',
+  '--no-default-browser-check',
+  'about:blank',
+], { stdio: 'ignore' });
+
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function targets() {
+  for (let i = 0; i < 120; i += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      if (response.ok) {
+        const list = await response.json();
+        const page = list.find((target) => target.type === 'page');
+        if (page) return page;
+      }
+    } catch {
+      // Chrome is still booting.
+    }
+    await sleep(100);
+  }
+  throw new Error('Chrome CDP was not ready');
+}
+
+let commandId = 0;
+function cdp(ws, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const id = ++commandId;
+    const timer = setTimeout(() => reject(new Error(`CDP timeout: ${method}`)), 20000);
+    const onMessage = (event) => {
+      const message = JSON.parse(event.data);
+      if (message.id !== id) return;
+      clearTimeout(timer);
+      ws.removeEventListener('message', onMessage);
+      if (message.error) reject(new Error(JSON.stringify(message.error)));
+      else resolve(message.result);
+    };
+    ws.addEventListener('message', onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+async function evalOnPage(ws, expression) {
+  const { result } = await cdp(ws, 'Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (result.subtype === 'error') throw new Error(result.description || 'Runtime error');
+  return result.value;
+}
+
+async function navigate(ws, path, viewport) {
+  await cdp(ws, 'Emulation.setDeviceMetricsOverride', viewport);
+  await cdp(ws, 'Page.navigate', { url: new URL(path, baseUrl).toString() });
+  await sleep(900);
+}
+
+async function screenshot(ws, name) {
+  const shot = await cdp(ws, 'Page.captureScreenshot', {
+    format: 'png',
+    fromSurface: true,
+    captureBeyondViewport: false,
+  });
+  const file = `${outDir}/${name}.png`;
+  writeFileSync(file, Buffer.from(shot.data, 'base64'));
+  return file;
+}
+
+const target = await targets();
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise((resolve) => ws.addEventListener('open', resolve, { once: true }));
+await cdp(ws, 'Page.enable');
+await cdp(ws, 'Runtime.enable');
+await cdp(ws, 'DOM.enable');
+
+const checks = [];
+
+await navigate(ws, '/', { width: 1360, height: 900, deviceScaleFactor: 1, mobile: false });
+await evalOnPage(ws, `document.querySelector('a[href="/contacto"]')?.click()`);
+await sleep(400);
+checks.push(await evalOnPage(ws, `(() => {
+  const modal = document.querySelector('[data-contact-modal]');
+  const title = document.querySelector('[data-contact-context-title]')?.textContent;
+  const fields = Array.from(document.querySelectorAll('#umContactModalForm input[name], #umContactModalForm textarea[name]')).map((el) => el.name);
+  const visible = Array.from(document.querySelectorAll('#umContactModalForm input[name], #umContactModalForm textarea[name]'))
+    .filter((el) => getComputedStyle(el).visibility !== 'hidden' && el.type !== 'hidden' && el.offsetParent !== null)
+    .map((el) => el.name);
+  const dialog = document.querySelector('.um-contact-dialog')?.getBoundingClientRect();
+  return {
+    step: 'home-open',
+    open: modal && modal.hidden === false,
+    title,
+    fields,
+    visible,
+    activeName: document.activeElement?.getAttribute('name'),
+    dialog: dialog ? { width: Math.round(dialog.width), height: Math.round(dialog.height), top: Math.round(dialog.top), left: Math.round(dialog.left) } : null,
+    overflowX: document.documentElement.scrollWidth > document.documentElement.clientWidth
+  };
+})()`));
+const desktopShot = await screenshot(ws, 'desktop-home-modal');
+await evalOnPage(ws, `document.querySelector('[data-contact-mode="guided"]')?.click()`);
+await sleep(180);
+await evalOnPage(ws, `document.querySelector('[data-contact-prompt]')?.click()`);
+await sleep(180);
+checks.push(await evalOnPage(ws, `(() => {
+  const message = document.querySelector('#umContactModalForm textarea[name="message"]')?.value || '';
+  const guides = document.querySelector('[data-contact-guides]');
+  return {
+    step: 'guided-autofill',
+    guidesVisible: guides ? guides.hidden === false : false,
+    message,
+    selected: Boolean(document.querySelector('[data-contact-prompt][aria-pressed="true"]')),
+    hasTemplateToken: message.includes('{context}'),
+    hasEmptyPrompt: /:\\s*$/.test(message)
+  };
+})()`));
+const guidedShot = await screenshot(ws, 'desktop-home-modal-guided');
+
+await evalOnPage(ws, `document.querySelector('[data-contact-close]')?.click()`);
+await sleep(200);
+
+await navigate(ws, '/', { width: 1366, height: 768, deviceScaleFactor: 1, mobile: false });
+await evalOnPage(ws, `document.querySelector('a[href="/contacto"]')?.click()`);
+await sleep(350);
+await evalOnPage(ws, `document.querySelector('[data-contact-mode="guided"]')?.click()`);
+await sleep(120);
+await evalOnPage(ws, `document.querySelectorAll('[data-contact-prompt]')[1]?.click()`);
+await sleep(180);
+checks.push(await evalOnPage(ws, `(() => {
+  const dialog = document.querySelector('.um-contact-dialog')?.getBoundingClientRect();
+  const main = document.querySelector('.um-contact-dialog__main');
+  const submit = document.querySelector('.um-contact-submit')?.getBoundingClientRect();
+  const message = document.querySelector('#umContactModalForm textarea[name="message"]')?.value || '';
+  return {
+    step: 'desktop-compact-guided',
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    dialog: dialog ? { width: Math.round(dialog.width), height: Math.round(dialog.height), top: Math.round(dialog.top), bottom: Math.round(dialog.bottom) } : null,
+    submit: submit ? { top: Math.round(submit.top), bottom: Math.round(submit.bottom) } : null,
+    main: main ? { clientHeight: main.clientHeight, scrollHeight: main.scrollHeight } : null,
+    message,
+    dialogFits: Boolean(dialog && dialog.top >= 8 && dialog.bottom <= window.innerHeight - 8),
+    submitVisible: Boolean(submit && submit.top >= 0 && submit.bottom <= window.innerHeight - 8),
+    overflowX: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    hasTemplateToken: message.includes('{context}'),
+    hasEmptyPrompt: /:\\s*$/.test(message)
+  };
+})()`));
+const compactShot = await screenshot(ws, 'desktop-compact-guided');
+await evalOnPage(ws, `document.querySelector('[data-contact-close]')?.click()`);
+await sleep(200);
+
+await navigate(ws, '/cctvai/', { width: 1360, height: 900, deviceScaleFactor: 1, mobile: false });
+await evalOnPage(ws, `document.querySelector('a[href="/contacto"]')?.click()`);
+await sleep(400);
+checks.push(await evalOnPage(ws, `(() => ({
+  step: 'cctvai-context',
+  title: document.querySelector('[data-contact-context-title]')?.textContent,
+  detail: document.querySelector('[data-contact-context-detail]')?.textContent,
+  modeGuided: document.querySelector('[data-contact-mode="guided"]')?.classList.contains('is-active'),
+  originIntent: document.querySelector('#umContactModalForm input[name="originIntent"]')?.value,
+  originPath: document.querySelector('#umContactModalForm input[name="originPath"]')?.value
+}))()`));
+
+await navigate(ws, '/servicios', { width: 390, height: 820, deviceScaleFactor: 2, mobile: true });
+await evalOnPage(ws, `document.querySelector('a[href="/contacto"]')?.click()`);
+await sleep(400);
+checks.push(await evalOnPage(ws, `(() => {
+  const dialog = document.querySelector('.um-contact-dialog')?.getBoundingClientRect();
+  return {
+    step: 'mobile-open',
+    open: document.querySelector('[data-contact-modal]')?.hidden === false,
+    dialog: dialog ? { width: Math.round(dialog.width), height: Math.round(dialog.height), top: Math.round(dialog.top), left: Math.round(dialog.left) } : null,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    overflowX: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    visibleFields: Array.from(document.querySelectorAll('#umContactModalForm input[name], #umContactModalForm textarea[name]'))
+      .filter((el) => getComputedStyle(el).visibility !== 'hidden' && el.type !== 'hidden' && el.offsetParent !== null)
+      .map((el) => el.name)
+  };
+})()`));
+const mobileShot = await screenshot(ws, 'mobile-services-modal');
+
+await navigate(ws, '/servicios', { width: 390, height: 667, deviceScaleFactor: 2, mobile: true });
+await evalOnPage(ws, `document.querySelector('a[href="/contacto"]')?.click()`);
+await sleep(350);
+await evalOnPage(ws, `document.querySelector('[data-contact-mode="guided"]')?.click()`);
+await sleep(120);
+await evalOnPage(ws, `document.querySelectorAll('[data-contact-prompt]')[1]?.click()`);
+await sleep(120);
+await evalOnPage(ws, `(() => {
+  const main = document.querySelector('.um-contact-dialog__main');
+  if (main) main.scrollTop = main.scrollHeight;
+})()`);
+await sleep(120);
+checks.push(await evalOnPage(ws, `(() => {
+  const dialog = document.querySelector('.um-contact-dialog')?.getBoundingClientRect();
+  const main = document.querySelector('.um-contact-dialog__main');
+  const close = document.querySelector('.um-contact-close')?.getBoundingClientRect();
+  const submit = document.querySelector('.um-contact-submit')?.getBoundingClientRect();
+  const message = document.querySelector('#umContactModalForm textarea[name="message"]')?.value || '';
+  return {
+    step: 'mobile-compact-guided-scroll',
+    open: document.querySelector('[data-contact-modal]')?.hidden === false,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    dialog: dialog ? { width: Math.round(dialog.width), height: Math.round(dialog.height), top: Math.round(dialog.top), bottom: Math.round(dialog.bottom) } : null,
+    main: main ? { clientHeight: main.clientHeight, scrollHeight: main.scrollHeight, scrollTop: Math.round(main.scrollTop) } : null,
+    close: close ? { top: Math.round(close.top), right: Math.round(close.right) } : null,
+    submit: submit ? { top: Math.round(submit.top), bottom: Math.round(submit.bottom) } : null,
+    message,
+    dialogFits: Boolean(dialog && dialog.top >= 0 && dialog.bottom <= window.innerHeight),
+    submitReachable: Boolean(submit && submit.top >= 0 && submit.bottom <= window.innerHeight),
+    closeVisible: Boolean(close && close.top >= 0 && close.right <= window.innerWidth),
+    overflowX: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    hasTemplateToken: message.includes('{context}'),
+    hasEmptyPrompt: /:\\s*$/.test(message)
+  };
+})()`));
+const mobileCompactShot = await screenshot(ws, 'mobile-compact-guided-scrolled');
+
+await navigate(ws, '/contacto', { width: 1360, height: 900, deviceScaleFactor: 1, mobile: false });
+checks.push(await evalOnPage(ws, `(() => ({
+  step: 'contact-page',
+  pageForm: Boolean(document.querySelector('#contactForm')),
+  modalPresent: Boolean(document.querySelector('#umContactModalForm')),
+  canonicalTitle: document.title,
+  overflowX: document.documentElement.scrollWidth > document.documentElement.clientWidth
+}))()`));
+
+ws.close();
+chrome.kill();
+cleanup();
+
+const failed = checks.filter((check) => {
+  if (check.step === 'home-open') return !check.open || check.overflowX || JSON.stringify(check.visible) !== JSON.stringify(['name', 'email', 'company', 'message']);
+  if (check.step === 'cctvai-context') return check.originPath !== '/cctvai/' || check.originIntent !== 'cctvai' || !check.modeGuided;
+  if (check.step === 'guided-autofill') return !check.guidesVisible || !check.selected || check.message.length < 20 || check.hasTemplateToken || check.hasEmptyPrompt;
+  if (check.step === 'desktop-compact-guided') return check.overflowX || !check.dialogFits || !check.submitVisible || check.hasTemplateToken || check.hasEmptyPrompt;
+  if (check.step === 'mobile-open') return !check.open || check.overflowX || !check.dialog || check.dialog.width > check.viewport.width;
+  if (check.step === 'mobile-compact-guided-scroll') return !check.open || check.overflowX || !check.dialogFits || !check.submitReachable || !check.closeVisible || check.hasTemplateToken || check.hasEmptyPrompt;
+  if (check.step === 'contact-page') return !check.pageForm || !check.modalPresent || check.overflowX;
+  return true;
+});
+
+console.log(JSON.stringify({ ok: failed.length === 0, checks, screenshots: { desktopShot, guidedShot, compactShot, mobileShot, mobileCompactShot } }, null, 2));
+if (failed.length > 0) process.exit(1);

--- a/src/components/um/ContactModal.astro
+++ b/src/components/um/ContactModal.astro
@@ -1,0 +1,1063 @@
+---
+import { Send, X } from 'lucide-astro';
+---
+
+<div id="umContactModal" class="um-contact-modal" hidden data-contact-modal>
+  <button class="um-contact-modal__backdrop" type="button" aria-label="Cerrar contacto" data-contact-close></button>
+
+  <section
+    class="um-contact-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="umContactTitle"
+    aria-describedby="umContactIntro"
+  >
+    <aside class="um-contact-dialog__rail" aria-label="Contexto de contacto">
+      <p class="um-contact-kicker">Contacto</p>
+      <h2 id="umContactTitle">Contacto rápido.</h2>
+      <p id="umContactIntro">Respondemos por email con el próximo paso.</p>
+
+      <div class="um-contact-context" data-contact-context hidden>
+        <span>Contexto detectado</span>
+        <strong data-contact-context-title>Consulta general</strong>
+        <p data-contact-context-detail>Origen: sitio ULTIMA MILLA</p>
+      </div>
+    </aside>
+
+    <button class="um-contact-close" type="button" aria-label="Cerrar contacto" data-contact-close>
+      <X aria-hidden="true" size={22} />
+    </button>
+
+    <div class="um-contact-dialog__main">
+      <div class="um-contact-mode" role="group" aria-label="Modo de consulta">
+        <button type="button" class="is-active" data-contact-mode="short" aria-pressed="true">Mensaje corto</button>
+        <button type="button" data-contact-mode="guided" aria-pressed="false">Completar mensaje</button>
+      </div>
+
+      <form id="umContactModalForm" class="um-contact-form" method="post" action="/api/contact" novalidate>
+        <div class="um-contact-field-grid">
+          <label>
+            <span>Nombre *</span>
+            <input type="text" name="name" required autocomplete="name" placeholder="Nombre y apellido" />
+            <small class="um-contact-error" data-error-for="name"></small>
+          </label>
+          <label>
+            <span>Email *</span>
+            <input type="email" name="email" required autocomplete="email" placeholder="mail@empresa.com" />
+            <small class="um-contact-error" data-error-for="email"></small>
+          </label>
+        </div>
+
+        <label>
+          <span>Empresa u organismo</span>
+          <input type="text" name="company" autocomplete="organization" placeholder="Opcional" />
+        </label>
+
+        <label>
+          <span>Mensaje *</span>
+          <textarea
+            name="message"
+            required
+            rows="5"
+            maxlength="1200"
+            placeholder="Necesito que me contacten por..."
+          ></textarea>
+          <small class="um-contact-error" data-error-for="message"></small>
+        </label>
+
+        <div class="um-contact-guides" data-contact-guides hidden>
+          <p>Atajos rápidos</p>
+          <div class="um-contact-guide-grid">
+            <button type="button" data-contact-prompt="Quiero coordinar un diagnóstico sobre {context}.">Diagnóstico</button>
+            <button type="button" data-contact-prompt="Quiero cotizar alcance y próximos pasos para {context}.">Cotizar alcance</button>
+            <button type="button" data-contact-prompt="Quiero ver un antecedente similar antes de avanzar con {context}.">Ver caso similar</button>
+            <button type="button" data-contact-prompt="Necesito hablar con un técnico sobre {context}.">Hablar con técnico</button>
+          </div>
+        </div>
+
+        <input type="text" name="website" class="um-contact-hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
+        <input type="text" name="contact_phone" class="um-contact-hp" tabindex="-1" autocomplete="off" aria-hidden="true" />
+        <input type="hidden" name="startedAt" value="" />
+        <input type="hidden" name="formVariant" value="modal" />
+        <input type="hidden" name="contactProof" value="" />
+        <input type="hidden" name="originPath" value="" />
+        <input type="hidden" name="originTitle" value="" />
+        <input type="hidden" name="originLabel" value="" />
+        <input type="hidden" name="originIntent" value="" />
+        <input type="hidden" name="originHref" value="" />
+
+        <div class="um-contact-submit-row">
+          <button type="submit" class="um-btn-primary um-contact-submit">
+            <Send aria-hidden="true" size={18} />
+            Enviar consulta
+          </button>
+          <p><span data-contact-count>0</span>/1200. El resto lo ordenamos nosotros.</p>
+        </div>
+
+        <div class="um-contact-message um-contact-message--success" role="status" hidden>
+          Mensaje enviado. Respondemos por email con el próximo paso.
+        </div>
+        <div class="um-contact-message um-contact-message--error" role="alert" hidden>
+          No se pudo enviar. Revisá los datos o usá la página de contacto.
+        </div>
+      </form>
+    </div>
+  </section>
+</div>
+
+<script>
+  (() => {
+    const modal = document.querySelector('[data-contact-modal]');
+    const form = document.getElementById('umContactModalForm');
+    if (!(modal instanceof HTMLElement) || !(form instanceof HTMLFormElement)) return;
+
+    const dialog = modal.querySelector('.um-contact-dialog');
+    const closeControls = modal.querySelectorAll('[data-contact-close]');
+    const modeButtons = modal.querySelectorAll('[data-contact-mode]');
+    const guides = modal.querySelector('[data-contact-guides]');
+    const textarea = form.querySelector('textarea[name="message"]');
+    const counter = modal.querySelector('[data-contact-count]');
+    const submitButton = form.querySelector('button[type="submit"]');
+    const successMessage = modal.querySelector('.um-contact-message--success');
+    const errorMessage = modal.querySelector('.um-contact-message--error');
+    const contextBox = modal.querySelector('[data-contact-context]');
+    const contextTitle = modal.querySelector('[data-contact-context-title]');
+    const contextDetail = modal.querySelector('[data-contact-context-detail]');
+    const startedAt = form.querySelector('input[name="startedAt"]');
+    const contactProof = form.querySelector('input[name="contactProof"]');
+    const focusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'input:not([disabled]):not([type="hidden"])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    let lastActiveElement = null;
+
+    const intentLabels = {
+      diagnostico: 'Diagnostico inicial',
+      relevamiento: 'Relevamiento tecnico',
+      documentacion: 'Documentacion',
+      presupuesto: 'Presupuesto',
+      soporte: 'Soporte',
+      cctvai: 'UMSA CCTV AI',
+      general: 'Consulta general'
+    };
+
+    function field(name) {
+      return form.querySelector(`[name="${name}"]`);
+    }
+
+    function normalizeText(value, fallback = '') {
+      return String(value || fallback).replace(/\s+/g, ' ').trim();
+    }
+
+    function setField(name, value) {
+      const input = field(name);
+      if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+        input.value = value;
+      }
+    }
+
+    function readPageHeading() {
+      return normalizeText(document.querySelector('h1')?.textContent, document.title);
+    }
+
+    function readSectionHeading(source) {
+      const section = source?.closest?.('section, article, aside, main');
+      return normalizeText(section?.querySelector?.('h1, h2, h3, strong')?.textContent, readPageHeading());
+    }
+
+    function inferIntent(label, path) {
+      const text = `${label} ${path}`.toLowerCase();
+      if (text.includes('cctv') || text.includes('cctvai')) return 'cctvai';
+      if (text.includes('presupuesto') || text.includes('cotizar') || text.includes('costo')) return 'presupuesto';
+      if (text.includes('relevamiento')) return 'relevamiento';
+      if (text.includes('document')) return 'documentacion';
+      if (text.includes('soporte') || text.includes('24/7')) return 'soporte';
+      if (text.includes('diagnostico') || text.includes('diagnóstico') || text.includes('incidente')) return 'diagnostico';
+      return 'general';
+    }
+
+    function contactHref(anchor) {
+      if (!(anchor instanceof HTMLAnchorElement)) return false;
+      if (anchor.target && anchor.target !== '_self') return false;
+      try {
+        const url = new URL(anchor.href, window.location.href);
+        return url.origin === window.location.origin && url.pathname.replace(/\/$/, '') === '/contacto';
+      } catch {
+        return false;
+      }
+    }
+
+    function buildContext(source) {
+      const label = normalizeText(source?.textContent, 'Contacto');
+      const path = window.location.pathname;
+      const sectionTitle = readSectionHeading(source);
+      const declaredIntent = source?.dataset?.contactIntent;
+      const intent = declaredIntent && declaredIntent !== 'general'
+        ? declaredIntent
+        : inferIntent(label, `${path} ${sectionTitle}`);
+      return {
+        path,
+        title: sectionTitle,
+        label,
+        intent,
+        href: source instanceof HTMLAnchorElement ? source.href : window.location.href
+      };
+    }
+
+    function setMode(mode) {
+      const isGuided = mode === 'guided';
+      modeButtons.forEach((button) => {
+        const active = button.getAttribute('data-contact-mode') === mode;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-pressed', String(active));
+      });
+      if (guides instanceof HTMLElement) {
+        guides.hidden = !isGuided;
+      }
+      if (textarea instanceof HTMLTextAreaElement) {
+        textarea.placeholder = isGuided
+          ? 'Elegí un atajo o escribí tu mensaje.'
+          : 'Necesito que me contacten por...';
+      }
+    }
+
+    function updateCounter() {
+      if (!(textarea instanceof HTMLTextAreaElement) || !counter) return;
+      counter.textContent = String(textarea.value.length);
+    }
+
+    function resetMessages() {
+      form.querySelectorAll('.um-contact-error').forEach((error) => {
+        error.textContent = '';
+      });
+      form.querySelectorAll('[aria-invalid="true"]').forEach((input) => {
+        input.removeAttribute('aria-invalid');
+      });
+      if (successMessage instanceof HTMLElement) successMessage.hidden = true;
+      if (errorMessage instanceof HTMLElement) errorMessage.hidden = true;
+    }
+
+    function showError(name, message) {
+      const input = field(name);
+      const error = form.querySelector(`[data-error-for="${name}"]`);
+      if (input instanceof HTMLElement) input.setAttribute('aria-invalid', 'true');
+      if (error) error.textContent = message;
+    }
+
+    function isValidEmail(email) {
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    }
+
+    function validate() {
+      resetMessages();
+      const name = normalizeText(field('name')?.value);
+      const email = normalizeText(field('email')?.value);
+      const message = normalizeText(field('message')?.value);
+      let valid = true;
+
+      if (name.length < 2) {
+        showError('name', 'Ingresa tu nombre.');
+        valid = false;
+      }
+
+      if (!isValidEmail(email)) {
+        showError('email', 'Ingresa un email valido.');
+        valid = false;
+      }
+
+      if (message.length < 12) {
+        showError('message', 'Agrega una frase corta de contexto.');
+        valid = false;
+      }
+
+      if (message.length > 1200) {
+        showError('message', 'Reduci el mensaje a 1200 caracteres.');
+        valid = false;
+      }
+
+      return valid;
+    }
+
+    function focusFirstField() {
+      const first = form.querySelector('input[name="name"]');
+      if (first instanceof HTMLElement) first.focus({ preventScroll: true });
+    }
+
+    function openContactModal(context = {}) {
+      const resolved = {
+        path: context.path || window.location.pathname,
+        title: context.title || readPageHeading(),
+        label: context.label || 'Contacto',
+        intent: context.intent || inferIntent(context.label || '', window.location.pathname),
+        href: context.href || window.location.href
+      };
+
+      lastActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      modal.hidden = false;
+      document.body.classList.add('um-contact-lock');
+
+      const now = Date.now();
+      setField('startedAt', String(now));
+      setField('contactProof', `${now}:${Math.round(performance.now())}:${navigator.language || 'es-AR'}`);
+      setField('originPath', resolved.path);
+      setField('originTitle', resolved.title);
+      setField('originLabel', resolved.label);
+      setField('originIntent', resolved.intent);
+      setField('originHref', resolved.href);
+
+      if (contextBox instanceof HTMLElement) contextBox.hidden = false;
+      if (contextTitle) contextTitle.textContent = intentLabels[resolved.intent] || intentLabels.general;
+      if (contextDetail) {
+        const displayPath = resolved.path === '/' ? 'Inicio del sitio' : `Página actual: ${resolved.path}`;
+        const displayTitle = resolved.title.replace(/[.。]+$/, '');
+        contextDetail.textContent = `${displayTitle}. ${displayPath}`;
+      }
+
+      resetMessages();
+      setMode(resolved.intent === 'general' ? 'short' : 'guided');
+      updateCounter();
+      window.setTimeout(focusFirstField, 60);
+    }
+
+    function closeContactModal() {
+      modal.hidden = true;
+      document.body.classList.remove('um-contact-lock');
+      if (lastActiveElement) lastActiveElement.focus({ preventScroll: true });
+    }
+
+    closeControls.forEach((control) => control.addEventListener('click', closeContactModal));
+
+    modeButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        setMode(button.getAttribute('data-contact-mode') || 'short');
+      });
+    });
+
+    modal.querySelectorAll('[data-contact-prompt]').forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!(textarea instanceof HTMLTextAreaElement)) return;
+        const template = button.getAttribute('data-contact-prompt') || '';
+        const contextInput = form.querySelector('input[name="originTitle"]');
+        const context = normalizeText(contextInput?.value, 'esta consulta').replace(/[.。]+$/, '');
+        const prompt = template.replace('{context}', context);
+        const value = textarea.value.trim();
+        const wasAutofilled = textarea.dataset.autofilled === 'true';
+        if (!value || wasAutofilled) {
+          textarea.value = prompt;
+          textarea.dataset.autofilled = 'true';
+        } else if (!value.includes(prompt)) {
+          textarea.value = `${value}\n${prompt}`;
+        }
+        modal.querySelectorAll('[data-contact-prompt]').forEach((item) => item.removeAttribute('aria-pressed'));
+        button.setAttribute('aria-pressed', 'true');
+        textarea.focus();
+        updateCounter();
+      });
+    });
+
+    textarea?.addEventListener('input', () => {
+      textarea.dataset.autofilled = 'false';
+      updateCounter();
+    });
+
+    document.addEventListener('click', (event) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      const source = event.target instanceof Element ? event.target.closest('a[href], [data-contact-open]') : null;
+      if (!source) return;
+      const isExplicit = source.hasAttribute('data-contact-open');
+      const isContactLink = source instanceof HTMLAnchorElement && contactHref(source);
+      if (!isExplicit && !isContactLink) return;
+      event.preventDefault();
+      openContactModal(buildContext(source));
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (modal.hidden) return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeContactModal();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+      const focusable = Array.from(modal.querySelectorAll(focusableSelector))
+        .filter((element) => element instanceof HTMLElement && element.offsetParent !== null);
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!validate()) return;
+
+      if (submitButton instanceof HTMLButtonElement) {
+        submitButton.disabled = true;
+        submitButton.dataset.originalText = submitButton.textContent || 'Enviar consulta';
+        submitButton.textContent = 'Enviando...';
+      }
+
+      try {
+        const response = await fetch('/api/contact', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(Object.fromEntries(new FormData(form).entries()))
+        });
+        const result = await response.json();
+
+        if (!response.ok || !result.success) {
+          throw new Error(result.message || 'No se pudo enviar.');
+        }
+
+        form.reset();
+        setField('startedAt', String(Date.now()));
+        setField('contactProof', `${Date.now()}:${Math.round(performance.now())}`);
+        updateCounter();
+        if (successMessage instanceof HTMLElement) successMessage.hidden = false;
+      } catch (error) {
+        if (errorMessage instanceof HTMLElement) {
+          errorMessage.textContent = error instanceof Error ? error.message : 'No se pudo enviar. Revisa los datos.';
+          errorMessage.hidden = false;
+        }
+      } finally {
+        if (submitButton instanceof HTMLButtonElement) {
+          submitButton.disabled = false;
+          submitButton.innerHTML = '<svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"></path><path d="M22 2 11 13"></path></svg>Enviar consulta';
+        }
+      }
+    });
+
+    window.addEventListener('umsa:contact:open', (event) => {
+      openContactModal(event.detail || {});
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('contact') === '1') {
+      window.setTimeout(() => openContactModal({
+        intent: params.get('intent') || 'general',
+        label: 'Contacto',
+        title: readPageHeading(),
+        path: window.location.pathname,
+        href: window.location.href
+      }), 320);
+    }
+  })();
+</script>
+
+<style is:global>
+  .um-contact-lock {
+    overflow: hidden;
+  }
+
+  .um-contact-modal[hidden] {
+    display: none !important;
+  }
+
+	  .um-contact-modal {
+	    position: fixed;
+	    inset: 0;
+	    z-index: 120;
+	    display: grid;
+	    place-items: center;
+	    min-height: 100dvh;
+	    overflow: hidden;
+	    padding: clamp(14px, 3vw, 32px);
+	  }
+
+  .um-contact-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    border: 0;
+    background: rgba(0, 0, 0, 0.58);
+    backdrop-filter: blur(12px) saturate(0.78);
+    -webkit-backdrop-filter: blur(12px) saturate(0.78);
+    cursor: pointer;
+  }
+
+	  .um-contact-dialog {
+	    position: relative;
+	    display: grid;
+	    grid-template-columns: minmax(250px, 0.52fr) minmax(430px, 1fr);
+	    width: min(100%, 960px);
+	    height: min(720px, calc(100dvh - 32px));
+	    max-height: calc(100dvh - 32px);
+	    min-height: 0;
+	    overflow: hidden;
+	    background: #fff;
+    color: #111;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+  }
+
+	  .um-contact-dialog__rail {
+	    display: flex;
+	    min-height: 0;
+	    flex-direction: column;
+	    justify-content: flex-start;
+	    gap: clamp(18px, 2.4vw, 28px);
+	    overflow: hidden;
+	    background: #050505;
+    color: #fff;
+    padding: clamp(22px, 2.5vw, 30px);
+  }
+
+  .um-contact-kicker {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .um-contact-dialog__rail h2 {
+    max-width: 12ch;
+    margin: 12px 0 0;
+    color: #fff;
+    font-family: var(--um-font-display);
+    font-size: clamp(1.62rem, 2.25vw, 2rem);
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: 0;
+  }
+
+  .um-contact-dialog__rail > p:not(.um-contact-kicker) {
+    max-width: 25ch;
+    margin: 16px 0 0;
+    color: rgba(255, 255, 255, 0.66);
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .um-contact-context {
+    display: grid;
+    gap: 6px;
+    margin-top: auto;
+    padding: 16px 0 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+  }
+
+  .um-contact-context span {
+    color: rgba(255, 255, 255, 0.54);
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .um-contact-context strong {
+    color: #fff;
+    font-size: 1.06rem;
+    font-weight: 700;
+  }
+
+  .um-contact-context p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.64);
+    font-size: 1rem;
+    line-height: 1.4;
+  }
+
+	  .um-contact-dialog__main {
+	    position: relative;
+	    min-height: 0;
+	    overflow-y: auto;
+	    overscroll-behavior: contain;
+	    padding: clamp(20px, 2.5vw, 28px);
+	    scrollbar-gutter: stable;
+	  }
+
+	  .um-contact-close {
+	    position: absolute;
+	    top: 18px;
+	    right: 18px;
+	    z-index: 3;
+	    display: inline-flex;
+	    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #DADDE1;
+    border-radius: 4px;
+    background: #fff;
+    color: #111;
+    cursor: pointer;
+  }
+
+  .um-contact-close:hover,
+  .um-contact-close:focus-visible {
+    border-color: var(--um-red);
+    outline: none;
+  }
+
+  .um-contact-mode {
+    display: inline-flex;
+    max-width: calc(100% - 58px);
+    margin-bottom: 18px;
+    background: #f5f5f5;
+    border: 1px solid #DADDE1;
+  }
+
+  .um-contact-mode button {
+    min-height: 44px;
+    border: 0;
+    border-right: 1px solid #DADDE1;
+    background: transparent;
+    color: #333;
+    cursor: pointer;
+    font: 700 1rem/1 var(--um-font-body);
+    padding: 0 16px;
+  }
+
+  .um-contact-mode button:last-child {
+    border-right: 0;
+  }
+
+  .um-contact-mode button.is-active,
+  .um-contact-mode button:hover,
+  .um-contact-mode button:focus-visible {
+    background: #111;
+    color: #fff;
+    outline: none;
+  }
+
+  .um-contact-form {
+    display: grid;
+    gap: 10px;
+  }
+
+  .um-contact-field-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .um-contact-form label {
+    display: grid;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .um-contact-form label > span {
+    color: #111;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .um-contact-form input,
+  .um-contact-form textarea {
+    width: 100%;
+    border: 0;
+    border-radius: 0;
+    background: #f7f8f9;
+    color: #111;
+    font: 400 1rem/1.5 var(--um-font-body);
+    outline: none;
+    padding: 12px 16px;
+    box-shadow: inset 0 -1px 0 #D6DAE1;
+    transition: background-color 180ms ease, box-shadow 180ms ease;
+  }
+
+  .um-contact-form textarea {
+    min-height: 104px;
+    resize: vertical;
+  }
+
+  .um-contact-form input:focus,
+  .um-contact-form textarea:focus {
+    background: #fff;
+    box-shadow: inset 0 -2px 0 var(--um-red);
+  }
+
+  .um-contact-form input[aria-invalid="true"],
+  .um-contact-form textarea[aria-invalid="true"] {
+    box-shadow: inset 0 -2px 0 var(--um-red);
+  }
+
+	  .um-contact-error {
+	    min-height: 1.35em;
+	    color: var(--um-red);
+	    font-size: 1rem;
+	    line-height: 1.35;
+	  }
+
+	  .um-contact-error:empty {
+	    display: none;
+	    min-height: 0;
+	  }
+
+  .um-contact-guides {
+    display: grid;
+    gap: 12px;
+    padding: 8px 0 2px;
+  }
+
+  .um-contact-guides p {
+    margin: 0;
+    color: #5F6368;
+    font-size: 1rem;
+    line-height: 1.4;
+  }
+
+  .um-contact-guide-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .um-contact-guides button {
+    min-height: 44px;
+    border: 1px solid #DADDE1;
+    border-radius: 4px;
+    background: #f7f8f9;
+    color: #111;
+    cursor: pointer;
+    font: 700 1rem/1.2 var(--um-font-body);
+    padding: 0 14px;
+    text-align: left;
+  }
+
+  .um-contact-guides button:hover,
+  .um-contact-guides button:focus-visible,
+  .um-contact-guides button[aria-pressed="true"] {
+    background: #fff;
+    border-color: var(--um-red);
+    color: var(--um-red);
+    outline: none;
+  }
+
+  .um-contact-guides button[aria-pressed="true"] {
+    box-shadow: inset 3px 0 0 var(--um-red);
+  }
+
+  .um-contact-hp {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    opacity: 0 !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+  }
+
+  .um-contact-submit-row {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 4px;
+  }
+
+  .um-contact-submit-row p {
+    max-width: 240px;
+    margin: 0;
+    color: #5F6368;
+    font-size: 1rem;
+    line-height: 1.45;
+  }
+
+  .um-contact-submit {
+    display: inline-flex;
+    gap: 9px;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+  }
+
+  .um-contact-submit:disabled {
+    cursor: wait;
+    opacity: 0.72;
+  }
+
+  .um-contact-message {
+    border-left: 3px solid currentColor;
+    padding: 14px 16px;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  .um-contact-message--success {
+    background: #F0FDF4;
+    color: #166534;
+  }
+
+	  .um-contact-message--error {
+	    background: #FEF2F2;
+	    color: #111;
+	  }
+
+	  @media (max-height: 760px) and (min-width: 861px) {
+	    .um-contact-modal {
+	      padding: 10px 18px;
+	    }
+
+	    .um-contact-dialog {
+	      width: min(100%, 940px);
+	      height: calc(100dvh - 20px);
+	      max-height: calc(100dvh - 20px);
+	      grid-template-columns: minmax(230px, 0.46fr) minmax(420px, 1fr);
+	    }
+
+	    .um-contact-dialog__rail {
+	      gap: 14px;
+	      padding: 18px 22px;
+	    }
+
+	    .um-contact-kicker {
+	      font-size: 0.9rem;
+	      letter-spacing: 0.07em;
+	    }
+
+	    .um-contact-dialog__rail h2 {
+	      max-width: 13ch;
+	      margin-top: 6px;
+	      font-size: clamp(1.36rem, 1.9vw, 1.72rem);
+	      line-height: 1.06;
+	    }
+
+	    .um-contact-dialog__rail > p:not(.um-contact-kicker) {
+	      margin-top: 8px;
+	      font-size: 0.95rem;
+	      line-height: 1.38;
+	    }
+
+	    .um-contact-context {
+	      gap: 4px;
+	      padding-top: 12px;
+	    }
+
+	    .um-contact-context span,
+	    .um-contact-context strong,
+	    .um-contact-context p {
+	      font-size: 0.92rem;
+	      line-height: 1.3;
+	    }
+
+	    .um-contact-dialog__main {
+	      padding: 16px 24px;
+	    }
+
+	    .um-contact-close {
+	      top: 12px;
+	      right: 12px;
+	      width: 40px;
+	      height: 40px;
+	    }
+
+	    .um-contact-mode {
+	      margin-bottom: 10px;
+	    }
+
+	    .um-contact-mode button {
+	      min-height: 38px;
+	      padding: 0 13px;
+	      font-size: 0.94rem;
+	    }
+
+	    .um-contact-form {
+	      gap: 8px;
+	    }
+
+	    .um-contact-field-grid {
+	      gap: 10px;
+	    }
+
+	    .um-contact-form label {
+	      gap: 5px;
+	    }
+
+	    .um-contact-form label > span {
+	      font-size: 0.94rem;
+	    }
+
+	    .um-contact-form input,
+	    .um-contact-form textarea {
+	      padding: 9px 14px;
+	      font-size: 0.95rem;
+	    }
+
+	    .um-contact-form textarea {
+	      min-height: 78px;
+	      max-height: 96px;
+	    }
+
+	    .um-contact-guides {
+	      gap: 7px;
+	      padding: 2px 0 0;
+	    }
+
+	    .um-contact-guides p {
+	      font-size: 0.92rem;
+	      line-height: 1.25;
+	    }
+
+	    .um-contact-guide-grid {
+	      gap: 7px;
+	    }
+
+	    .um-contact-guides button {
+	      min-height: 36px;
+	      padding: 0 12px;
+	      font-size: 0.92rem;
+	    }
+
+	    .um-contact-submit-row {
+	      gap: 12px;
+	      padding-top: 2px;
+	    }
+
+	    .um-contact-submit-row p {
+	      font-size: 0.9rem;
+	      line-height: 1.32;
+	    }
+
+	    .um-contact-submit {
+	      min-height: 42px;
+	    }
+	  }
+
+	  @media (max-width: 860px) {
+	    .um-contact-modal {
+	      place-items: end center;
+	      padding: 0;
+    }
+
+	    .um-contact-dialog {
+	      grid-template-rows: auto minmax(0, 1fr);
+	      grid-template-columns: 1fr;
+	      width: 100%;
+	      height: calc(100dvh - 10px);
+	      max-height: calc(100dvh - 10px);
+	      border-right: 0;
+	      border-bottom: 0;
+	      border-left: 0;
+    }
+
+	    .um-contact-dialog__rail {
+	      min-height: auto;
+	      gap: 8px;
+	      padding: 13px 18px 12px;
+	    }
+
+	    .um-contact-dialog__rail h2 {
+	      max-width: 100%;
+	      margin-top: 4px;
+	      font-size: clamp(1.18rem, 4.9vw, 1.44rem);
+	      line-height: 1.08;
+	    }
+
+    .um-contact-dialog__rail > p:not(.um-contact-kicker) {
+      display: none;
+    }
+
+	    .um-contact-context {
+	      gap: 3px;
+	      margin-top: 3px;
+	      padding-top: 8px;
+	    }
+
+    .um-contact-context span,
+    .um-contact-context strong {
+      font-size: 1rem;
+      line-height: 1.25;
+    }
+
+    .um-contact-context p {
+      display: none;
+    }
+
+	    .um-contact-dialog__main {
+	      min-height: 0;
+	      padding: 14px 16px 16px;
+	    }
+
+	    .um-contact-mode {
+	      display: grid;
+	      grid-template-columns: repeat(2, minmax(0, 1fr));
+	      width: 100%;
+	      max-width: none;
+	      margin-bottom: 12px;
+	    }
+
+	    .um-contact-mode button {
+	      min-height: 40px;
+	      padding: 0 8px;
+	      font-size: 0.92rem;
+	      line-height: 1.08;
+	    }
+
+	    .um-contact-close {
+	      top: 10px;
+	      right: 10px;
+	      width: 40px;
+	      height: 40px;
+	    }
+
+	    .um-contact-form {
+	      gap: 8px;
+	    }
+
+	    .um-contact-form label {
+	      gap: 5px;
+	    }
+
+	    .um-contact-form input,
+	    .um-contact-form textarea {
+	      padding: 10px 13px;
+	    }
+
+	    .um-contact-form textarea {
+	      min-height: 86px;
+	    }
+
+	    .um-contact-guides {
+	      gap: 8px;
+	      padding-top: 2px;
+	    }
+
+	    .um-contact-guides button {
+	      min-height: 40px;
+	    }
+
+    .um-contact-field-grid,
+    .um-contact-submit-row {
+      grid-template-columns: 1fr;
+    }
+
+    .um-contact-field-grid {
+      display: grid;
+    }
+
+    .um-contact-submit-row {
+      display: grid;
+      justify-items: stretch;
+    }
+
+    .um-contact-submit-row p {
+      max-width: none;
+    }
+
+	    .um-contact-submit {
+	      width: 100%;
+	      min-height: 44px;
+	    }
+
+    .um-contact-guide-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/v4/NavbarV4.astro
+++ b/src/components/v4/NavbarV4.astro
@@ -51,6 +51,8 @@ const isActive = (href: string) => {
         ))}
         <a
           href="/contacto"
+          data-contact-open
+          data-contact-intent="general"
           class="um-nav-cta px-5 py-2.5 rounded-[4px] text-base font-bold"
         >
           Contacto
@@ -88,6 +90,8 @@ const isActive = (href: string) => {
       ))}
       <a
         href="/contacto"
+        data-contact-open
+        data-contact-intent="general"
         class={`um-mobile-cta ${isActive('/contacto') ? 'is-active' : ''}`}
       >
         Contacto

--- a/src/layouts/LayoutV4.astro
+++ b/src/layouts/LayoutV4.astro
@@ -9,6 +9,7 @@
 
 import NavbarV4 from '../components/v4/NavbarV4.astro';
 import FooterV4 from '../components/v4/FooterV4.astro';
+import ContactModal from '../components/um/ContactModal.astro';
 import SEOHead from '../components/SEO/SEOHead.astro';
 import { SITE_URL } from '../config/seo';
 import { hasEnglishAlternate } from '../config/i18nRoutes';
@@ -221,6 +222,7 @@ const shouldEmitHreflang = hasEnglishAlternate(Astro.url.pathname);
       <slot />
     </main>
 
+    <ContactModal />
     <FooterV4 />
   </body>
 </html>

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -2,9 +2,12 @@ import type { APIRoute } from 'astro';
 import nodemailer from 'nodemailer';
 
 const rateLimitMap = new Map<string, number[]>();
+const duplicateMap = new Map<string, number>();
 const RATE_LIMIT_WINDOW = 15 * 60 * 1000;
-const MAX_REQUESTS_PER_WINDOW = 3;
-const MIN_FORM_SECONDS = 4;
+const MAX_REQUESTS_PER_WINDOW = 5;
+const DUPLICATE_WINDOW = 2 * 60 * 1000;
+const MIN_FORM_SECONDS = 2.5;
+const MAX_FORM_AGE_MS = 2 * 60 * 60 * 1000;
 const MESSAGE_MIN_LENGTH = 12;
 const MESSAGE_MAX_LENGTH = 2400;
 const MAX_LINKS = 2;
@@ -72,7 +75,7 @@ function countLinks(message: string): number {
   return (message.match(/https?:\/\/|www\.|\.com\b|\.ar\b/gi) || []).length;
 }
 
-function isTooFast(startedAt: unknown): boolean {
+function isInvalidFormTiming(startedAt: unknown): boolean {
   if (!startedAt) {
     return false;
   }
@@ -82,7 +85,8 @@ function isTooFast(startedAt: unknown): boolean {
     return true;
   }
 
-  return Date.now() - startedAtMs < MIN_FORM_SECONDS * 1000;
+  const age = Date.now() - startedAtMs;
+  return age < MIN_FORM_SECONDS * 1000 || age > MAX_FORM_AGE_MS;
 }
 
 function isSpam(data: Record<string, unknown>): boolean {
@@ -136,8 +140,32 @@ function checkRateLimit(ip: string): boolean {
   return true;
 }
 
+function isDuplicateSubmission(ip: string, email: string, message: string): boolean {
+  const now = Date.now();
+  const normalized = `${ip}|${email}|${message.toLowerCase().replace(/\s+/g, ' ').slice(0, 260)}`;
+
+  for (const [key, timestamp] of duplicateMap.entries()) {
+    if (now - timestamp > DUPLICATE_WINDOW) {
+      duplicateMap.delete(key);
+    }
+  }
+
+  const previous = duplicateMap.get(normalized);
+  duplicateMap.set(normalized, now);
+
+  return Boolean(previous && now - previous < DUPLICATE_WINDOW);
+}
+
 function hasHoneypot(data: Record<string, unknown>): boolean {
-  return trimString(data.website, 500).length > 0;
+  return trimString(data.website, 500).length > 0 || trimString(data.contact_phone, 500).length > 0;
+}
+
+function hasInvalidModalProof(data: Record<string, unknown>): boolean {
+  const formVariant = trimString(data.formVariant, 40);
+  if (formVariant !== 'modal') return false;
+
+  const proof = trimString(data.contactProof, 180);
+  return !/^\d{12,}:\d{1,8}(?::[a-z]{2}(?:-[A-Z]{2})?)?$/i.test(proof);
 }
 
 function buildEmailHtml(data: {
@@ -145,6 +173,12 @@ function buildEmailHtml(data: {
   email: string;
   company: string;
   message: string;
+  formVariant: string;
+  originPath: string;
+  originTitle: string;
+  originLabel: string;
+  originIntent: string;
+  originHref: string;
   timestamp: string;
   ip: string;
 }) {
@@ -155,6 +189,20 @@ function buildEmailHtml(data: {
         <td style="padding:14px 16px;border-top:1px solid #E5E7EB;color:#111827;font-size:16px;font-weight:700;">${escapeHtml(data.company)}</td>
       </tr>`
     : '';
+  const contextRows = [
+    ['Origen', data.originTitle],
+    ['Ruta', data.originPath],
+    ['CTA', data.originLabel],
+    ['Intención', data.originIntent],
+    ['URL', data.originHref],
+  ]
+    .filter(([, value]) => value)
+    .map(([label, value]) => `
+      <tr>
+        <td style="padding:12px 16px;border-top:1px solid #E5E7EB;color:#6B7280;font-size:16px;">${escapeHtml(label)}</td>
+        <td style="padding:12px 16px;border-top:1px solid #E5E7EB;color:#111827;font-size:16px;font-weight:700;">${escapeHtml(value)}</td>
+      </tr>`)
+    .join('');
 
   return `
     <div style="font-family:Arial,sans-serif;max-width:680px;margin:0 auto;background:#FFFFFF;color:#111827;border:1px solid #E5E7EB;">
@@ -177,6 +225,12 @@ function buildEmailHtml(data: {
         ${companyRow}
       </table>
 
+      ${contextRows ? `
+      <div style="padding:20px 30px 0;border-top:1px solid #E5E7EB;">
+        <p style="margin:0 0 10px;color:#6B7280;font-size:16px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;">Contexto de origen</p>
+        <table style="width:100%;border-collapse:collapse;">${contextRows}</table>
+      </div>` : ''}
+
       <div style="padding:24px 30px;border-top:1px solid #E5E7EB;">
         <p style="margin:0 0 10px;color:#6B7280;font-size:16px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;">Mensaje</p>
         <div style="white-space:pre-wrap;color:#111827;font-size:17px;line-height:1.65;">${escapeHtml(data.message)}</div>
@@ -186,7 +240,7 @@ function buildEmailHtml(data: {
         <strong style="color:#111827;">Datos técnicos</strong><br>
         Fecha: ${escapeHtml(data.timestamp)}<br>
         IP: ${escapeHtml(data.ip)}<br>
-        Formulario: contacto simplificado White Dossier
+        Formulario: ${escapeHtml(data.formVariant || 'contacto simplificado White Dossier')}
       </div>
     </div>
   `;
@@ -223,10 +277,17 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       });
     }
 
-    if (isTooFast(data.startedAt)) {
+    if (isInvalidFormTiming(data.startedAt)) {
       return jsonResponse({
         success: false,
-        message: 'El formulario fue enviado demasiado rápido. Intenta nuevamente.'
+        message: 'El formulario no pudo validarse. Intenta nuevamente.'
+      }, 400);
+    }
+
+    if (hasInvalidModalProof(data)) {
+      return jsonResponse({
+        success: false,
+        message: 'No se pudo validar el formulario. Recarga la página e intenta nuevamente.'
       }, 400);
     }
 
@@ -235,6 +296,12 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     const email = trimString(data.email, 120).toLowerCase();
     const company = trimString(data.company, 120);
     const message = rawMessage.slice(0, MESSAGE_MAX_LENGTH);
+    const formVariant = trimString(data.formVariant, 40);
+    const originPath = trimString(data.originPath, 180);
+    const originTitle = trimString(data.originTitle, 180);
+    const originLabel = trimString(data.originLabel, 120);
+    const originIntent = trimString(data.originIntent, 80);
+    const originHref = trimString(data.originHref, 240);
 
     if (!name || !email || !message) {
       return jsonResponse({
@@ -264,11 +331,24 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       }, 400);
     }
 
+    if (isDuplicateSubmission(clientIP, email, message)) {
+      return jsonResponse({
+        success: true,
+        message: 'Mensaje recibido.'
+      });
+    }
+
     const sanitizedData = {
       name,
       email,
       company,
       message,
+      formVariant,
+      originPath,
+      originTitle,
+      originLabel,
+      originIntent,
+      originHref,
       timestamp: new Date().toISOString(),
       ip: clientIP
     };
@@ -279,7 +359,7 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       from: `"ULTIMA MILLA web" <${fromAddress}>`,
       to: 'martin@ultimamilla.com.ar',
       replyTo: sanitizedData.email,
-      subject: `Consulta web UMSA: ${sanitizedData.company || sanitizedData.name}`,
+      subject: `Consulta web UMSA: ${sanitizedData.originIntent || sanitizedData.company || sanitizedData.name}`,
       html: buildEmailHtml(sanitizedData),
     });
 


### PR DESCRIPTION
## Summary\n- Add a global contextual contact modal opened from existing /contacto CTAs while preserving the /contacto fallback page.\n- Keep the visible form to four fields and send page/intent context invisibly.\n- Harden the contact API with modal proof, honeypot, timing, duplicate suppression, and contextual email metadata.\n- Add a Chrome CDP QA script covering desktop, compact desktop, mobile, and short mobile scroll behavior.\n\n## Verification\n- npm run typecheck\n- npm run audit:css\n- npm test -- --runInBand contactModalContract\n- node scripts/contact-modal-qa.mjs\n- npm test -- --runInBand\n- npm run lint (0 errors, existing warnings)\n- npm run build