### PR TITLE
fix: suppress duplicate contact submissions

### DIFF
--- a/__tests__/contactModalContract.test.js
+++ b/__tests__/contactModalContract.test.js
@@ -47,6 +47,8 @@ describe('global contact modal contract', () => {
 
     expect(api).toContain('const duplicateMap = new Map<string, number>();');
     expect(api).toContain('hasInvalidModalProof(data)');
+    expect(api).toContain('function isDuplicateSubmission(email: string, message: string): boolean');
+    expect(api).not.toContain('isDuplicateSubmission(clientIP');
     expect(api).toContain('trimString(data.originPath');
     expect(api).toContain('Contexto de origen');
     expect(api).toContain('trimString(data.contact_phone');

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -140,9 +140,9 @@ function checkRateLimit(ip: string): boolean {
   return true;
 }
 
-function isDuplicateSubmission(ip: string, email: string, message: string): boolean {
+function isDuplicateSubmission(email: string, message: string): boolean {
   const now = Date.now();
-  const normalized = `${ip}|${email}|${message.toLowerCase().replace(/\s+/g, ' ').slice(0, 260)}`;
+  const normalized = `${email}|${message.toLowerCase().replace(/\s+/g, ' ').slice(0, 260)}`;
 
   for (const [key, timestamp] of duplicateMap.entries()) {
     if (now - timestamp > DUPLICATE_WINDOW) {
@@ -331,7 +331,7 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       }, 400);
     }
 
-    if (isDuplicateSubmission(clientIP, email, message)) {
+    if (isDuplicateSubmission(email, message)) {
       return jsonResponse({
         success: true,
         message: 'Mensaje recibido.'


### PR DESCRIPTION
## Summary\n- Make duplicate contact suppression independent from client IP so Cloudflare/proxy IP variation cannot bypass it.\n- Add a contract assertion to keep duplicate suppression keyed by email + normalized message.\n\n## Verification\n- npm run typecheck\n- npm test -- --runInBand contactModalContract runtimeConfigContracts\n- npm run build