### PR TITLE
deploy: antecedentes seo directus

### DIFF
--- a/__tests__/antecedentesCuration.test.ts
+++ b/__tests__/antecedentesCuration.test.ts
@@ -1,0 +1,70 @@
+import antecedentesSnapshot from '../src/data/snapshots/antecedentes.json';
+import {
+  curateAntecedente,
+  formatAntecedenteYear,
+  isPromotableAntecedente,
+  sortAntecedentesForPublicList,
+} from '../src/utils/antecedentesCuration';
+import { buildGeoCaseResourcesFromAntecedentes, buildGeoCasesResource } from '../src/data/geoResources';
+
+const antecedentes = (antecedentesSnapshot as { data: Array<Record<string, any>> }).data;
+const byId = (id: number) => antecedentes.find((item) => Number(item.id) === id) as Record<string, any>;
+
+describe('antecedentes curation', () => {
+  test('curates the complete published antecedentes snapshot without dropping records', () => {
+    const curated = antecedentes.map((item) => curateAntecedente(item));
+
+    expect(curated).toHaveLength(518);
+    expect(curated.every((item) => item.displayTitle.length > 0)).toBe(true);
+    expect(curated.every((item) => item.displayDescription.length > 0)).toBe(true);
+    expect(curated.every((item) => item.canonicalPath.startsWith(`/antecedentes/${item.id}/`))).toBe(true);
+  });
+
+  test('keeps strategic cases promotable and demotes low-value supply records', () => {
+    const softwareGobierno = curateAntecedente(byId(3064));
+    const pcMonitor = curateAntecedente(byId(3623));
+    const discoDuro = curateAntecedente(byId(3591));
+
+    expect(softwareGobierno.curation.quality).toBe('strong-case');
+    expect(isPromotableAntecedente(softwareGobierno)).toBe(true);
+    expect(pcMonitor.curation.quality).toBe('low-value-candidate');
+    expect(discoDuro.curation.quality).toBe('low-value-candidate');
+    expect(isPromotableAntecedente(pcMonitor)).toBe(false);
+  });
+
+  test('flags real data errors and only applies deterministic spelling cleanup for display', () => {
+    const remplazo = curateAntecedente(byId(3087));
+    const universidad = curateAntecedente(byId(3484));
+    const camaras = curateAntecedente(byId(3578));
+
+    expect(remplazo.curation.quality).toBe('data-error-candidate');
+    expect(remplazo.curation.issues).toContain('typo:remplazo');
+    expect(remplazo.displayTitle).toContain('Reemplazo');
+    expect(universidad.curation.issues).toContain('typo:univercidad');
+    expect(universidad.displayTitle).toContain('Universidad del Aconcagua');
+    expect(camaras.curation.issues).toContain('typo:cpamaras');
+    expect(camaras.displayTitle).toContain('cámaras');
+  });
+
+  test('public ordering starts with promotable cases and never renders Invalid Date as a year', () => {
+    const sorted = sortAntecedentesForPublicList(antecedentes);
+
+    expect(sorted.slice(0, 12).every((item) => item.curation.quality === 'strong-case')).toBe(true);
+    expect(formatAntecedenteYear('Invalid Date')).toBe('documentado');
+    expect(formatAntecedenteYear('')).toBe('documentado');
+  });
+
+  test('GEO cases prefer curated strong evidence over weak inventory records', () => {
+    const payload = buildGeoCasesResource(buildGeoCaseResourcesFromAntecedentes(antecedentes as any)) as {
+      cases: Array<{ id: number; quality: string; title: string; client: string | null }>;
+    };
+
+    const ids = new Set(payload.cases.map((item) => Number(item.id)));
+
+    expect(payload.cases.length).toBeGreaterThanOrEqual(100);
+    expect(ids.has(3064)).toBe(true);
+    expect(ids.has(3623)).toBe(false);
+    expect(ids.has(3591)).toBe(false);
+    expect(payload.cases.every((item) => item.title && item.quality !== 'low-value-candidate')).toBe(true);
+  });
+});

--- a/__tests__/geoDiscoveryContracts.test.ts
+++ b/__tests__/geoDiscoveryContracts.test.ts
@@ -146,6 +146,18 @@ describe('GEO discovery and commercial hub contracts', () => {
     }
   });
 
