### PR TITLE
fix: prioritize generated antecedente images

### DIFF
--- a/__tests__/antecedentesGeneratedImages.test.ts
+++ b/__tests__/antecedentesGeneratedImages.test.ts
@@ -51,4 +51,18 @@ describe('generated antecedentes image integration', () => {
     expect(detail).toContain('getGeneratedAntecedenteImageUrl(antecedente.id)');
     expect(sectors).toContain('getAntecedenteImageUrl(item)');
   });
+
+  test('generated case images win over legacy Directus assets on public surfaces', () => {
+    const directus = fs.readFileSync(path.join(repoRoot, 'src/lib/directus.ts'), 'utf8');
+    const evidence = fs.readFileSync(path.join(repoRoot, 'src/utils/antecedentesImageEvidence.ts'), 'utf8');
+    const detail = fs.readFileSync(path.join(repoRoot, 'src/pages/antecedentes/[id]/[slug].astro'), 'utf8');
+
+    expect(directus.indexOf('const generatedImage = getGeneratedAntecedenteImageUrl')).toBeLessThan(
+      directus.indexOf('const directusImageId = typeof item.Imagen'),
+    );
+    expect(evidence.indexOf('const generatedImage = generatedMap')).toBeLessThan(
+      evidence.indexOf('const directusImageId = getDirectusImageId'),
+    );
+    expect(detail).toContain('const mainImageUrl = generatedMainImageUrl');
+  });
 });

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -623,13 +623,14 @@ export function getAntecedenteImageUrl(
   item: { id?: string | number | null; original_id?: string | number | null; Imagen?: string | { id?: string; directus_files_id?: string } | null } | null | undefined
 ): string {
   if (!item) return '/images/default-background.jpg';
+  const generatedImage = getGeneratedAntecedenteImageUrl(item.id) || getGeneratedAntecedenteImageUrl(item.original_id);
+  if (generatedImage) return generatedImage;
+
   const directusImageId = typeof item.Imagen === 'object'
     ? item.Imagen?.id || item.Imagen?.directus_files_id
     : item.Imagen;
   const directusImage = getDirectusImageUrl(directusImageId);
   if (directusImage && !directusImage.includes('default-background')) return directusImage;
-  const generatedImage = getGeneratedAntecedenteImageUrl(item.id) || getGeneratedAntecedenteImageUrl(item.original_id);
-  if (generatedImage) return generatedImage;
   return '/images/default-background.jpg';
 }
 

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -92,12 +92,12 @@ if (!antecedente) return Astro.redirect('/404');
 
 antecedente = curateAntecedente(antecedente);
 
-// --- Prepare data for UI (Directus-first) ---
+// --- Prepare data for UI (generated-case image first, Directus as fallback) ---
 const directusMainImageUrl = getAssetUrl(antecedente.Imagen || antecedente.ImagenPrincipal);
 const generatedMainImageUrl = getGeneratedAntecedenteImageUrl(antecedente.id) || getGeneratedAntecedenteImageUrl(antecedente.original_id);
-const mainImageUrl = directusMainImageUrl && !directusMainImageUrl.includes('default-background')
-    ? directusMainImageUrl
-    : generatedMainImageUrl || DEFAULT_IMAGE_URL;
+const mainImageUrl = generatedMainImageUrl
+    || (directusMainImageUrl && !directusMainImageUrl.includes('default-background') ? directusMainImageUrl : '')
+    || DEFAULT_IMAGE_URL;
 
 const formatDate = (dateString: string): string => {
     const formatted = formatAntecedenteDate(dateString);

--- a/src/utils/antecedentesImageEvidence.ts
+++ b/src/utils/antecedentesImageEvidence.ts
@@ -48,9 +48,12 @@ function getDirectusImageId(image: SnapshotCase['Imagen']): string {
 }
 
 function getEvidenceImagePath(item: SnapshotCase): string {
+  const generatedImage = generatedMap[String(item.id)] || generatedMap[String(item.original_id || '')] || '';
+  if (generatedImage) return generatedImage;
+
   const directusImageId = getDirectusImageId(item.Imagen);
   if (directusImageId) return `/assets/${directusImageId}?v=${directusImageVersion}`;
-  return generatedMap[String(item.id)] || generatedMap[String(item.original_id || '')] || '';
+  return '';
 }
 
 export function getAntecedentesImageEvidenceEntries(): AntecedenteImageEvidenceEntry[] {


### PR DESCRIPTION
## Problema
Produccion estaba mostrando imagenes legacy de Directus en antecedentes, aunque las 518 imagenes generadas por SKILLIMAGENUM ya estaban publicadas.

## Causa
El ultimo pase dejo a `getAntecedenteImageUrl` y el dataset async de GEO priorizando `Imagen` de Directus sobre `src/data/antecedentes-generated-image-map.json`. Como Directus tenia UUIDs viejos, la web servia `/assets/{uuid}`.

## Fix
- Para antecedentes, la imagen generada aprobada por `id/original_id` gana siempre.
- Directus queda como fallback, no como fuente visual principal del antecedente.
- Single, OG/Twitter, JSON-LD, sitemap y GEO vuelven a usar `/images/antecedentes/generated/...webp`.
- Se agrega contrato para impedir regresion.

## Validacion
- npm test -- --runInBand __tests__/antecedentesGeneratedImages.test.ts __tests__/geoDiscoveryContracts.test.ts
- npm run typecheck
- npm run lint (0 errores)
- npm run audit:css
- npm run build
- npm test -- --runInBand (30 suites, 250 tests)
- Preview SSR con Directus real: single 3064 usa imagen generada en hero/OG/Twitter/JSON-LD; sitemap antecedentes 518 imagenes generadas y 0 /assets; GEO image-evidence 518 imagenes generadas y 0 /assets.