+  test('common antecedentes typo redirects to the canonical evidence archive', () => {
+    const typoRedirect = fs.readFileSync(path.join(repoRoot, 'src/pages/antecedntes.astro'), 'utf8');
+    const detail = fs.readFileSync(path.join(repoRoot, 'src/pages/antecedentes/[id]/[slug].astro'), 'utf8');
+    const directusLib = fs.readFileSync(path.join(repoRoot, 'src/lib/directus.ts'), 'utf8');
+
+    expect(typoRedirect).toContain("Astro.redirect('/antecedentes', 301)");
+    expect(detail).toContain('getAntecedenteConServicios');
+    expect(detail).not.toContain('loadAntecedenteFromSnapshot');
+    expect(directusLib).not.toContain("import('../data/snapshots/antecedentes.json')");
+    expect(directusLib).toContain('Token rechazado');
+  });
+
   test('the GEO index and strategic graph link only published machine-readable resources', () => {
     const geoIndex = fs.readFileSync(path.join(repoRoot, 'src/pages/geo/index.astro'), 'utf8');
     const strategicGraph = fs.readFileSync(path.join(repoRoot, 'src/data/strategicLinkGraph.ts'), 'utf8');
@@ -165,11 +177,18 @@ describe('GEO discovery and commercial hub contracts', () => {
     const imageSitemap = fs.readFileSync(path.join(repoRoot, 'src/pages/sitemap-images.xml.ts'), 'utf8');
     const antecedentesSitemap = fs.readFileSync(path.join(repoRoot, 'src/pages/sitemap-antecedentes.xml.ts'), 'utf8');
     const blogSitemap = fs.readFileSync(path.join(repoRoot, 'src/pages/sitemap-blog.xml.ts'), 'utf8');
+    const casesGeo = fs.readFileSync(path.join(repoRoot, 'src/pages/geo/cases.json.ts'), 'utf8');
+    const imageEvidenceGeo = fs.readFileSync(path.join(repoRoot, 'src/pages/geo/image-evidence.json.ts'), 'utf8');
 
     expect(sitemapIndex).toContain('/sitemap-images.xml');
     expect(robots).toContain('/sitemap-images.xml');
     expect(imageSitemap).toContain('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"');
     expect(imageSitemap).toContain('<image:loc>');
+    expect(imageSitemap).toContain('getAntecedentesImageEvidenceEntriesFromDirectus');
+    expect(antecedentesSitemap).toContain('getAllAntecedentes');
+    expect(antecedentesSitemap).not.toContain('snapshots/antecedentes');
+    expect(casesGeo).toContain("buildGeoResourceAsync('cases')");
+    expect(imageEvidenceGeo).toContain("buildGeoResourceAsync('image-evidence')");
     expect(imageSitemap).not.toContain('<image:title>');
     expect(antecedentesSitemap).not.toContain('<image:title>');
     expect(blogSitemap).not.toContain('<image:title>');

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -56,9 +56,9 @@ describe('Production runtime configuration contracts', () => {
     const fn = source.match(/export function getDirectusToken\(\): string \{([\s\S]*?)\n\}/)?.[1] || '';
 
     expect(fn).toContain("processEnv('DIRECTUS_ADMIN_TOKEN')");
-    expect(fn.indexOf("processEnv('DIRECTUS_STATIC_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_STATIC_TOKEN'));
-    expect(fn.indexOf("processEnv('PUBLIC_DIRECTUS_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.PUBLIC_DIRECTUS_TOKEN'));
-    expect(fn.indexOf("processEnv('DIRECTUS_ADMIN_TOKEN')")).toBeLessThan(fn.indexOf('import.meta.env?.DIRECTUS_ADMIN_TOKEN'));
+    expect(fn.indexOf("processEnv('DIRECTUS_STATIC_TOKEN')")).toBeLessThan(fn.indexOf("import.meta.env?.['DIRECTUS_STATIC_TOKEN']"));
+    expect(fn.indexOf("processEnv('PUBLIC_DIRECTUS_TOKEN')")).toBeLessThan(fn.indexOf("import.meta.env?.['PUBLIC_DIRECTUS_TOKEN']"));
+    expect(fn.indexOf("processEnv('DIRECTUS_ADMIN_TOKEN')")).toBeLessThan(fn.indexOf("import.meta.env?.['DIRECTUS_ADMIN_TOKEN']"));
   });
 
   test('production smoke test validates current theme content and Directus-backed collections', () => {

--- a/src/components/templates/AntecedentesTemplateEditorial.astro
+++ b/src/components/templates/AntecedentesTemplateEditorial.astro
@@ -4,7 +4,6 @@ import SectionHeader from '../um/SectionHeader.astro';
 import { truncateEditorialText } from '../../utils/editorialContent';
 import { resolveReplicaH1 } from '../../utils/replicaProdCopy';
 import { extractCaseMetricsFromAntecedente } from '../../utils/caseMetrics';
-import { getAntecedentesCatalogCount, getAntecedentesCountShort } from '../../utils/verifiedProof';
 
 const antecedentesPath = `${Astro.url.pathname}${Astro.url.search}`;
 const antecedentesIndexH1 = resolveReplicaH1(antecedentesPath, 'Evidencia operativa documentada.');
@@ -36,8 +35,10 @@ const spotlight = pageData.spotlightAntecedentes || [];
 const archive = pageData.antecedentes || [];
 const totalItems = pageData.totalItems || 0;
 const archiveTotalItems = pageData.archiveTotalItems ?? Math.max(0, totalItems - spotlight.length);
-const institutionalProofTotal = getAntecedentesCatalogCount();
-const institutionalProofShort = getAntecedentesCountShort();
+const institutionalProofTotal = Number(pageData.catalogTotalItems || totalItems || 0);
+const institutionalProofShort = institutionalProofTotal >= 500
+  ? `${Math.floor(institutionalProofTotal / 100) * 100}+`
+  : String(institutionalProofTotal);
 const totalPages = Math.max(1, pageData.totalPages || 1);
 const currentPage = pageData.currentPage || 1;
 const feature = featuredAntecedente || spotlight[0];
@@ -84,13 +85,18 @@ const paginationPages = computePaginationPages();
 const cleanText = (value: unknown) => String(value || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
 const truncate = (value: unknown, length = 170) => truncateEditorialText(value, length);
 const projectHref = (item: any) => `/antecedentes/${item.slug}`;
-const projectTitle = (item: any) => item?.Cliente || item?.Titulo || 'Antecedente UMSA';
+const projectTitle = (item: any) => item?.displayTitle || item?.Titulo || item?.Cliente || 'Antecedente UMSA';
+const projectDescription = (item: any) => item?.displayDescription || item?.Descripcion || item?.Titulo || '';
 const projectScope = (item: any) => item?.Area || item?.Unidad_de_negocio || 'Servicios IT';
 const projectYear = (item: any) => {
+  if (item?.displayYear && item.displayYear !== 'Invalid Date') return item.displayYear;
   const raw = item?.Fecha || item?.fecha || item?.anio || item?.year;
   if (!raw) return 'documentado';
+  if (/invalid date/i.test(String(raw))) return 'documentado';
   const date = new Date(raw);
-  return Number.isNaN(date.getTime()) ? String(raw) : String(date.getFullYear());
+  if (!Number.isNaN(date.getTime())) return String(date.getFullYear());
+  const year = String(raw).match(/\b(19\d{2}|20\d{2})\b/)?.[1];
+  return year || 'documentado';
 };
 ---
 
@@ -194,15 +200,15 @@ const projectYear = (item: any) => {
             <div class="ante-dossier__feature-body">
               <span>Proyecto protagonista</span>
               <h3>{projectTitle(feature)}</h3>
-              <p>{truncate(feature.Descripcion || feature.Titulo, 210)}</p>
+              <p>{truncate(projectDescription(feature), 210)}</p>
               <dl>
                 <div>
                   <dt>Sector</dt>
                   <dd>{projectScope(feature)}</dd>
                 </div>
                 <div>
-                  <dt>Ubicación / cliente</dt>
-                  <dd>{feature.Cliente || 'UMSA'}</dd>
+                  <dt>Cliente</dt>
+                  <dd>{feature.Cliente || `ANT-${feature.id}`}</dd>
                 </div>
                 <div>
                   <dt>Año</dt>
@@ -224,7 +230,7 @@ const projectYear = (item: any) => {
                 <div>
                   <span>{String(index + 2).padStart(2, '0')}</span>
                   <h3>{projectTitle(item)}</h3>
-                  <p>{truncate(item.Descripcion || item.Titulo, 128)}</p>
+                  <p>{truncate(projectDescription(item), 128)}</p>
                   <dl>
                     <div>
                       <dt>Sector</dt>
@@ -263,7 +269,7 @@ const projectYear = (item: any) => {
             href={projectHref(item)}
             number={String(showingStart + index).padStart(2, '0')}
             title={projectTitle(item)}
-            description={truncate(item.Descripcion || item.Titulo, 150)}
+            description={truncate(projectDescription(item), 150)}
             image={item.imageUrl}
             imageAlt={item.Titulo || projectTitle(item)}
             sector={projectScope(item)}

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -15,14 +15,14 @@ function envFlag(value: string | boolean | undefined): boolean {
 /** Localhost debe comportarse como producción (hybrid, datos CMS, sin mocks de lab). */
 export function isLocalProdReplica(): boolean {
   const fromProcess = processEnv('UMSA_LOCAL_REPLICA');
-  const fromImport = import.meta.env?.UMSA_LOCAL_REPLICA;
+  const fromImport = import.meta.env?.['UMSA_LOCAL_REPLICA'];
   return envFlag(fromImport) || envFlag(fromProcess);
 }
 
 export function getDirectusInternalUrl(): string {
   const fromProcess = processEnv('DIRECTUS_INTERNAL_URL');
-  const fromImport = import.meta.env?.DIRECTUS_INTERNAL_URL;
-  const publicUrl = processEnv('PUBLIC_DIRECTUS_URL') || import.meta.env?.PUBLIC_DIRECTUS_URL;
+  const fromImport = import.meta.env?.['DIRECTUS_INTERNAL_URL'];
+  const publicUrl = processEnv('PUBLIC_DIRECTUS_URL') || import.meta.env?.['PUBLIC_DIRECTUS_URL'];
   return fromProcess || fromImport || publicUrl || 'http://localhost:8055';
 }
 
@@ -31,22 +31,22 @@ export function getDirectusToken(): string {
     processEnv('DIRECTUS_STATIC_TOKEN') ||
     processEnv('PUBLIC_DIRECTUS_TOKEN') ||
     processEnv('DIRECTUS_ADMIN_TOKEN') ||
-    import.meta.env?.DIRECTUS_STATIC_TOKEN ||
-    import.meta.env?.PUBLIC_DIRECTUS_TOKEN ||
-    import.meta.env?.DIRECTUS_ADMIN_TOKEN ||
+    import.meta.env?.['DIRECTUS_STATIC_TOKEN'] ||
+    import.meta.env?.['PUBLIC_DIRECTUS_TOKEN'] ||
+    import.meta.env?.['DIRECTUS_ADMIN_TOKEN'] ||
     '';
 
   if (token) return token;
 
   if (isLocalProdReplica()) {
     console.warn(
-      '[runtime] UMSA_LOCAL_REPLICA=1 sin token Directus: solo snapshots JSON (ejecutá npm run replica:sync con túnel SSH).',
+      '[runtime] UMSA_LOCAL_REPLICA=1 sin token Directus: se intentarán lecturas públicas del CMS.',
     );
     return '';
   }
 
   if (import.meta.env?.DEV) {
-    console.warn('[runtime] Directus token ausente: se usarán snapshots o respuestas vacías según ruta.');
+    console.warn('[runtime] Directus token ausente: se intentarán lecturas públicas del CMS.');
   }
   return '';
 }
@@ -54,7 +54,7 @@ export function getDirectusToken(): string {
 /** URL pública para canonical/OG: prod real en réplica, localhost en dev normal. */
 export function getPublicSiteUrl(): string {
   if (isLocalProdReplica()) return SITE_URL;
-  return processEnv('PUBLIC_SITE_URL') || import.meta.env?.PUBLIC_SITE_URL || 'http://localhost:4321';
+  return processEnv('PUBLIC_SITE_URL') || import.meta.env?.['PUBLIC_SITE_URL'] || 'http://localhost:4321';
 }
 
 /** Blog: en réplica, fallback a HTML de producción (no mock estático). */

--- a/src/data/geoResources.ts
+++ b/src/data/geoResources.ts
@@ -1,15 +1,20 @@
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '../config/seo';
 import { generateSlug } from '../utils/slugUtils.js';
 import { canonicalUrl } from '../utils/seoUrl';
+import {
+  curateAntecedente,
+  isPromotableAntecedente,
+  sortAntecedentesForPublicList,
+} from '../utils/antecedentesCuration';
 import { geoCommercialHubs } from './geoCommercialHubs';
 import { sectorVisualOrder, sectorVisualSystem } from './sectorVisualSystem';
 import { serviceVisualOrder, serviceVisualSystem } from './serviceVisualSystem';
-import antecedentesSnapshot from './snapshots/antecedentes.json';
 import serviciosSnapshot from './snapshots/servicios.json';
 import { getInstitutionalProofLines } from '../utils/verifiedProof';
 import {
   getAntecedentesImageEvidenceCoverage,
   getAntecedentesImageEvidenceEntries,
+  getAntecedentesImageEvidenceDatasetFromDirectus,
 } from '../utils/antecedentesImageEvidence';
 
 type Snapshot<T> = { data?: T[] } | T[];
@@ -21,7 +26,7 @@ interface SnapshotService {
   slug?: string;
 }
 
-interface SnapshotCase {
+interface GeoCaseInput {
   id: number;
   Titulo: string;
   Descripcion?: string;
@@ -92,26 +97,85 @@ const prioritizedCaseIds = new Set<number>(
     .filter(Boolean)
 );
 
-export const geoCaseResources = snapshotData<SnapshotCase>(antecedentesSnapshot as Snapshot<SnapshotCase>)
-  .filter((item, index) => prioritizedCaseIds.has(item.id) || index < 64)
-  .map((item) => ({
+export function buildGeoCaseResourcesFromAntecedentes(items: GeoCaseInput[]) {
+  return sortAntecedentesForPublicList(items.map((item) => curateAntecedente(item)))
+    .filter((item) => prioritizedCaseIds.has(item.id) || isPromotableAntecedente(item))
+    .map((item) => ({
     id: item.id,
-    title: item.Titulo,
-    client: item.Cliente || 'Cliente institucional',
+    title: item.displayTitle,
+    client: item.Cliente || null,
     sector: item.Area || 'Servicios IT',
-    url: canonicalUrl(`/antecedentes/${item.id}/${generateSlug(item.Titulo)}`),
-    summary: item.Descripcion || '',
+    url: canonicalUrl(item.canonicalPath || `/antecedentes/${item.id}/${generateSlug(item.Titulo)}`),
+    summary: item.displayDescription || '',
     date: item.Fecha || null,
+    quality: item.curation.quality,
+    issues: item.curation.issues,
     priority: prioritizedCaseIds.has(item.id) ? 'high' : 'supporting',
-  }));
+    }));
+}
 
-export function buildGeoResource(resource: string) {
-  const common = {
+export async function getGeoCaseResources() {
+  const { getAllAntecedentes } = await import('../lib/directus');
+  const antecedentes = await getAllAntecedentes();
+  return buildGeoCaseResourcesFromAntecedentes(antecedentes as GeoCaseInput[]);
+}
+
+export const geoCaseResources: ReturnType<typeof buildGeoCaseResourcesFromAntecedentes> = [];
+
+function buildCommonGeoResource() {
+  return {
     version: geoVersion,
     canonicalDomain: SITE_URL,
     language: 'es-AR',
     brand: SITE_NAME,
   };
+}
+
+export function buildGeoCasesResource(cases: ReturnType<typeof buildGeoCaseResourcesFromAntecedentes>) {
+  return { ...buildCommonGeoResource(), cases };
+}
+
+export function buildGeoImageEvidenceResource(
+  entries: ReturnType<typeof getAntecedentesImageEvidenceEntries>,
+  coverage: ReturnType<typeof getAntecedentesImageEvidenceCoverage>,
+) {
+  return {
+    ...buildCommonGeoResource(),
+    role: 'Mapa verificable de imagenes generadas, aprobadas y asociadas a antecedentes publicos.',
+    policy: [
+      'No inventar nombres de clientes, ubicaciones ni resultados a partir de la imagen.',
+      'Usar pageUrl como fuente canonica del antecedente y imageUrl como evidencia visual asociada.',
+      'Si un campo aparece como null, tratarlo como no publicado.',
+    ],
+    coverage,
+    sitemap: canonicalUrl('/sitemap-images.xml'),
+    images: entries.map((entry) => ({
+      id: entry.id,
+      title: entry.title,
+      pageUrl: entry.pageUrl,
+      imageUrl: entry.imageUrl,
+      client: entry.client,
+      sector: entry.sector,
+      date: entry.date,
+    })),
+  };
+}
+
+export async function buildGeoResourceAsync(resource: string) {
+  if (resource === 'cases') {
+    return buildGeoCasesResource(await getGeoCaseResources());
+  }
+
+  if (resource === 'image-evidence') {
+    const imageEvidence = await getAntecedentesImageEvidenceDatasetFromDirectus();
+    return buildGeoImageEvidenceResource(imageEvidence.entries, imageEvidence.coverage);
+  }
+
+  return buildGeoResource(resource);
+}
+
+export function buildGeoResource(resource: string) {
+  const common = buildCommonGeoResource();
 
   switch (resource) {
     case 'brand-facts':
@@ -135,31 +199,12 @@ export function buildGeoResource(resource: string) {
       return { ...common, sectors: geoSectorResources };
 
     case 'cases':
-      return { ...common, cases: geoCaseResources };
+      return buildGeoCasesResource(geoCaseResources);
 
     case 'image-evidence': {
       const imageEvidence = getAntecedentesImageEvidenceEntries();
 
-      return {
-        ...common,
-        role: 'Mapa verificable de imagenes generadas, aprobadas y asociadas a antecedentes publicos.',
-        policy: [
-          'No inventar nombres de clientes, ubicaciones ni resultados a partir de la imagen.',
-          'Usar pageUrl como fuente canonica del antecedente y imageUrl como evidencia visual asociada.',
-          'Si un campo aparece como null, tratarlo como no publicado.',
-        ],
-        coverage: getAntecedentesImageEvidenceCoverage(),
-        sitemap: canonicalUrl('/sitemap-images.xml'),
-        images: imageEvidence.map((entry) => ({
-          id: entry.id,
-          title: entry.title,
-          pageUrl: entry.pageUrl,
-          imageUrl: entry.imageUrl,
-          client: entry.client,
-          sector: entry.sector,
-          date: entry.date,
-        })),
-      };
+      return buildGeoImageEvidenceResource(imageEvidence, getAntecedentesImageEvidenceCoverage());
     }
 
     case 'faqs':

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -7,6 +7,9 @@ import type {
 } from '../types/directus-v4';
 import { getDirectusInternalUrl, getDirectusToken, isLocalProdReplica } from '../config/runtime';
 
+const readItemsAny = readItems as any;
+const readItemAny = readItem as any;
+
 // SSR: misma máquina que Directus (prod :8055, réplica local vía túnel o localhost)
 export const DIRECTUS_CONFIG = {
   url: getDirectusInternalUrl(),
@@ -30,7 +33,7 @@ if (!DIRECTUS_CONFIG.url) {
 }
 
 if (!DIRECTUS_CONFIG.token && !isLocalProdReplica()) {
-  throw new Error('Configuración de Directus incompleta: falta PUBLIC_DIRECTUS_TOKEN o DIRECTUS_STATIC_TOKEN');
+  console.warn('[directus] Token ausente: se intentará lectura pública del CMS sin snapshots.');
 }
 
 // Exportar cliente con tipos para casos específicos
@@ -43,6 +46,51 @@ export const getClient = () => {
 
   return client.with(rest());
 };
+
+type DirectusJsonOptions = {
+  allowMissing?: boolean;
+};
+
+function getDirectusFetchHeaders(includeToken = true): Record<string, string> {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (includeToken && DIRECTUS_CONFIG.token) {
+    headers['Authorization'] = `Bearer ${DIRECTUS_CONFIG.token}`;
+  }
+  return headers;
+}
+
+async function requestDirectusJson<T>(
+  path: string,
+  options: DirectusJsonOptions = {},
+  includeToken = true,
+): Promise<T | null> {
+  const baseUrl = DIRECTUS_CONFIG.url.replace(/\/$/, '');
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: getDirectusFetchHeaders(includeToken),
+  });
+
+  if ((response.status === 401 || response.status === 403) && includeToken && DIRECTUS_CONFIG.token) {
+    console.warn(`[directus] Token rechazado para ${path}; reintentando lectura pública.`);
+    return requestDirectusJson<T>(path, options, false);
+  }
+
+  if (response.status === 404 && options.allowMissing) return null;
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`[directus] ${path} respondió ${response.status}: ${body.slice(0, 280)}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function directusDataArray<T>(payload: { data?: T[] } | null): T[] {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+function directusDataItem<T>(payload: { data?: T } | null): T | null {
+  return payload?.data || null;
+}
 
 async function loadSnapshotData<T>(fileName: string): Promise<T[]> {
   const snapshot = await import(`../data/snapshots/${fileName}.json`);
@@ -121,6 +169,25 @@ type ArchivoDirectus = {
   alto?: number;
 };
 
+async function obtenerContenidoPublicado<T = unknown>(
+  coleccion: keyof Colecciones,
+  options: { limite?: number } = {},
+): Promise<T[]> {
+  try {
+    const client = getClient() as any;
+    const response = await client.request(
+      readItemsAny(coleccion, {
+        limit: options.limite ?? 10,
+        fields: ['*'],
+      }),
+    );
+    return (response || []) as T[];
+  } catch (error) {
+    console.error(`[directus] Error fetching ${String(coleccion)}:`, error);
+    return [];
+  }
+}
+
 // 6. Funciones específicas para cada colección (LEGACY - mantener por compatibilidad)
 export const getServicios = async (limite: number = 10) =>
   obtenerContenidoPublicado('servicios', { limite });
@@ -144,7 +211,7 @@ export async function getServiciosV4(): Promise<ServicioV4[]> {
   try {
     const client = getClient();
     const response = await client.request(
-      readItems('Servicios', {
+      readItemsAny('Servicios', {
         fields: [
           'id',
           'Titulo',
@@ -161,7 +228,7 @@ export async function getServiciosV4(): Promise<ServicioV4[]> {
       })
     );
 
-    const list = (response || []) as ServicioV4[];
+    const list = (response || []) as unknown as ServicioV4[];
     if (list.length > 0) return list;
 
     console.warn('[directus] Servicios vacíos desde API, usando snapshot');
@@ -188,7 +255,7 @@ export async function getServicioConProductos(id: number | string): Promise<Serv
 
     // Query 1: Obtener servicio
     const servicio = await client.request(
-      readItem('Servicios', id, {
+      readItemAny('Servicios', id, {
         fields: [
           'id',
           'Titulo',
@@ -257,7 +324,7 @@ export async function getProductoComercialBySlug(slug: string): Promise<Producto
   try {
     const client = getClient();
     const response = await client.request(
-      readItems('productos', {
+      readItemsAny('productos', {
         filter: {
           slug_producto: { _eq: slug }
         },
@@ -266,7 +333,7 @@ export async function getProductoComercialBySlug(slug: string): Promise<Producto
       })
     );
 
-    const [producto] = (response || []) as ProductoV4[];
+    const [producto] = (response || []) as unknown as ProductoV4[];
     if (!producto) return fallback;
 
     return {
@@ -288,34 +355,30 @@ export async function getProductoComercialBySlug(slug: string): Promise<Producto
  * Usado en página de detalle de antecedente (/antecedentes/[id]/[slug])
  */
 export async function getAntecedenteConServicios(id: number | string): Promise<AntecedenteV4 | null> {
-  const numId = Number(id);
   try {
-    const client = getClient();
-    const response = await client.request(
-      readItem('Antecedentes', id, {
-        fields: [
-          '*',
-          'servicios_relacionados.Servicios_id.id',
-          'servicios_relacionados.Servicios_id.Titulo',
-          'servicios_relacionados.Servicios_id.Descripcion',
-          'servicios_relacionados.Servicios_id.Imagen',
-          'servicios_relacionados.Servicios_id.Area',
-          'servicios_relacionados.orden',
-          'servicios_relacionados.destacado'
-        ]
-      })
+    const fields = [
+      '*',
+      'Imagen.*',
+      'ImagenPrincipal.*',
+      'Imagenes.*',
+      'Imagenes.directus_files_id',
+      'servicios_relacionados.Servicios_id.id',
+      'servicios_relacionados.Servicios_id.Titulo',
+      'servicios_relacionados.Servicios_id.Descripcion',
+      'servicios_relacionados.Servicios_id.Imagen',
+      'servicios_relacionados.Servicios_id.Area',
+      'servicios_relacionados.orden',
+      'servicios_relacionados.destacado',
+    ].join(',');
+    const payload = await requestDirectusJson<{ data?: AntecedenteV4 }>(
+      `/items/Antecedentes/${encodeURIComponent(String(id))}?fields=${encodeURIComponent(fields)}`,
+      { allowMissing: true },
     );
 
-    return response as AntecedenteV4;
+    return directusDataItem<AntecedenteV4>(payload);
   } catch (error) {
-    console.error(`Error fetching antecedente ${id} with services, trying snapshot:`, error);
-    try {
-      const allAntecedentes = await loadSnapshotData<AntecedenteV4>('antecedentes');
-      const antecedente = allAntecedentes.find((a: any) => Number(a.id) === numId);
-      return antecedente || null;
-    } catch {
-      return null;
-    }
+    console.error(`Error fetching antecedente ${id} with services from Directus:`, error);
+    throw error;
   }
 }
 
@@ -327,7 +390,7 @@ export async function getAntecedentesPorServicio(servicioId: number, limit: numb
   try {
     const client = getClient();
     const response = await client.request(
-      readItems('Antecedentes', {
+      readItemsAny('Antecedentes', {
         filter: {
           'servicios_relacionados.Servicios_id': { _eq: servicioId }
         },
@@ -343,7 +406,7 @@ export async function getAntecedentesPorServicio(servicioId: number, limit: numb
       })
     );
 
-    return (response || []) as AntecedenteV4[];
+    return (response || []) as unknown as AntecedenteV4[];
   } catch (error) {
     console.error(`Error fetching antecedentes for servicio ${servicioId}:`, error);
     return [];
@@ -378,7 +441,7 @@ export async function buscarServicios(query: string, area?: string): Promise<Ser
     }
 
     const response = await client.request(
-      readItems('Servicios', {
+      readItemsAny('Servicios', {
         filter: filters._and.length > 0 ? filters : undefined,
         fields: [
           'id',
@@ -394,7 +457,7 @@ export async function buscarServicios(query: string, area?: string): Promise<Ser
       })
     );
 
-    return (response || []) as ServicioV4[];
+    return (response || []) as unknown as ServicioV4[];
   } catch (error) {
     console.error('Error searching servicios:', error);
     return [];
@@ -409,14 +472,14 @@ export async function getAllProductos(): Promise<ProductoV4[]> {
   try {
     const client = getClient();
     const response = await client.request(
-      readItems('productos', {
+      readItemsAny('productos', {
         sort: ['servicio_id', 'orden'],
         fields: ['*', 'imagen.*'],
         limit: -1
       })
     );
 
-    return (response || []) as ProductoV4[];
+    return (response || []) as unknown as ProductoV4[];
   } catch (error) {
     console.error('Error fetching all productos:', error);
     return [];
@@ -431,14 +494,14 @@ export async function getHeroHomeImages() {
   try {
     const client = getClient();
     const response = await client.request(
-      readItems('Hero_Home', {
+      readItemsAny('Hero_Home', {
         sort: ['orden'],
         fields: ['id', 'titulo', 'orden', 'imagen'],
         limit: -1
       })
     );
 
-    return (response || []) as Array<{
+    return (response || []) as unknown as Array<{
       id: number;
       titulo: string;
       orden: number;
@@ -503,11 +566,8 @@ try {
   generatedAntecedenteImageMap = {};
 }
 
-// IMPORTANT: Directus /assets/ endpoint requires authentication (403 Forbidden)
-// We always use local images for service thumbnails instead of Directus assets
-// This avoids build-time vs runtime inconsistencies and auth issues
-const directusAssetsAvailable = false;
-console.log('[directus] Using local images for all service content (Directus assets require auth)');
+const directusAssetsAvailable = !import.meta.env?.DEV || isLocalProdReplica();
+console.log('[directus] Using Directus assets in public runtime; local maps remain development fallback');
 
 // Cache-bust version: incrementar cuando se actualizan imágenes en Directus
 const IMAGE_CACHE_VERSION = '20260201';
@@ -522,7 +582,7 @@ export function getDirectusImageUrl(imageId: string | null | undefined): string 
     return '';
   }
 
-  // Prioridad 1: Directus /assets/ (deshabilitado por 403 auth)
+  // Prioridad 1: Directus /assets/ en runtime público.
   if (directusAssetsAvailable) {
     return `/assets/${imageId}?v=${IMAGE_CACHE_VERSION}`;
   }
@@ -560,12 +620,17 @@ export function getGeneratedAntecedenteImageUrl(id: string | number | null | und
 }
 
 export function getAntecedenteImageUrl(
-  item: { id?: string | number | null; original_id?: string | number | null; Imagen?: string | null } | null | undefined
+  item: { id?: string | number | null; original_id?: string | number | null; Imagen?: string | { id?: string; directus_files_id?: string } | null } | null | undefined
 ): string {
   if (!item) return '/images/default-background.jpg';
+  const directusImageId = typeof item.Imagen === 'object'
+    ? item.Imagen?.id || item.Imagen?.directus_files_id
+    : item.Imagen;
+  const directusImage = getDirectusImageUrl(directusImageId);
+  if (directusImage && !directusImage.includes('default-background')) return directusImage;
   const generatedImage = getGeneratedAntecedenteImageUrl(item.id) || getGeneratedAntecedenteImageUrl(item.original_id);
   if (generatedImage) return generatedImage;
-  return getDirectusImageUrl(item.Imagen) || '/images/default-background.jpg';
+  return '/images/default-background.jpg';
 }
 
 /**
@@ -574,35 +639,25 @@ export function getAntecedenteImageUrl(
  */
 export async function getAllAntecedentes(): Promise<AntecedenteV4[]> {
   try {
-    const client = getClient();
-    const response = await client.request(
-      readItems('Antecedentes', {
-        fields: [
-          'id',
-          'Titulo',
-          'Descripcion',
-          'Cliente',
-          'Imagen',
-          'Area',
-          'Unidad_de_negocio',
-          'Fecha',
-          'Presupuesto',
-          'original_id'
-        ],
-        sort: ['-Fecha', '-id'],
-        limit: -1
-      })
+    const fields = [
+      'id',
+      'Titulo',
+      'Descripcion',
+      'Cliente',
+      'Imagen',
+      'Area',
+      'Unidad_de_negocio',
+      'Fecha',
+      'Presupuesto',
+      'original_id',
+    ].join(',');
+    const response = await requestDirectusJson<{ data?: AntecedenteV4[] }>(
+      `/items/Antecedentes?fields=${encodeURIComponent(fields)}&sort[]=-Fecha&sort[]=-id&limit=-1`,
     );
 
-    return (response || []) as AntecedenteV4[];
+    return directusDataArray<AntecedenteV4>(response);
   } catch (error) {
-    console.error('Error fetching antecedentes V4, trying snapshot:', error);
-    try {
-      const snapshot = await import('../data/snapshots/antecedentes.json');
-      const items = (snapshot.data || snapshot.default?.data || []) as AntecedenteV4[];
-      return items.sort((a, b) => {
-        return (b.Fecha || '').localeCompare(a.Fecha || '');
-      });
-    } catch { return []; }
+    console.error('Error fetching antecedentes V4 from Directus:', error);
+    throw error;
   }
 }

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -12,8 +12,13 @@ import EmailLink from '../../../components/common/EmailLink.astro';
 import { generateSlug } from '../../../utils/slugUtils.js';
 import { getServicioById } from '../../../utils/directusHelpers';
 import { getServiceIdFromArea } from '../../../data/areaToServiceMap.js';
-import { getAntecedenteImageUrl, getDirectusImageUrl, getGeneratedAntecedenteImageUrl, getAllAntecedentes } from '../../../lib/directus.ts';
+import { getAntecedenteConServicios, getAntecedenteImageUrl, getDirectusImageUrl, getGeneratedAntecedenteImageUrl, getAllAntecedentes } from '../../../lib/directus.ts';
 import { canonicalUrl as toCanonicalUrl, publicImageUrl } from '../../../utils/seoUrl';
+import {
+  curateAntecedente,
+  formatAntecedenteDate,
+  formatAntecedenteYear,
+} from '../../../utils/antecedentesCuration';
 import {
   plainTextFromHtml,
   renderEditorialBody,
@@ -22,7 +27,6 @@ import {
   truncateEditorialText,
 } from '../../../utils/editorialContent';
 import { isReplicaIdenticalCopy, resolveReplicaH1 } from '../../../utils/replicaProdCopy';
-import { getDirectusInternalUrl, isLocalProdReplica } from '../../../config/runtime';
 import {
   buildCaseStrategicLinkGroups,
   buildStrategicWebPageStructuredData,
@@ -30,9 +34,7 @@ import {
 import { buildCaseSeoMeta } from '../../../utils/seoMetaPolicy';
 
 // --- Configuration ---
-const DIRECTUS_URL = getDirectusInternalUrl();
 const DEFAULT_IMAGE_URL = `/images/default-background.jpg`;
-const DIRECTUS_STATIC_TOKEN = import.meta.env.DIRECTUS_STATIC_TOKEN || import.meta.env.PUBLIC_DIRECTUS_TOKEN || '';
 
 export const prerender = false;
 
@@ -66,98 +68,62 @@ const getAssetUrl = (assetId: any): string => {
     return DEFAULT_IMAGE_URL;
 };
 
-// --- Fetch Data ---
-async function fetchAntecedenteById(itemId: string) {
-    try {
-        const response = await fetch(`${DIRECTUS_URL}/items/Antecedentes/${itemId}?fields=*,Imagen.*,ImagenPrincipal.*,Imagenes.*,Imagenes.directus_files_id`, {
-            headers: {
-                'Authorization': `Bearer ${DIRECTUS_STATIC_TOKEN}`,
-                'Accept': 'application/json'
-            }
-        });
-        if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        const data = await response.json();
-        return data?.data || null;
-    } catch (error) {
-        console.error(`Error fetching item ${itemId}:`, error);
-        throw error;
-    }
-}
-
-async function loadAntecedenteFromSnapshot(itemId: string) {
-    const snapshot = await import('../../../data/snapshots/antecedentes.json');
-    const allAntecedentes = (snapshot.data || snapshot.default?.data || []) as any[];
-    return allAntecedentes.find((item: any) => item.id?.toString() === itemId) || null;
-}
-
-// --- Get data and validate (réplica: snapshot primero; evita 401 con token viejo) ---
+// --- Get data and validate: Directus is the only public source for antecedentes. ---
 try {
-    if (isLocalProdReplica()) {
-        antecedente = await loadAntecedenteFromSnapshot(id);
-    } else if (DIRECTUS_STATIC_TOKEN) {
-        antecedente = await fetchAntecedenteById(id);
-    } else {
-        throw new Error('No token');
-    }
+    antecedente = await getAntecedenteConServicios(id);
 
     if (antecedente) {
         const expectedSlug = generateSlug(antecedente.Titulo);
         if (expectedSlug !== slugFromUrl) {
             return Astro.redirect(`/antecedentes/${id}/${expectedSlug}`, 301);
         }
-    } else if (!isLocalProdReplica()) {
-        throw new Error('Not found');
-    }
-} catch (error) {
-    try {
-        antecedente = await loadAntecedenteFromSnapshot(id);
-        if (antecedente) {
-            const expectedSlug = generateSlug(antecedente.Titulo);
-            if (expectedSlug !== slugFromUrl) {
-                return Astro.redirect(`/antecedentes/${id}/${expectedSlug}`, 301);
-            }
-        } else {
-            return Astro.redirect('/404');
-        }
-    } catch {
+    } else {
         return Astro.redirect('/404');
     }
-}
-
-if (isLocalProdReplica() && !antecedente) {
-    return Astro.redirect('/404');
+} catch (error) {
+    console.error(`Error loading antecedente ${id} from Directus:`, error);
+    return new Response('Directus antecedente unavailable', {
+      status: 503,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
 }
 
 if (!antecedente) return Astro.redirect('/404');
 
+antecedente = curateAntecedente(antecedente);
+
 // --- Prepare data for UI (Directus-first) ---
+const directusMainImageUrl = getAssetUrl(antecedente.Imagen || antecedente.ImagenPrincipal);
 const generatedMainImageUrl = getGeneratedAntecedenteImageUrl(antecedente.id) || getGeneratedAntecedenteImageUrl(antecedente.original_id);
-const mainImageUrl = generatedMainImageUrl || getAssetUrl(antecedente.Imagen || antecedente.ImagenPrincipal);
+const mainImageUrl = directusMainImageUrl && !directusMainImageUrl.includes('default-background')
+    ? directusMainImageUrl
+    : generatedMainImageUrl || DEFAULT_IMAGE_URL;
 
 const formatDate = (dateString: string): string => {
-    if (!dateString) return 'No especificada';
-    try {
-        return new Date(dateString).toLocaleDateString('es-ES', { year: 'numeric', month: 'long' });
-    } catch { return dateString; }
+    const formatted = formatAntecedenteDate(dateString);
+    return formatted || '';
 };
+const caseDateLabel = formatAntecedenteDate(antecedente.Fecha);
+const caseDatePublished = caseDateLabel ? antecedente.Fecha : undefined;
 
 const cleanDisplayText = (value: unknown) => String(value || '')
   .replace(/<[^>]+>/g, '')
   .replace(/\s+/g, ' ')
   .trim();
 
-const caseBodySource = antecedente.Descripcion || antecedente.descripcion || '';
+const caseBodySource = antecedente.displayDescription || antecedente.Descripcion || antecedente.descripcion || '';
 const caseBodyPlain = plainTextFromHtml(caseBodySource, 4000);
 const caseDescriptionHtml = await renderEditorialBody(caseBodySource);
-const caseHeroExcerpt = truncateEditorialText(caseBodySource, 170);
+const caseHeroExcerpt = truncateEditorialText(caseBodySource, 170)
+  || cleanDisplayText(antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre);
 
 const buildStructuredScopeItems = (item: any): string[] => {
   const rows = [
-    item.Titulo ? `Alcance: ${cleanDisplayText(item.Titulo)}` : '',
+    item.displayTitle || item.Titulo ? `Alcance: ${cleanDisplayText(item.displayTitle || item.Titulo)}` : '',
     item.Cliente ? `Cliente: ${cleanDisplayText(item.Cliente)}` : '',
     item.Area ? `Sector: ${cleanDisplayText(item.Area)}` : '',
     item.Unidad_de_negocio ? `Unidad: ${cleanDisplayText(item.Unidad_de_negocio)}` : '',
-    item.Fecha ? `Cierre: ${formatDate(item.Fecha)}` : '',
+    formatAntecedenteDate(item.Fecha) ? `Cierre: ${formatDate(item.Fecha)}` : '',
   ].filter((row) => row.length > 8);
   return rows.slice(0, 5);
 };
@@ -184,10 +150,16 @@ const scopeItems = (() => {
 })();
 
 const isDuplicateCallout = (() => {
-  const callout = `Proyecto aplicado en ${antecedente.Area || 'tecnología'} para ${antecedente.Cliente}`.toLowerCase();
+  const callout = `Proyecto aplicado en ${antecedente.Area || ''} para ${antecedente.Cliente || ''}`.toLowerCase();
   const bodyStart = caseBodyPlain.slice(0, 180).toLowerCase();
   return bodyStart.includes(callout.slice(0, 40)) || caseBodyPlain.length < 90;
 })();
+
+const caseCalloutText = [
+  'Proyecto aplicado',
+  antecedente.Area ? `en ${cleanDisplayText(antecedente.Area)}` : '',
+  antecedente.Cliente ? `para ${cleanDisplayText(antecedente.Cliente)}` : '',
+].filter(Boolean).join(' ');
 
 const resolveServiceImageUrl = (servicio: any): string => {
   const serviceImage = getDirectusImageUrl(servicio?.Imagen);
@@ -270,7 +242,7 @@ const getRelatedAntecedentes = async (area: string, excludeId: string, limit: nu
       })
       .slice(0, limit)
       .map(item => ({
-        ...item,
+        ...curateAntecedente(item),
         slug: generateSlug(item.Titulo || 'proyecto'),
         imageUrl: getAntecedenteImageUrl(item)
       }));
@@ -320,8 +292,8 @@ const buildCaseHeadline = (item: any): string => {
 };
 
 const caseHeadlineSource = isReplicaIdenticalCopy()
-  ? resolveReplicaH1(Astro.url.pathname, cleanDisplayText(antecedente.Titulo || antecedente.Nombre))
-  : cleanDisplayText(antecedente.Titulo || antecedente.Nombre);
+  ? resolveReplicaH1(Astro.url.pathname, cleanDisplayText(antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre))
+  : cleanDisplayText(antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre);
 const caseHeadline = buildCaseHeadline({ ...antecedente, Titulo: caseHeadlineSource });
 const compactCaseTitle = (value: unknown, client?: unknown): string => {
   const title = cleanDisplayText(value)
@@ -350,12 +322,13 @@ const compactCaseTitle = (value: unknown, client?: unknown): string => {
 const siteUrl = 'https://www.ultimamilla.com.ar';
 const canonicalUrl = toCanonicalUrl(`/antecedentes/${id}/${slugFromUrl}`);
 const caseSeo = buildCaseSeoMeta({
-  title: antecedente.Titulo || antecedente.Nombre,
-  description: caseBodySource,
+  title: antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre,
+  description: antecedente.displayDescription || caseBodySource,
   area: antecedente.Area || antecedente.Unidad_de_negocio,
   date: antecedente.Fecha,
 });
 const metaDescription = caseSeo.description;
+const structuredImageUrl = publicImageUrl(mainImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL);
 const caseStrategicLinkGroups = buildCaseStrategicLinkGroups({
   currentPath: `/antecedentes/${id}/${slugFromUrl}`,
   title: caseHeadline,
@@ -367,14 +340,29 @@ const caseStrategicLinkGroups = buildCaseStrategicLinkGroups({
 });
 const antecedenteStructuredData = {
   "@type": "CreativeWork",
-  "name": antecedente.Titulo,
-  "headline": antecedente.Titulo,
+  "name": antecedente.displayTitle || antecedente.Titulo,
+  "headline": antecedente.displayTitle || antecedente.Titulo,
   "description": metaDescription,
   "url": canonicalUrl,
-  "image": publicImageUrl(mainImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL),
-  "datePublished": antecedente.Fecha || undefined,
+  "image": {
+    "@type": "ImageObject",
+    "url": structuredImageUrl,
+    "caption": [
+      antecedente.displayTitle || antecedente.Titulo,
+      antecedente.Cliente ? `Cliente: ${cleanDisplayText(antecedente.Cliente)}` : '',
+      antecedente.Area ? `Sector: ${cleanDisplayText(antecedente.Area)}` : '',
+    ].filter(Boolean).join(' | '),
+  },
+  "datePublished": caseDatePublished,
   "inLanguage": "es-AR",
-  "about": antecedente.Area || undefined,
+  "about": antecedente.Area ? { "@type": "Thing", "name": cleanDisplayText(antecedente.Area) } : undefined,
+  "mentions": antecedente.Cliente ? [{ "@type": "Organization", "name": cleanDisplayText(antecedente.Cliente) }] : undefined,
+  "identifier": `ANT-${id}`,
+  "isPartOf": {
+    "@type": "CollectionPage",
+    "name": "Evidencia operativa documentada",
+    "url": toCanonicalUrl('/antecedentes')
+  },
   "provider": {
     "@type": "Organization",
     "name": "ULTIMA MILLA",
@@ -426,7 +414,7 @@ const antecedentePageStructuredData = [
           <h1>{caseHeadline}</h1>
 
           <p>
-            {caseHeroExcerpt || 'Proyecto documentado con alcance técnico verificable.'}
+            {caseHeroExcerpt}
           </p>
 
           <div class="case-detail-actions">
@@ -450,21 +438,23 @@ const antecedentePageStructuredData = [
           </figure>
           <div class="case-detail-dossier__body">
             <span>Dossier del proyecto</span>
-            <strong>{antecedente.Cliente || 'ULTIMA MILLA'}</strong>
+            <strong>{antecedente.Cliente || `ANT-${id}`}</strong>
             <div class="case-detail-meta">
-              <div>
-                <span>Vertical</span>
-                <strong>{antecedente.Area || 'Tecnología'}</strong>
-              </div>
-              {antecedente.Fecha && (
+              {antecedente.Area && (
+                <div>
+                  <span>Vertical</span>
+                  <strong>{antecedente.Area}</strong>
+                </div>
+              )}
+              {caseDateLabel && (
                 <div>
                   <span>Fecha</span>
-                  <strong>{formatDate(antecedente.Fecha)}</strong>
+                  <strong>{caseDateLabel}</strong>
                 </div>
               )}
               <div>
-                <span>Ubicación</span>
-                <strong>Mendoza</strong>
+                <span>Registro</span>
+                <strong>ANT-{id}</strong>
               </div>
             </div>
           </div>
@@ -489,13 +479,13 @@ const antecedentePageStructuredData = [
             {caseDescriptionHtml ? (
               <div set:html={caseDescriptionHtml} />
             ) : (
-              <p>{caseHeroExcerpt || 'Información detallada del proyecto no disponible.'}</p>
+              <p>{caseHeroExcerpt}</p>
             )}
           </div>
 
-          {!isDuplicateCallout && (
+          {!isDuplicateCallout && caseCalloutText.length > 'Proyecto aplicado'.length && (
             <div class="case-callout">
-              <span>Proyecto aplicado en {antecedente.Area || 'tecnología'} para {antecedente.Cliente}</span>
+              <span>{caseCalloutText}</span>
             </div>
           )}
         </div>
@@ -589,31 +579,38 @@ const antecedentePageStructuredData = [
             <span class="case-info-card__title">Ficha técnica</span>
           </div>
           <div class="p-0 flex flex-col gap-3 sm:gap-4">
-            <div class="flex flex-col gap-1">
-              <span class="case-info-label">Organización</span>
-              <span class="case-info-value">{antecedente.Cliente}</span>
-            </div>
-            <div class="h-px bg-gray-100"></div>
-            <div class="flex flex-col gap-1">
-              <span class="case-info-label">Vertical</span>
-              <span class="case-info-value">{antecedente.Area || 'Tecnología'}</span>
-            </div>
-            <div class="h-px bg-gray-100"></div>
-            <div class="flex flex-col gap-1">
-              <span class="case-info-label">Unidad de Negocio</span>
-              <span class="case-info-value">{antecedente.Unidad_de_negocio || 'Consultoría'}</span>
-            </div>
-            <div class="h-px bg-gray-100"></div>
-            <div class="flex flex-col gap-1">
-              <span class="case-info-label">Ubicación</span>
-              <span class="case-info-value">Mendoza, Argentina</span>
-            </div>
-            {antecedente.Fecha && (
+            {antecedente.Cliente && (
               <>
+                <div class="flex flex-col gap-1">
+                  <span class="case-info-label">Organización</span>
+                  <span class="case-info-value">{antecedente.Cliente}</span>
+                </div>
                 <div class="h-px bg-gray-100"></div>
+              </>
+            )}
+            {antecedente.Area && (
+              <>
+                <div class="flex flex-col gap-1">
+                  <span class="case-info-label">Vertical</span>
+                  <span class="case-info-value">{antecedente.Area}</span>
+                </div>
+                <div class="h-px bg-gray-100"></div>
+              </>
+            )}
+            {antecedente.Unidad_de_negocio && (
+              <>
+                <div class="flex flex-col gap-1">
+                  <span class="case-info-label">Unidad de Negocio</span>
+                  <span class="case-info-value">{antecedente.Unidad_de_negocio}</span>
+                </div>
+                <div class="h-px bg-gray-100"></div>
+              </>
+            )}
+            {caseDateLabel && (
+              <>
                 <div class="flex flex-col gap-1">
                   <span class="case-info-label">Finalización</span>
-                  <span class="case-info-value">{formatDate(antecedente.Fecha)}</span>
+                  <span class="case-info-value">{caseDateLabel}</span>
                 </div>
               </>
             )}
@@ -683,12 +680,12 @@ const antecedentePageStructuredData = [
             <EvidenceCaseRow
               href={`/antecedentes/${ant.id}/${ant.slug}`}
               number={String(index + 1).padStart(2, '0')}
-              title={compactCaseTitle(ant.Titulo || 'Proyecto', ant.Cliente)}
-              description={truncateEditorialText(ant.Descripcion || ant.Titulo, 150)}
+              title={compactCaseTitle(ant.displayTitle || ant.Titulo || 'Proyecto', ant.Cliente)}
+              description={truncateEditorialText(ant.displayDescription || ant.Descripcion || ant.Titulo, 150)}
               image={ant.imageUrl}
               imageAlt={ant.Titulo || 'Antecedente'}
               sector={ant.Area || 'Servicios IT'}
-              year={ant.Fecha ? new Date(ant.Fecha).getFullYear().toString() : 'documentado'}
+              year={formatAntecedenteYear(ant.Fecha)}
               imageLoading="eager"
             />
           ))}

--- a/src/pages/antecedentes/index.astro
+++ b/src/pages/antecedentes/index.astro
@@ -11,6 +11,13 @@ import IntentLinkGraph from '../../components/um/IntentLinkGraph.astro';
 import { getAllAntecedentes, getAntecedenteImageUrl } from '../../lib/directus.ts';
 import { getDevTemplateVariant } from '../../utils/templateVariant';
 import {
+  buildAntecedenteListItemStructuredData,
+  curateAntecedente,
+  isPromotableAntecedente,
+  sortAntecedentesForPublicList,
+} from '../../utils/antecedentesCuration';
+import { canonicalUrl } from '../../utils/seoUrl';
+import {
   buildCaseStrategicLinkGroups,
   buildStrategicWebPageStructuredData,
 } from '../../data/strategicLinkGraph';
@@ -68,7 +75,7 @@ const filterAntecedentes = (antecedentes, filters, searchQuery) => {
   if (searchQuery) {
     const query = safeText(searchQuery);
     filtered = filtered.filter((item) => {
-      const searchText = `${item.Titulo || ''} ${item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`.toLowerCase();
+      const searchText = `${item.displayTitle || item.Titulo || ''} ${item.displayDescription || item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`.toLowerCase();
       return searchText.includes(query);
     });
   }
@@ -76,7 +83,7 @@ const filterAntecedentes = (antecedentes, filters, searchQuery) => {
   if (filters.sector && sectorKeywords[filters.sector]) {
     const keywords = sectorKeywords[filters.sector];
     filtered = filtered.filter((item) => {
-      const searchText = `${item.Titulo || ''} ${item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`.toLowerCase();
+      const searchText = `${item.displayTitle || item.Titulo || ''} ${item.displayDescription || item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`.toLowerCase();
       return keywords.some((keyword) => searchText.includes(keyword.toLowerCase()));
     });
   }
@@ -137,14 +144,22 @@ let allAntecedentesForIndex: any[] = [];
 try {
   const response = await getAllAntecedentes();
 
-  const allAntecedentes = response.map((item) => ({
-    ...item,
-    slug: `${item.id}/${localGenerateSlug(item.Titulo)}`,
-    imageUrl: getAntecedenteImageUrl(item)
+  const allAntecedentes = sortAntecedentesForPublicList(response.map((item) => {
+    const curated = curateAntecedente({
+      ...item,
+      imageUrl: getAntecedenteImageUrl(item),
+    });
+
+    return {
+      ...curated,
+      slug: `${item.id}/${localGenerateSlug(item.Titulo)}`,
+    };
   }));
   allAntecedentesForIndex = allAntecedentes;
 
-  const filteredAntecedentes = filterAntecedentes(allAntecedentes, pageData.activeFilters, pageData.searchQuery);
+  const filteredAntecedentes = sortAntecedentesForPublicList(
+    filterAntecedentes(allAntecedentes, pageData.activeFilters, pageData.searchQuery)
+  );
   const hasActiveFilters = Boolean(
     pageData.searchQuery
     || pageData.activeFilters.sector
@@ -157,14 +172,17 @@ try {
   let archivePool;
 
   if (pageData.currentPage === 1 && !hasActiveFilters) {
-    featuredAntecedente = pickProtagonistAntecedente(filteredAntecedentes);
+    const promotableAntecedentes = filteredAntecedentes.filter(isPromotableAntecedente);
+    const spotlightSource = promotableAntecedentes.length > 0 ? promotableAntecedentes : filteredAntecedentes;
+    featuredAntecedente = pickProtagonistAntecedente(spotlightSource);
     const remaining = featuredAntecedente
       ? filteredAntecedentes.filter((item) => item.id !== featuredAntecedente.id)
       : filteredAntecedentes;
-    spotlightAntecedentes = featuredAntecedente
-      ? [featuredAntecedente, ...remaining.slice(0, 2)]
-      : filteredAntecedentes.slice(0, 3);
-    archivePool = featuredAntecedente ? remaining.slice(2) : filteredAntecedentes.slice(3);
+    const secondarySource = remaining.filter(isPromotableAntecedente);
+    const secondarySpotlight = secondarySource.length >= 2 ? secondarySource.slice(0, 2) : remaining.slice(0, 2);
+    spotlightAntecedentes = featuredAntecedente ? [featuredAntecedente, ...secondarySpotlight] : filteredAntecedentes.slice(0, 3);
+    const spotlightIds = new Set(spotlightAntecedentes.map((item) => item.id));
+    archivePool = filteredAntecedentes.filter((item) => !spotlightIds.has(item.id));
   } else {
     spotlightAntecedentes = filteredAntecedentes.slice(0, 3);
     archivePool = filteredAntecedentes.slice(3);
@@ -178,6 +196,7 @@ try {
     antecedentes: archivePool.slice(archiveStartIndex, archiveEndIndex),
     spotlightAntecedentes,
     totalItems: filteredAntecedentes.length,
+    catalogTotalItems: allAntecedentes.length,
     archiveTotalItems: archivePool.length,
     totalPages: Math.max(1, Math.ceil(archivePool.length / PAGE_SIZE)),
     error: null,
@@ -222,16 +241,17 @@ const visibleAntecedentes = [
 const crawlableAntecedenteIndex = allAntecedentesForIndex
   .map((item) => ({
     id: item.id,
-    title: item.Titulo || 'Antecedente técnico',
+    title: item.displayTitle || item.Titulo || 'Antecedente técnico',
     area: item.Area || item.Unidad_de_negocio || '',
     href: `/antecedentes/${item.slug}`,
+    quality: item.curation?.quality || '',
   }))
   .sort((a, b) => String(a.title).localeCompare(String(b.title), 'es'));
 const antecedentesStrategicLinkGroups = buildCaseStrategicLinkGroups({
   currentPath: '/antecedentes',
   title: 'Evidencia operativa documentada',
   summary: 'Antecedentes técnicos de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.',
-  text: visibleAntecedentes.map((item: any) => `${item.Titulo || ''} ${item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`).join(' '),
+  text: visibleAntecedentes.map((item: any) => `${item.displayTitle || item.Titulo || ''} ${item.displayDescription || item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`).join(' '),
   relatedCases: visibleAntecedentes.map((item: any) => ({
     ...item,
     href: item.slug ? `/antecedentes/${item.slug}` : '',
@@ -243,13 +263,30 @@ const antecedentesStructuredData = buildStrategicWebPageStructuredData({
   description: 'Antecedentes técnicos de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.',
   groups: antecedentesStrategicLinkGroups,
 });
+const antecedentesCollectionStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Evidencia operativa documentada',
+  description: 'Archivo curado de antecedentes técnicos de ULTIMA MILLA con cliente, sector, fecha, imagen asociada y enlace canónico.',
+  url: canonicalUrl('/antecedentes'),
+  inLanguage: 'es-AR',
+  mainEntity: {
+    '@type': 'ItemList',
+    numberOfItems: allAntecedentesForIndex.length,
+    itemListOrder: 'https://schema.org/ItemListOrderDescending',
+    itemListElement: allAntecedentesForIndex
+      .filter(isPromotableAntecedente)
+      .slice(0, 48)
+      .map((item, index) => buildAntecedenteListItemStructuredData(item, index + 1)),
+  },
+};
 ---
 
 <LayoutV4
   title="Evidencia operativa documentada | ULTIMA MILLA"
   description="Antecedentes técnicos de ULTIMA MILLA: proyectos reales de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT."
   keywords="casos exito tecnologia mendoza, proyectos telecomunicaciones, antecedentes cableado estructurado, portfolio seguridad electronica, software a medida casos"
-  structuredData={antecedentesStructuredData}
+  structuredData={[antecedentesStructuredData, antecedentesCollectionStructuredData]}
 >
   {templateVariant === 'atlas' && (
     <AntecedentesTemplateAtlas

--- a/src/pages/antecedntes.astro
+++ b/src/pages/antecedntes.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/antecedentes', 301);
+---

--- a/src/pages/geo/[resource].json.ts
+++ b/src/pages/geo/[resource].json.ts
@@ -1,9 +1,22 @@
 import type { APIRoute } from 'astro';
-import { buildGeoResource } from '../../data/geoResources';
+import { buildGeoResourceAsync } from '../../data/geoResources';
 
 export const GET: APIRoute = async ({ params }) => {
   const resource = params.resource || '';
-  const payload = buildGeoResource(resource);
+  let payload = null;
+
+  try {
+    payload = await buildGeoResourceAsync(resource);
+  } catch (error) {
+    console.error(`[GEO-${resource}] Directus unavailable:`, error);
+    return new Response(JSON.stringify({ error: 'Directus unavailable for GEO resource' }), {
+      status: 503,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
 
   if (!payload) {
     return new Response(JSON.stringify({ error: 'GEO resource not found' }), {

--- a/src/pages/geo/cases.json.ts
+++ b/src/pages/geo/cases.json.ts
@@ -1,12 +1,23 @@
 import type { APIRoute } from 'astro';
-import { buildGeoResource } from '../../data/geoResources';
+import { buildGeoResourceAsync } from '../../data/geoResources';
 
 export const GET: APIRoute = async () => {
-  return new Response(JSON.stringify(buildGeoResource('cases'), null, 2), {
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600',
-      'X-Robots-Tag': 'index, follow',
-    },
-  });
+  try {
+    return new Response(JSON.stringify(await buildGeoResourceAsync('cases'), null, 2), {
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+        'X-Robots-Tag': 'index, follow',
+      },
+    });
+  } catch (error) {
+    console.error('[GEO-CASES] Directus unavailable:', error);
+    return new Response(JSON.stringify({ error: 'Directus unavailable for GEO cases' }), {
+      status: 503,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
 };

--- a/src/pages/geo/image-evidence.json.ts
+++ b/src/pages/geo/image-evidence.json.ts
@@ -1,12 +1,23 @@
 import type { APIRoute } from 'astro';
-import { buildGeoResource } from '../../data/geoResources';
+import { buildGeoResourceAsync } from '../../data/geoResources';
 
 export const GET: APIRoute = async () => {
-  return new Response(JSON.stringify(buildGeoResource('image-evidence'), null, 2), {
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600',
-      'X-Robots-Tag': 'index, follow',
-    },
-  });
+  try {
+    return new Response(JSON.stringify(await buildGeoResourceAsync('image-evidence'), null, 2), {
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+        'X-Robots-Tag': 'index, follow',
+      },
+    });
+  } catch (error) {
+    console.error('[GEO-IMAGE-EVIDENCE] Directus unavailable:', error);
+    return new Response(JSON.stringify({ error: 'Directus unavailable for image evidence' }), {
+      status: 503,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,10 +16,6 @@ import { getServiceVisualSpec, serviceVisualOrder } from '../data/serviceVisualS
 import { resolveReplicaH1 } from '../utils/replicaProdCopy';
 import { extractCaseMetricsFromAntecedente } from '../utils/caseMetrics';
 import {
-  getAntecedentesCountShort,
-  getAntecedentesCatalogCount,
-} from '../utils/verifiedProof';
-import {
   buildServiceStrategicLinkGroups,
   buildStrategicWebPageStructuredData,
 } from '../data/strategicLinkGraph';
@@ -54,8 +50,8 @@ const serviceModules = serviceVisualOrder
   .filter(Boolean);
 
 const homeHeroImage = '/uploads/hero/c194b40e-925c-4de5-924b-ea61ab835c0e.jpg';
-const proofCountShort = getAntecedentesCountShort();
-const proofCountExact = getAntecedentesCatalogCount();
+const proofCountExact = antecedentesData.length;
+const proofCountShort = proofCountExact >= 500 ? '500+' : String(proofCountExact);
 
 const caseTargets = [
   { label: 'Gobierno de Mendoza', terms: ['gobierno de mendoza', 'ministerio', 'municipalidad'] },

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -3,6 +3,7 @@ import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from '../config/seo';
 import {
   geoCaseResources,
   geoHubRoutes,
+  getGeoCaseResources,
   geoResourceNames,
   geoSectorResources,
   geoServiceResources,
@@ -11,6 +12,20 @@ import {
 import { getInstitutionalProofLines } from '../utils/verifiedProof';
 
 export const GET: APIRoute = async () => {
+  let directusCaseResources = geoCaseResources;
+  try {
+    directusCaseResources = await getGeoCaseResources();
+  } catch (error) {
+    console.error('[LLMS-FULL] Directus unavailable for cases:', error);
+    return new Response('Directus unavailable for LLM cases index', {
+      status: 503,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+
   const lines = [
     `# ${SITE_NAME} — GEO/LLM Index`,
     '',
@@ -60,7 +75,7 @@ export const GET: APIRoute = async () => {
     ...geoSectorResources.map((sector) => `- ${sector.name}: ${sector.operatingNeed} (${sector.url})`),
     '',
     '## Prioritized Cases',
-    ...geoCaseResources.slice(0, 24).map((item) => `- ${item.client}: ${item.title} (${item.url})`),
+    ...directusCaseResources.slice(0, 32).map((item) => `- ${item.client ? `${item.client}: ` : ''}${item.title} (${item.url})`),
     '',
     '## Contact',
     `- ${SITE_URL}/contacto`,

--- a/src/pages/sitemap-antecedentes.xml.ts
+++ b/src/pages/sitemap-antecedentes.xml.ts
@@ -1,28 +1,13 @@
 import type { APIRoute } from 'astro';
 
 import { generateSlug } from '../utils/slugUtils.js';
-import { SITE_URL } from '../config/seo';
 import { canonicalUrl, escapeXml, formatSitemapDate, publicImageUrl } from '../utils/seoUrl';
-import antecedentesSnapshot from '../data/snapshots/antecedentes.json';
-import imageLocalMap from '../data/image-local-map.json';
-import generatedAntecedenteImageMap from '../data/antecedentes-generated-image-map.json';
+import { getAllAntecedentes, getAntecedenteImageUrl } from '../lib/directus';
 
 function getImageUrl(item: any): string | null {
-    const generatedImage = (generatedAntecedenteImageMap as Record<string, string>)[String(item.id || item.ID || '')];
-    if (generatedImage) return publicImageUrl(generatedImage);
-
-    const imagen = item.Imagen;
-    if (!imagen) return null;
-    if (typeof imagen === 'string') {
-        if (imagen.startsWith('http')) return publicImageUrl(imagen);
-        const localPath = (imageLocalMap as Record<string, string>)[imagen];
-        return publicImageUrl(localPath || `/assets/${imagen}`);
-    }
-    if (typeof imagen === 'object' && imagen.id) {
-        const localPath = (imageLocalMap as Record<string, string>)[imagen.id];
-        return publicImageUrl(localPath || `/assets/${imagen.id}`);
-    }
-    return null;
+    const imageUrl = getAntecedenteImageUrl(item);
+    if (!imageUrl || imageUrl.includes('default-background')) return null;
+    return publicImageUrl(imageUrl);
 }
 
 function generateSitemapXml(antecedentes: any[]): string {
@@ -51,30 +36,7 @@ function generateSitemapXml(antecedentes: any[]): string {
 
 export const GET: APIRoute = async () => {
     try {
-        // Obtener todos los antecedentes desde Directus
-        const directusUrl = (typeof process !== 'undefined' ? process.env['DIRECTUS_INTERNAL_URL'] : undefined) ?? import.meta.env['DIRECTUS_INTERNAL_URL'] ?? 'http://localhost:8055';
-        const token = (typeof process !== 'undefined' ? process.env['DIRECTUS_ADMIN_TOKEN'] : undefined) ?? import.meta.env['DIRECTUS_ADMIN_TOKEN'] ?? '';
-        const headers: HeadersInit = {
-            'Content-Type': 'application/json'
-        };
-        if (token) headers['Authorization'] = `Bearer ${token}`;
-
-        const response = await fetch(
-            `${directusUrl}/items/Antecedentes?limit=-1&fields=id,Titulo,Fecha,Imagen`,
-            { headers }
-        );
-
-        let antecedentes = [];
-        
-        if (response.ok) {
-            const data = await response.json();
-            antecedentes = data.data || [];
-        } else {
-            // Fallback: usar datos estáticos si Directus no está disponible
-            const errorText = await response.text().catch(() => 'unknown');
-            console.error(`[SITEMAP-ANTECEDENTES] Directus returned ${response.status}: ${errorText.slice(0, 300)}`);
-            antecedentes = (antecedentesSnapshot as any).data || [];
-        }
+        const antecedentes = await getAllAntecedentes();
 
         const sitemap = generateSitemapXml(antecedentes);
 
@@ -86,31 +48,12 @@ export const GET: APIRoute = async () => {
         });
     } catch (error) {
         console.error('Error generando sitemap de antecedentes:', error);
-
-        try {
-            const fallbackSitemap = generateSitemapXml((antecedentesSnapshot as any).data || []);
-            return new Response(fallbackSitemap, {
-                headers: {
-                    'Content-Type': 'application/xml; charset=utf-8',
-                    'Cache-Control': 'public, max-age=3600'
-                },
-            });
-        } catch {
-            // Retornar sitemap mínimo en caso de error extremo
-            const minimalSitemap = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-        <loc>${SITE_URL}/antecedentes</loc>
-        <lastmod>${formatSitemapDate()}</lastmod>
-    </url>
-</urlset>`;
-
-            return new Response(minimalSitemap, {
-                headers: {
-                    'Content-Type': 'application/xml; charset=utf-8',
-                    'Cache-Control': 'public, max-age=3600'
-                },
-            });
-        }
+        return new Response('Directus unavailable for antecedentes sitemap', {
+            status: 503,
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+                'Cache-Control': 'no-store'
+            },
+        });
     }
 }

--- a/src/pages/sitemap-images.xml.ts
+++ b/src/pages/sitemap-images.xml.ts
@@ -1,11 +1,9 @@
 import type { APIRoute } from 'astro';
 
-import { getAntecedentesImageEvidenceEntries } from '../utils/antecedentesImageEvidence';
+import { getAntecedentesImageEvidenceEntriesFromDirectus } from '../utils/antecedentesImageEvidence';
 import { escapeXml, formatSitemapDate } from '../utils/seoUrl';
 
-function generateImageSitemapXml(): string {
-  const entries = getAntecedentesImageEvidenceEntries();
-
+function generateImageSitemapXml(entries: Awaited<ReturnType<typeof getAntecedentesImageEvidenceEntriesFromDirectus>>): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -21,10 +19,23 @@ function generateImageSitemapXml(): string {
 }
 
 export const GET: APIRoute = async () => {
-  return new Response(generateImageSitemapXml(), {
-    headers: {
-      'Content-Type': 'application/xml; charset=utf-8',
-      'Cache-Control': 'public, max-age=86400',
-    },
-  });
+  try {
+    const entries = await getAntecedentesImageEvidenceEntriesFromDirectus();
+
+    return new Response(generateImageSitemapXml(entries), {
+      headers: {
+        'Content-Type': 'application/xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400',
+      },
+    });
+  } catch (error) {
+    console.error('[SITEMAP-IMAGES] Directus unavailable:', error);
+    return new Response('Directus unavailable for image sitemap', {
+      status: 503,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
 };

--- a/src/utils/antecedentesCuration.ts
+++ b/src/utils/antecedentesCuration.ts
@@ -1,0 +1,307 @@
+import { canonicalUrl, publicImageUrl } from './seoUrl';
+import { generateSlug } from './slugUtils.js';
+
+export type AntecedenteQuality =
+  | 'strong-case'
+  | 'needs-editorial-review'
+  | 'low-value-candidate'
+  | 'data-error-candidate';
+
+export interface AntecedenteCuration {
+  quality: AntecedenteQuality;
+  issues: string[];
+  isPromotable: boolean;
+  displayTitle: string;
+  displayDescription: string;
+  displayYear: string;
+  canonicalPath: string;
+}
+
+export type CuratedAntecedente<T extends Record<string, any> = Record<string, any>> = T & {
+  curation: AntecedenteCuration;
+  displayTitle: string;
+  displayDescription: string;
+  displayYear: string;
+  canonicalPath: string;
+};
+
+const DATA_ERROR_PATTERNS: Array<[RegExp, string]> = [
+  [/\bsistena\b/i, 'typo:sistena'],
+  [/\bremplazo\b/i, 'typo:remplazo'],
+  [/\bunivercidad\b/i, 'typo:univercidad'],
+  [/\bcpamaras\b/i, 'typo:cpamaras'],
+  [/\bpusaldor\b/i, 'typo:pusaldor'],
+  [/\bmunicip$/i, 'truncated:municip'],
+];
+
+const LOW_VALUE_PATTERNS: Array<[RegExp, string]> = [
+  [/\b(dis[ck]o duro|nas\s*\d+tb|ssd|memoria ram|ram\s*\d+gb)\b/i, 'minor-supply:storage-memory'],
+  [/\b(pc\s*\+\s*monitor|computadora\s*\+\s*monitor|pcs?\s+con\s+monitor)\b/i, 'minor-supply:monitor'],
+  [/\bmonitor\s*(22|24|pulgadas|")?\b/i, 'minor-supply:monitor'],
+  [/\btablets?\b/i, 'minor-supply:tablet'],
+  [/\bproyector\b/i, 'minor-supply:projector'],
+  [/\bcomodato\b/i, 'commercial-loan:comodato'],
+  [/\bremanente de proyectos\b/i, 'minor-supply:remanent-sale'],
+];
+
+const GENERIC_PATTERNS: Array<[RegExp, string]> = [
+  [/\bprovisi[oó]n de\b/i, 'generic-provision'],
+  [/\basistencia t[eé]cnica\b/i, 'generic:asistencia-tecnica'],
+  [/\bvisita t[eé]cnica\b/i, 'generic:visita-tecnica'],
+  [/\bconfiguraci[oó]n\b/i, 'generic:configuracion'],
+  [/\btrabajos varios\b/i, 'generic:trabajos-varios'],
+];
+
+const STRATEGIC_PATTERNS = [
+  /\bdesarrollo de software\b/i,
+  /\bdigitalizaci[oó]n\b/i,
+  /\bimplementaci[oó]n de redes\b/i,
+  /\bfibra [oó]ptica\b/i,
+  /\bdata center\b/i,
+  /\binfraestructura\b/i,
+  /\bmantenimiento cr[ií]tico\b/i,
+  /\bdetecci[oó]n de incendios\b/i,
+  /\bseguridad electr[oó]nica\b/i,
+  /\bgesti[oó]n y monitoreo\b/i,
+  /\bsoporte de infraestructura\b/i,
+  /\balta disponibilidad\b/i,
+  /\bcorrientes d[eé]biles\b/i,
+  /\bcctv\b/i,
+  /\bvideo vigilancia\b/i,
+];
+
+const QUALITY_RANK: Record<AntecedenteQuality, number> = {
+  'strong-case': 0,
+  'needs-editorial-review': 1,
+  'low-value-candidate': 2,
+  'data-error-candidate': 3,
+};
+
+export function cleanAntecedenteText(value: unknown): string {
+  return String(value ?? '')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function fixKnownTextErrors(value: string): string {
+  return value
+    .replace(/\bSistena\b/g, 'Sistema')
+    .replace(/\bsistena\b/g, 'sistema')
+    .replace(/\bRemplazo\b/g, 'Reemplazo')
+    .replace(/\bremplazo\b/g, 'reemplazo')
+    .replace(/\bUnivercidad\b/g, 'Universidad')
+    .replace(/\bunivercidad\b/g, 'universidad')
+    .replace(/\bcpamaras\b/g, 'cámaras')
+    .replace(/\bCpamaras\b/g, 'Cámaras')
+    .replace(/\bpusaldor\b/g, 'pulsador')
+    .replace(/\bPusaldor\b/g, 'Pulsador')
+    .replace(/\btecnica\b/g, 'técnica')
+    .replace(/\bTecnica\b/g, 'Técnica')
+    .replace(/\btelefonico\b/g, 'telefónico')
+    .replace(/\bTelefonico\b/g, 'Telefónico')
+    .replace(/\bAmpliacion\b/g, 'Ampliación')
+    .replace(/\bampliacion\b/g, 'ampliación')
+    .replace(/\bmodulo\b/g, 'módulo')
+    .replace(/\bModulo\b/g, 'Módulo');
+}
+
+function uniqueIssues(issues: string[]): string[] {
+  return [...new Set(issues.filter(Boolean))];
+}
+
+function isTemplateDescription(title: string, description: string): boolean {
+  if (!title || !description) return false;
+  const normalizedTitle = title.toLowerCase().replace(/\s+/g, ' ').trim();
+  const normalizedDescription = description.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  return normalizedDescription.startsWith(`${normalizedTitle} cliente:`)
+    || /^.+?\s+cliente:\s+.+?\.\s+sector:\s+.+?\.?$/i.test(description);
+}
+
+function getDateTime(value: unknown): number {
+  const raw = cleanAntecedenteText(value);
+  if (!raw || /invalid date/i.test(raw)) return 0;
+  const parsed = new Date(raw).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function formatAntecedenteYear(value: unknown): string {
+  const raw = cleanAntecedenteText(value);
+  if (!raw || /invalid date/i.test(raw)) return 'documentado';
+  const parsed = new Date(raw);
+  if (!Number.isNaN(parsed.getTime())) return String(parsed.getFullYear());
+  const year = raw.match(/\b(19\d{2}|20\d{2})\b/)?.[1];
+  return year || 'documentado';
+}
+
+export function formatAntecedenteDate(value: unknown): string {
+  const raw = cleanAntecedenteText(value);
+  if (!raw || /invalid date/i.test(raw)) return '';
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return '';
+
+  return parsed.toLocaleDateString('es-AR', {
+    year: 'numeric',
+    month: 'long',
+  });
+}
+
+function buildDisplayTitle(item: Record<string, any>): string {
+  const title = fixKnownTextErrors(cleanAntecedenteText(item.Titulo || item.Nombre || 'Antecedente técnico documentado'));
+  return title
+    .replace(/\s+\(\d+\)$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function humanizeTemplateDescription(title: string, description: string): string {
+  const match = description.match(/^(.+?)\s+Cliente:\s+(.+?)\.\s+Sector:\s+(.+?)\.?$/i);
+  if (!match) return description;
+
+  const [, sourceTitle, client, sector] = match.map((part) => fixKnownTextErrors(cleanAntecedenteText(part)));
+  return `Antecedente de ${sourceTitle || title} para ${client}, dentro de ${sector}.`;
+}
+
+function buildDisplayDescription(item: Record<string, any>, displayTitle: string): string {
+  const title = cleanAntecedenteText(item.Titulo || item.Nombre);
+  const description = fixKnownTextErrors(cleanAntecedenteText(item.Descripcion || item.descripcion || ''));
+  const client = cleanAntecedenteText(item.Cliente);
+  const sector = cleanAntecedenteText(item.Area || item.Unidad_de_negocio);
+
+  if (description && isTemplateDescription(title, description)) {
+    return humanizeTemplateDescription(displayTitle, description);
+  }
+
+  if (description.length >= 70) return description;
+
+  const factualParts = [
+    description || displayTitle,
+    client ? `Cliente: ${client}` : '',
+    sector ? `Sector: ${sector}` : '',
+  ].filter(Boolean);
+
+  const combined = factualParts.join('. ').replace(/\.\s*\./g, '.');
+  return combined.endsWith('.') ? combined : `${combined}.`;
+}
+
+export function getAntecedenteIssues(item: Record<string, any>): string[] {
+  const title = cleanAntecedenteText(item.Titulo || item.Nombre);
+  const description = cleanAntecedenteText(item.Descripcion || item.descripcion);
+  const combined = `${title} ${description}`;
+  const issues: string[] = [];
+
+  if (title.length > 95) issues.push('title-too-long');
+  if (title.includes('...') || title.includes('…')) issues.push('title-truncated-ellipsis');
+  if (description.includes('...') || description.includes('…')) issues.push('description-truncated-ellipsis');
+  if (/\(\d+\)$/.test(title)) issues.push('duplicate-sequence-suffix');
+  if (/cliente confidencial/i.test(title)) issues.push('confidential-client-in-title');
+  if (description.length > 0 && description.length < 70) issues.push('description-too-short-for-seo');
+  if (description.length > 0 && description.split(/\s+/).filter(Boolean).length < 10) issues.push('description-too-few-words');
+  if (description && !/[.!?)]$/.test(description)) issues.push('description-no-terminal-punctuation');
+  if (isTemplateDescription(title, description)) issues.push('description-only-template');
+
+  for (const [pattern, issue] of DATA_ERROR_PATTERNS) {
+    if (pattern.test(combined)) issues.push(issue);
+  }
+
+  for (const [pattern, issue] of LOW_VALUE_PATTERNS) {
+    if (pattern.test(combined)) issues.push(issue);
+  }
+
+  for (const [pattern, issue] of GENERIC_PATTERNS) {
+    if (pattern.test(combined)) issues.push(issue);
+  }
+
+  return uniqueIssues(issues);
+}
+
+function classifyAntecedente(item: Record<string, any>, issues: string[]): AntecedenteQuality {
+  const rawTitle = cleanAntecedenteText(item.Titulo || item.Nombre);
+  const rawDescription = cleanAntecedenteText(item.Descripcion || item.descripcion).replace(/\s+Cliente:\s+.+$/i, '');
+  const contentText = `${rawTitle} ${rawDescription}`;
+  const hasDataError = issues.some((issue) => issue.startsWith('typo:') || issue.startsWith('truncated:'));
+  const hasLowValueSignal = issues.some((issue) => issue.startsWith('minor-supply:') || issue.startsWith('commercial-loan:'));
+  const hasStrategicSignal = STRATEGIC_PATTERNS.some((pattern) => pattern.test(contentText));
+  const hasNamedClient = cleanAntecedenteText(item.Cliente).length >= 3;
+  const hasSector = cleanAntecedenteText(item.Area || item.Unidad_de_negocio).length >= 3;
+  const hasDate = formatAntecedenteYear(item.Fecha) !== 'documentado';
+
+  if (hasDataError) return 'data-error-candidate';
+  if (hasLowValueSignal && !hasStrategicSignal) return 'low-value-candidate';
+  if (hasStrategicSignal && hasNamedClient && hasSector && hasDate && !issues.includes('confidential-client-in-title')) {
+    return 'strong-case';
+  }
+  return 'needs-editorial-review';
+}
+
+export function curateAntecedente<T extends Record<string, any>>(item: T): CuratedAntecedente<T> {
+  const issues = getAntecedenteIssues(item);
+  const quality = classifyAntecedente(item, issues);
+  const displayTitle = buildDisplayTitle(item);
+  const displayDescription = buildDisplayDescription(item, displayTitle);
+  const slug = generateSlug(cleanAntecedenteText(item.Titulo || item.Nombre || displayTitle));
+  const canonicalPath = `/antecedentes/${item.id}/${slug}`;
+  const curation: AntecedenteCuration = {
+    quality,
+    issues,
+    isPromotable: quality === 'strong-case',
+    displayTitle,
+    displayDescription,
+    displayYear: formatAntecedenteYear(item.Fecha),
+    canonicalPath,
+  };
+
+  return {
+    ...item,
+    curation,
+    displayTitle,
+    displayDescription,
+    displayYear: curation.displayYear,
+    canonicalPath,
+  };
+}
+
+export function isPromotableAntecedente(item: Record<string, any>): boolean {
+  return item?.curation?.isPromotable === true || curateAntecedente(item).curation.isPromotable;
+}
+
+export function sortAntecedentesForPublicList<T extends Record<string, any>>(items: T[]): CuratedAntecedente<T>[] {
+  return items
+    .map((item) => ('curation' in item ? item as CuratedAntecedente<T> : curateAntecedente(item)))
+    .sort((a, b) => {
+      const qualityDiff = QUALITY_RANK[a.curation.quality] - QUALITY_RANK[b.curation.quality];
+      if (qualityDiff !== 0) return qualityDiff;
+      const dateDiff = getDateTime(b.Fecha) - getDateTime(a.Fecha);
+      if (dateDiff !== 0) return dateDiff;
+      return Number(b.id || 0) - Number(a.id || 0);
+    });
+}
+
+export function buildAntecedenteListItemStructuredData(item: Record<string, any>, position: number) {
+  const curated = 'curation' in item ? item as CuratedAntecedente : curateAntecedente(item);
+  const imageUrl = publicImageUrl(curated.imageUrl || curated.Imagen || '');
+  const datePublished = formatAntecedenteDate(curated.Fecha) ? cleanAntecedenteText(curated.Fecha) : undefined;
+
+  return {
+    '@type': 'ListItem',
+    position,
+    url: canonicalUrl(curated.canonicalPath),
+    name: curated.displayTitle,
+    item: {
+      '@type': 'CreativeWork',
+      name: curated.displayTitle,
+      description: curated.displayDescription,
+      url: canonicalUrl(curated.canonicalPath),
+      image: imageUrl || undefined,
+      datePublished,
+      about: curated.Area ? { '@type': 'Thing', name: cleanAntecedenteText(curated.Area) } : undefined,
+      mentions: curated.Cliente ? [{ '@type': 'Organization', name: cleanAntecedenteText(curated.Cliente) }] : undefined,
+      identifier: curated.id ? `ANT-${curated.id}` : undefined,
+    },
+  };
+}

--- a/src/utils/antecedentesImageEvidence.ts
+++ b/src/utils/antecedentesImageEvidence.ts
@@ -12,6 +12,8 @@ interface SnapshotCase {
   Cliente?: string;
   Area?: string;
   Fecha?: string;
+  Imagen?: string | { id?: string; directus_files_id?: string } | null;
+  original_id?: number | string | null;
 }
 
 export interface AntecedenteImageEvidenceEntry {
@@ -32,10 +34,23 @@ function snapshotData<T>(snapshot: SnapshotRoot<T>): T[] {
 const antecedentes = snapshotData<SnapshotCase>(antecedentesSnapshot as SnapshotRoot<SnapshotCase>);
 const antecedentesById = new Map(antecedentes.map((item) => [Number(item.id), item]));
 const generatedMap = generatedAntecedenteImageMap as Record<string, string>;
+const directusImageVersion = '20260201';
 
 function cleanOptionalText(value: string | null | undefined): string | null {
   const normalized = String(value || '').replace(/\s+/g, ' ').trim();
   return normalized || null;
+}
+
+function getDirectusImageId(image: SnapshotCase['Imagen']): string {
+  if (!image) return '';
+  if (typeof image === 'string') return image;
+  return image.id || image.directus_files_id || '';
+}
+
+function getEvidenceImagePath(item: SnapshotCase): string {
+  const directusImageId = getDirectusImageId(item.Imagen);
+  if (directusImageId) return `/assets/${directusImageId}?v=${directusImageVersion}`;
+  return generatedMap[String(item.id)] || generatedMap[String(item.original_id || '')] || '';
 }
 
 export function getAntecedentesImageEvidenceEntries(): AntecedenteImageEvidenceEntry[] {
@@ -72,5 +87,66 @@ export function getAntecedentesImageEvidenceCoverage() {
     totalAntecedentes,
     missingGeneratedImages: Math.max(0, totalAntecedentes - entries.length),
     coverageRatio: Number(coverageRatio.toFixed(4)),
+  };
+}
+
+export function buildAntecedentesImageEvidenceEntries(items: SnapshotCase[]): AntecedenteImageEvidenceEntry[] {
+  return items
+    .map((item) => {
+      const id = Number(item.id);
+      const imagePath = getEvidenceImagePath(item);
+      const imageUrl = publicImageUrl(imagePath);
+
+      if (!Number.isFinite(id) || !item.Titulo || !imageUrl) return null;
+
+      return {
+        id,
+        title: item.Titulo,
+        pageUrl: canonicalUrl(`/antecedentes/${id}/${generateSlug(item.Titulo)}`),
+        imageUrl,
+        imagePath,
+        client: cleanOptionalText(item.Cliente),
+        sector: cleanOptionalText(item.Area),
+        date: cleanOptionalText(item.Fecha),
+      };
+    })
+    .filter((entry): entry is AntecedenteImageEvidenceEntry => Boolean(entry))
+    .sort((a, b) => a.id - b.id);
+}
+
+export function buildAntecedentesImageEvidenceCoverage(
+  entries: AntecedenteImageEvidenceEntry[],
+  totalAntecedentes: number,
+) {
+  const coverageRatio = totalAntecedentes > 0 ? entries.length / totalAntecedentes : 0;
+
+  return {
+    generatedImages: entries.length,
+    totalAntecedentes,
+    missingGeneratedImages: Math.max(0, totalAntecedentes - entries.length),
+    coverageRatio: Number(coverageRatio.toFixed(4)),
+  };
+}
+
+export async function getAntecedentesImageEvidenceEntriesFromDirectus(): Promise<AntecedenteImageEvidenceEntry[]> {
+  const { getAllAntecedentes } = await import('../lib/directus');
+  const items = await getAllAntecedentes();
+  return buildAntecedentesImageEvidenceEntries(items as SnapshotCase[]);
+}
+
+export async function getAntecedentesImageEvidenceCoverageFromDirectus() {
+  const { getAllAntecedentes } = await import('../lib/directus');
+  const items = await getAllAntecedentes();
+  const entries = buildAntecedentesImageEvidenceEntries(items as SnapshotCase[]);
+  return buildAntecedentesImageEvidenceCoverage(entries, items.length);
+}
+
+export async function getAntecedentesImageEvidenceDatasetFromDirectus() {
+  const { getAllAntecedentes } = await import('../lib/directus');
+  const items = await getAllAntecedentes();
+  const entries = buildAntecedentesImageEvidenceEntries(items as SnapshotCase[]);
+  return {
+    entries,
+    coverage: buildAntecedentesImageEvidenceCoverage(entries, items.length),
   };
 }

--- a/src/utils/replicaProdCopy.ts
+++ b/src/utils/replicaProdCopy.ts
@@ -7,7 +7,7 @@ type ProdCopyEntry = { status?: number; title?: string; h1?: string };
 export function isReplicaIdenticalCopy(): boolean {
   if (!isLocalProdReplica()) return false;
   const v =
-    import.meta.env?.UMSA_REPLICA_IDENTICAL ??
+    import.meta.env?.['UMSA_REPLICA_IDENTICAL'] ??
     (typeof process !== 'undefined' ? process.env['UMSA_REPLICA_IDENTICAL'] : undefined);
   if (v === '0' || v === 'false') return false;
   return true;

--- a/src/utils/sectoresHelpers.ts
+++ b/src/utils/sectoresHelpers.ts
@@ -87,8 +87,7 @@ function trimSectorSEO(sector: Sector): Sector {
 }
 
 /**
- * Obtiene antecedentes filtrados por keywords de un sector
- * Con fallback automático a snapshot de antecedentes
+ * Obtiene antecedentes filtrados por keywords de un sector desde Directus.
  */
 export async function getAntecedentesForSector(
   keywords: string[],
@@ -109,11 +108,11 @@ export async function getAntecedentesForSector(
     console.log(`[${sectorName.toUpperCase()}] Found ${filtered.length} antecedentes from Directus`);
     return filtered;
   } catch (error) {
-    console.error(`[${sectorName.toUpperCase()}] Error fetching from Directus, trying snapshot:`, error);
+    console.error(`[${sectorName.toUpperCase()}] Error fetching sector query from Directus, retrying shared Directus loader:`, error);
     try {
       const allAntecedentes = await getAllAntecedentes();
       const filtered = filterAntecedentesByKeywords(allAntecedentes as any[], keywords, limit);
-      console.log(`[${sectorName.toUpperCase()}] Found ${filtered.length} antecedentes from snapshot`);
+      console.log(`[${sectorName.toUpperCase()}] Found ${filtered.length} antecedentes from shared Directus loader`);
       return filtered;
     } catch {
       return [];


### PR DESCRIPTION
## Produccion
Despliega el pase de antecedentes/SEO/GEO ya validado y mergeado en develop.

## Alcance
- Antecedentes, singles, sitemaps y recursos GEO/LLM consumen Directus como fuente real.
- Imagenes de antecedentes publicadas por /assets/{uuid}?v=20260201, con cobertura 518/518 en preview.
- Curaduria deterministica para priorizar casos fuertes sin inventar clientes, titulos ni nombres propios artificiales.

## Validacion
- PR #97 a develop: PR Checks verdes.
- Local: typecheck, lint, audit:css, tests completos, build.
- Preview SSR con Directus real: /antecedentes 200, single canonico 200, sitemap antecedentes 518 URLs/518 imagenes, GEO image evidence 518/518.