### PR TITLE
feat: upgrade antecedentes evidence experience

### DIFF
--- a/__tests__/antecedentesCuration.test.ts
+++ b/__tests__/antecedentesCuration.test.ts
@@ -26,8 +26,10 @@ describe('antecedentes curation', () => {
     const discoDuro = curateAntecedente(byId(3591));
 
     expect(softwareGobierno.curation.quality).toBe('strong-case');
+    expect(softwareGobierno.curation.recordLabel).toBe('Caso operativo');
     expect(isPromotableAntecedente(softwareGobierno)).toBe(true);
     expect(pcMonitor.curation.quality).toBe('low-value-candidate');
+    expect(pcMonitor.curation.recordLabel).toBe('Registro documental');
     expect(discoDuro.curation.quality).toBe('low-value-candidate');
     expect(isPromotableAntecedente(pcMonitor)).toBe(false);
   });

--- a/src/components/templates/AntecedentesTemplateEditorial.astro
+++ b/src/components/templates/AntecedentesTemplateEditorial.astro
@@ -47,6 +47,7 @@ const hasResults = totalItems > 0;
 const showingStart = archiveTotalItems === 0 ? 0 : ((currentPage - 1) * pageSize) + 1;
 const showingEnd = Math.min(currentPage * pageSize, archiveTotalItems);
 const hasActiveFilters = Boolean(sectorFilter || searchQuery || areaFilter || unidadFilter);
+const isLandingPage = Boolean(pageData.isLandingPage ?? (currentPage === 1 && !hasActiveFilters && spotlight.length > 0));
 const preservedSearchParams = Array.from(currentUrl.searchParams.entries()).filter(
   ([key]) => !['q', 'page', 'reset'].includes(key)
 );
@@ -82,12 +83,13 @@ const computePaginationPages = () => {
 
 const paginationPages = computePaginationPages();
 
-const cleanText = (value: unknown) => String(value || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
 const truncate = (value: unknown, length = 170) => truncateEditorialText(value, length);
 const projectHref = (item: any) => `/antecedentes/${item.slug}`;
 const projectTitle = (item: any) => item?.displayTitle || item?.Titulo || item?.Cliente || 'Antecedente UMSA';
 const projectDescription = (item: any) => item?.displayDescription || item?.Descripcion || item?.Titulo || '';
 const projectScope = (item: any) => item?.Area || item?.Unidad_de_negocio || 'Servicios IT';
+const projectRecordLabel = (item: any) => item?.curation?.recordLabel || 'Registro técnico';
+const projectRecordTone = (item: any) => item?.curation?.recordTone || 'technical-record';
 const projectYear = (item: any) => {
   if (item?.displayYear && item.displayYear !== 'Invalid Date') return item.displayYear;
   const raw = item?.Fecha || item?.fecha || item?.anio || item?.year;
@@ -98,44 +100,96 @@ const projectYear = (item: any) => {
   const year = String(raw).match(/\b(19\d{2}|20\d{2})\b/)?.[1];
   return year || 'documentado';
 };
+const heroImages = [
+  feature,
+  ...secondary,
+  ...archive,
+]
+  .filter((item: any) => item?.imageUrl)
+  .slice(0, 5);
+const archiveTitle = isLandingPage
+  ? 'Centro de evidencia operativa'
+  : currentPage > 1
+    ? `Archivo documental - página ${currentPage}`
+    : 'Archivo documental filtrado';
+const archiveText = isLandingPage
+  ? 'Lectura ejecutiva por cliente, alcance, sector y año para abrir cada dossier con contexto comercial claro.'
+  : 'Registros reales cargados desde Directus, con imagen asociada, cliente, sector, año y jerarquía documental.';
 ---
 
 <section class="ante-dossier">
-  <header class="ante-dossier__hero">
-    <div class="um-container ante-dossier__hero-grid">
-      <div class="ante-dossier__hero-copy">
-        <span class="ante-dossier__mark" aria-hidden="true"></span>
-        <h1>{antecedentesIndexH1}</h1>
-        <p>
-          Un archivo de proyectos reales para evaluar alcance, continuidad, criticidad y experiencia
-          en redes, seguridad electrónica, telecomunicaciones, software, soporte y energía para IT.
-        </p>
-        <div class="ante-dossier__actions">
-          <a href="#archivo-antecedentes">Ver archivo documental</a>
-          <a href="/contacto">Solicitar relevamiento</a>
+  {isLandingPage ? (
+    <header class="ante-dossier__hero">
+      <div class="um-container ante-dossier__hero-grid">
+        <div class="ante-dossier__hero-copy">
+          <span class="ante-dossier__mark" aria-hidden="true"></span>
+          <h1>{antecedentesIndexH1}</h1>
+          <p>
+            Un archivo de proyectos reales para evaluar alcance, continuidad, criticidad y experiencia
+            en redes, seguridad electrónica, telecomunicaciones, software, soporte y energía para IT.
+          </p>
+          <div class="ante-dossier__actions">
+            <a href="#archivo-antecedentes">Ver archivo documental</a>
+            <a href="/contacto">Solicitar relevamiento</a>
+          </div>
         </div>
-      </div>
 
-      <aside class="ante-dossier__proof" aria-label="Resumen de antecedentes">
+        <aside class="ante-dossier__hero-panel" aria-label="Resumen visual de antecedentes">
+          {heroImages.length > 0 && (
+            <div class="ante-dossier__image-wall" aria-label="Imágenes generadas de antecedentes documentados">
+              {heroImages.map((item: any, index: number) => (
+                <figure class={index === 0 ? 'is-main' : ''}>
+                  <img
+                    src={item.imageUrl}
+                    alt={item.Titulo || projectTitle(item)}
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                    decoding="async"
+                    onerror="this.src='/images/default.jpg'"
+                  />
+                </figure>
+              ))}
+            </div>
+          )}
+          <div class="ante-dossier__proof" aria-label="Resumen de antecedentes">
+            <div>
+              <span>Proyectos</span>
+              <strong>{institutionalProofShort}</strong>
+            </div>
+            <div>
+              <span>Trayectoria</span>
+              <strong>22+ años</strong>
+            </div>
+            <div>
+              <span>Sectores</span>
+              <strong>{Math.max(filterChips.length - 1, 0)} mercados</strong>
+            </div>
+            <div>
+              <span>Soporte</span>
+              <strong>24/7</strong>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </header>
+  ) : (
+    <header class="ante-dossier__archive-intro">
+      <div class="um-container ante-dossier__archive-intro-grid">
         <div>
-          <span>Proyectos</span>
-          <strong>{institutionalProofShort}</strong>
+          <span class="ante-dossier__mark" aria-hidden="true"></span>
+          <h1>{currentPage > 1 ? `Archivo documental de antecedentes. Página ${currentPage}.` : 'Archivo documental de antecedentes.'}</h1>
+          <p>
+            Registros reales cargados desde Directus, ordenados para consultar cliente, sector,
+            año, imagen asociada y calidad documental sin repetir la portada institucional.
+          </p>
         </div>
-        <div>
-          <span>Trayectoria</span>
-          <strong>22+ años</strong>
-        </div>
-        <div>
-          <span>Sectores</span>
-          <strong>{Math.max(filterChips.length - 1, 0)} mercados</strong>
-        </div>
-        <div>
-          <span>Soporte</span>
-          <strong>24/7</strong>
-        </div>
-      </aside>
-    </div>
-  </header>
+        <aside aria-label="Estado del archivo">
+          <span>{showingStart}-{showingEnd}</span>
+          <strong>{hasActiveFilters ? `${totalItems} coincidencias` : `${institutionalProofShort} registros`}</strong>
+          <em>{currentPage > 1 ? `Página ${currentPage} de ${totalPages}` : 'Vista filtrada'}</em>
+        </aside>
+      </div>
+    </header>
+  )}
 
   <section class="ante-dossier__controls" aria-label="Índice documental de antecedentes">
       <div class="um-container ante-dossier__controls-grid">
@@ -176,85 +230,87 @@ const projectYear = (item: any) => {
     </div>
   </nav>
 
-  <section class="um-container ante-dossier__evidence" aria-labelledby="evidencia-destacada">
-    <SectionHeader
-      id="evidencia-destacada"
-      class="ante-dossier__section-head"
-      title="Evidencia destacada"
-      text="Casos con contexto, alcance y metadata para entender la escala real del trabajo."
-    />
+  {isLandingPage && (
+    <section class="um-container ante-dossier__evidence" aria-labelledby="evidencia-destacada">
+      <SectionHeader
+        id="evidencia-destacada"
+        class="ante-dossier__section-head"
+        title="Evidencia destacada"
+        text="Casos con contexto, alcance y metadata para entender la escala real del trabajo."
+      />
 
-    {!hasResults ? (
-      <div class="ante-dossier__empty">
-        <h2>No se encontraron proyectos</h2>
-        <p>Probá con otro sector o una búsqueda más amplia dentro del archivo.</p>
-        <a href={buildClearUrl()}>Ver todos los proyectos</a>
-      </div>
-    ) : (
-      <>
-        {feature && (
-          <a href={projectHref(feature)} class="um-click-surface ante-dossier__feature">
-            <figure>
-              <img src={feature.imageUrl} alt={feature.Titulo || projectTitle(feature)} loading="eager" decoding="async" onerror="this.src='/images/default.jpg'" />
-            </figure>
-            <div class="ante-dossier__feature-body">
-              <span>Proyecto protagonista</span>
-              <h3>{projectTitle(feature)}</h3>
-              <p>{truncate(projectDescription(feature), 210)}</p>
-              <dl>
-                <div>
-                  <dt>Sector</dt>
-                  <dd>{projectScope(feature)}</dd>
-                </div>
-                <div>
-                  <dt>Cliente</dt>
-                  <dd>{feature.Cliente || `ANT-${feature.id}`}</dd>
-                </div>
-                <div>
-                  <dt>Año</dt>
-                  <dd>{projectYear(feature)}</dd>
-                </div>
-              </dl>
-              <strong>Ver dossier del proyecto</strong>
+      {!hasResults ? (
+        <div class="ante-dossier__empty">
+          <h2>No se encontraron proyectos</h2>
+          <p>Probá con otro sector o una búsqueda más amplia dentro del archivo.</p>
+          <a href={buildClearUrl()}>Ver todos los proyectos</a>
+        </div>
+      ) : (
+        <>
+          {feature && (
+            <a href={projectHref(feature)} class="um-click-surface ante-dossier__feature">
+              <figure>
+                <img src={feature.imageUrl} alt={feature.Titulo || projectTitle(feature)} loading="eager" decoding="async" onerror="this.src='/images/default.jpg'" />
+              </figure>
+              <div class="ante-dossier__feature-body">
+                <span>{projectRecordLabel(feature)}</span>
+                <h3>{projectTitle(feature)}</h3>
+                <p>{truncate(projectDescription(feature), 210)}</p>
+                <dl>
+                  <div>
+                    <dt>Sector</dt>
+                    <dd>{projectScope(feature)}</dd>
+                  </div>
+                  <div>
+                    <dt>Cliente</dt>
+                    <dd>{feature.Cliente || `ANT-${feature.id}`}</dd>
+                  </div>
+                  <div>
+                    <dt>Año</dt>
+                    <dd>{projectYear(feature)}</dd>
+                  </div>
+                </dl>
+                <strong>Ver dossier del proyecto</strong>
+              </div>
+            </a>
+          )}
+
+          {secondary.length > 0 && (
+            <div class="ante-dossier__secondary" aria-label="Casos secundarios">
+              {secondary.map((item: any) => (
+                <a href={projectHref(item)} class="um-click-surface ante-dossier__secondary-item">
+                  <figure>
+                    <img src={item.imageUrl} alt={item.Titulo || projectTitle(item)} loading="lazy" decoding="async" onerror="this.src='/images/default.jpg'" />
+                  </figure>
+                  <div>
+                    <span>{projectRecordLabel(item)}</span>
+                    <h3>{projectTitle(item)}</h3>
+                    <p>{truncate(projectDescription(item), 128)}</p>
+                    <dl>
+                      <div>
+                        <dt>Sector</dt>
+                        <dd>{projectScope(item)}</dd>
+                      </div>
+                      <div>
+                        <dt>Año</dt>
+                        <dd>{projectYear(item)}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </a>
+              ))}
             </div>
-          </a>
-        )}
-
-        {secondary.length > 0 && (
-          <div class="ante-dossier__secondary" aria-label="Casos secundarios">
-            {secondary.map((item: any, index: number) => (
-              <a href={projectHref(item)} class="um-click-surface ante-dossier__secondary-item">
-                <figure>
-                  <img src={item.imageUrl} alt={item.Titulo || projectTitle(item)} loading="lazy" decoding="async" onerror="this.src='/images/default.jpg'" />
-                </figure>
-                <div>
-                  <span>{String(index + 2).padStart(2, '0')}</span>
-                  <h3>{projectTitle(item)}</h3>
-                  <p>{truncate(projectDescription(item), 128)}</p>
-                  <dl>
-                    <div>
-                      <dt>Sector</dt>
-                      <dd>{projectScope(item)}</dd>
-                    </div>
-                    <div>
-                      <dt>Año</dt>
-                      <dd>{projectYear(item)}</dd>
-                    </div>
-                  </dl>
-                </div>
-              </a>
-            ))}
-          </div>
-        )}
-      </>
-    )}
-  </section>
+          )}
+        </>
+      )}
+    </section>
+  )}
 
   {archive.length > 0 && (
     <section class="um-container ante-dossier__archive" id="archivo-antecedentes" aria-labelledby="archivo-antecedentes-title">
       <div class="ante-dossier__archive-head">
-        <h2 id="archivo-antecedentes-title">Centro de evidencia operativa</h2>
-        <p>Lectura ejecutiva por cliente, alcance, sector y año para abrir cada dossier con contexto comercial claro.</p>
+        <h2 id="archivo-antecedentes-title">{archiveTitle}</h2>
+        <p>{archiveText}</p>
       </div>
 
       <div class="ante-dossier__ledger antecedentes-list">
@@ -275,6 +331,8 @@ const projectYear = (item: any) => {
             sector={projectScope(item)}
             year={projectYear(item)}
             imageLoading={index < 6 ? 'eager' : 'lazy'}
+            eyebrow={projectRecordLabel(item)}
+            recordTone={projectRecordTone(item)}
             metrics={extractCaseMetricsFromAntecedente(item)}
           />
         ))}
@@ -323,7 +381,7 @@ const projectYear = (item: any) => {
 
   .ante-dossier__hero-grid {
     display: grid;
-    grid-template-columns: minmax(0, 0.64fr) minmax(320px, 0.36fr);
+    grid-template-columns: minmax(0, 0.54fr) minmax(360px, 0.46fr);
     gap: clamp(30px, 6vw, 86px);
     align-items: center;
   }
@@ -412,6 +470,42 @@ const projectYear = (item: any) => {
     text-decoration-color: currentColor;
   }
 
+  .ante-dossier__hero-panel {
+    display: grid;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .ante-dossier__image-wall {
+    display: grid;
+    grid-template-columns: minmax(160px, 1.25fr) repeat(2, minmax(90px, 0.75fr));
+    grid-template-rows: repeat(2, minmax(118px, 1fr));
+    gap: 8px;
+    height: clamp(260px, 25vw, 344px);
+    min-width: 0;
+    background: #0b0b0b;
+  }
+
+  .ante-dossier__image-wall figure {
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    overflow: hidden;
+    background: #111;
+  }
+
+  .ante-dossier__image-wall figure.is-main {
+    grid-row: 1 / span 2;
+  }
+
+  .ante-dossier__image-wall img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(0.9) contrast(1.04);
+  }
+
   .ante-dossier__proof {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -443,6 +537,69 @@ const projectYear = (item: any) => {
     font-weight: var(--um-weight-title, 600);
     line-height: 1.04;
     text-wrap: balance;
+  }
+
+  .ante-dossier__archive-intro {
+    background: #fff;
+    padding: clamp(28px, 4.6vw, 58px) 0 clamp(10px, 2vw, 20px);
+  }
+
+  .ante-dossier__archive-intro-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.68fr) minmax(260px, 0.32fr);
+    gap: clamp(24px, 5vw, 72px);
+    align-items: end;
+  }
+
+  .ante-dossier__archive-intro h1 {
+    max-width: 760px;
+    margin-top: clamp(14px, 2vw, 20px);
+    color: var(--ante-text);
+    font-family: var(--um-font-display);
+    font-size: clamp(2.05rem, 2.45vw, 2.65rem);
+    font-weight: var(--um-weight-title, 600);
+    line-height: 1.1;
+    letter-spacing: 0;
+    text-wrap: balance;
+  }
+
+  .ante-dossier__archive-intro p {
+    max-width: 780px;
+    margin-top: 12px;
+    color: var(--ante-muted);
+    font-size: clamp(1.0625rem, 1.1vw, 1.1875rem);
+    line-height: 1.64;
+  }
+
+  .ante-dossier__archive-intro aside {
+    display: grid;
+    justify-items: start;
+    border-left: 3px solid var(--um-red);
+    padding-left: clamp(18px, 2.2vw, 28px);
+  }
+
+  .ante-dossier__archive-intro aside span {
+    color: var(--um-red);
+    font-family: var(--um-font-display);
+    font-size: clamp(1.55rem, 2vw, 2rem);
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .ante-dossier__archive-intro aside strong,
+  .ante-dossier__archive-intro aside em {
+    display: block;
+    margin-top: 8px;
+    color: #111;
+    font-size: 1.0625rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 1.35;
+  }
+
+  .ante-dossier__archive-intro aside em {
+    color: var(--ante-muted);
+    font-weight: 600;
   }
 
   .ante-dossier__controls {
@@ -1125,6 +1282,7 @@ const projectYear = (item: any) => {
 
   @media (max-width: 1080px) {
     .ante-dossier__hero-grid,
+    .ante-dossier__archive-intro-grid,
     .ante-dossier__feature,
     .ante-dossier__secondary-item {
       grid-template-columns: 1fr;
@@ -1171,6 +1329,7 @@ const projectYear = (item: any) => {
     }
 
     .ante-dossier__hero-grid,
+    .ante-dossier__archive-intro-grid,
     .ante-dossier__controls-grid,
     .ante-dossier__section-head,
     .ante-dossier__archive-head,
@@ -1183,6 +1342,23 @@ const projectYear = (item: any) => {
       font-size: clamp(2rem, 7.2vw, 2.32rem);
       line-height: 1.12;
       text-wrap: pretty;
+    }
+
+    .ante-dossier__image-wall {
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: auto auto;
+      height: auto;
+    }
+
+    .ante-dossier__image-wall figure {
+      min-height: 132px;
+      aspect-ratio: 4 / 3;
+    }
+
+    .ante-dossier__image-wall figure.is-main {
+      grid-column: 1 / -1;
+      grid-row: auto;
+      aspect-ratio: 16 / 9;
     }
 
     .ante-dossier__proof {
@@ -1348,6 +1524,16 @@ const projectYear = (item: any) => {
       font-size: clamp(2rem, 6.9vw, 2.18rem);
       line-height: 1.14;
       text-wrap: pretty;
+    }
+
+    .ante-dossier__archive-intro h1 {
+      max-width: 100%;
+      font-size: clamp(1.82rem, 6.4vw, 2.08rem);
+    }
+
+    .ante-dossier__archive-intro aside {
+      border-left-width: 2px;
+      padding-left: 16px;
     }
 
     .ante-dossier__row-number {

--- a/src/components/um/EvidenceCaseRow.astro
+++ b/src/components/um/EvidenceCaseRow.astro
@@ -10,6 +10,8 @@ interface Props {
   year?: string;
   actionLabel?: string;
   imageLoading?: 'lazy' | 'eager';
+  eyebrow?: string;
+  recordTone?: 'case' | 'technical-record' | 'documentary-record' | 'editorial-review';
   /** KPIs opcionales (B1) — solo se muestran si hay datos reales */
   metrics?: Array<{ value: string; label: string }>;
 }
@@ -25,6 +27,8 @@ const {
   year = '—',
   actionLabel = 'Detalle',
   imageLoading = 'lazy',
+  eyebrow = '',
+  recordTone = 'case',
   metrics = [],
 } = Astro.props;
 
@@ -41,6 +45,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
     <span class="evidence-case-row__thumb evidence-case-row__thumb--empty" aria-hidden="true"></span>
   )}
   <div class="evidence-case-row__copy">
+    {eyebrow && <span class:list={['evidence-case-row__eyebrow', `is-${recordTone}`]}>{eyebrow}</span>}
     <h3>{title}</h3>
     {description && <p>{description}</p>}
     {visibleMetrics.length > 0 && (
@@ -129,6 +134,37 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 
   .evidence-case-row__copy {
     min-width: 0;
+  }
+
+  .evidence-case-row__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    margin-bottom: 8px;
+    color: #4b5563;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .evidence-case-row__eyebrow::before {
+    content: "";
+    width: 18px;
+    height: 2px;
+    background: currentColor;
+  }
+
+  .evidence-case-row__eyebrow.is-case {
+    color: var(--um-red);
+  }
+
+  .evidence-case-row__eyebrow.is-documentary-record,
+  .evidence-case-row__eyebrow.is-technical-record {
+    color: #6b7280;
+  }
+
+  .evidence-case-row__eyebrow.is-editorial-review {
+    color: #92400e;
   }
 
   .evidence-case-row h3 {

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -91,6 +91,9 @@ try {
 if (!antecedente) return Astro.redirect('/404');
 
 antecedente = curateAntecedente(antecedente);
+const caseRecordLabel = antecedente.curation?.recordLabel || 'Registro técnico';
+const caseRecordTone = antecedente.curation?.recordTone || 'technical-record';
+const caseRecordSummary = antecedente.curation?.recordSummary || 'Antecedente real cargado desde Directus.';
 
 // --- Prepare data for UI (generated-case image first, Directus as fallback) ---
 const directusMainImageUrl = getAssetUrl(antecedente.Imagen || antecedente.ImagenPrincipal);
@@ -294,7 +297,16 @@ const buildCaseHeadline = (item: any): string => {
 const caseHeadlineSource = isReplicaIdenticalCopy()
   ? resolveReplicaH1(Astro.url.pathname, cleanDisplayText(antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre))
   : cleanDisplayText(antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre);
-const caseHeadline = buildCaseHeadline({ ...antecedente, Titulo: caseHeadlineSource });
+const baseCaseHeadline = buildCaseHeadline({ ...antecedente, Titulo: caseHeadlineSource });
+const caseHeadline = (() => {
+  if (antecedente.curation?.quality === 'low-value-candidate') {
+    return `Registro documental: ${baseCaseHeadline}`;
+  }
+  if (antecedente.curation?.quality === 'data-error-candidate') {
+    return `Registro técnico en revisión: ${baseCaseHeadline}`;
+  }
+  return baseCaseHeadline;
+})();
 const compactCaseTitle = (value: unknown, client?: unknown): string => {
   const title = cleanDisplayText(value)
     .replace(/Sistena/gi, 'Sistema')
@@ -329,6 +341,13 @@ const caseSeo = buildCaseSeoMeta({
 });
 const metaDescription = caseSeo.description;
 const structuredImageUrl = publicImageUrl(mainImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL);
+const caseDossierFacts = [
+  { label: 'Registro', value: `ANT-${id}` },
+  { label: 'Tipo', value: caseRecordLabel },
+  antecedente.Cliente ? { label: 'Organización', value: cleanDisplayText(antecedente.Cliente) } : null,
+  antecedente.Area ? { label: 'Vertical', value: cleanDisplayText(antecedente.Area) } : null,
+  caseDateLabel ? { label: 'Fecha', value: caseDateLabel } : null,
+].filter(Boolean) as Array<{ label: string; value: string }>;
 const caseStrategicLinkGroups = buildCaseStrategicLinkGroups({
   currentPath: `/antecedentes/${id}/${slugFromUrl}`,
   title: caseHeadline,
@@ -355,6 +374,7 @@ const antecedenteStructuredData = {
   },
   "datePublished": caseDatePublished,
   "inLanguage": "es-AR",
+  "genre": caseRecordLabel,
   "about": antecedente.Area ? { "@type": "Thing", "name": cleanDisplayText(antecedente.Area) } : undefined,
   "mentions": antecedente.Cliente ? [{ "@type": "Organization", "name": cleanDisplayText(antecedente.Cliente) }] : undefined,
   "identifier": `ANT-${id}`,
@@ -388,12 +408,6 @@ const antecedentePageStructuredData = [
   structuredData={antecedentePageStructuredData}
 >
   <section class="case-detail-hero">
-    <img
-      src={mainImageUrl}
-      alt={antecedente.Titulo}
-      class="case-detail-hero__image"
-      onerror="this.src='/images/default-background.jpg'"
-    />
     <div class="case-detail-hero__wash"></div>
 
     <div class="um-container case-detail-hero__content">
@@ -407,7 +421,7 @@ const antecedentePageStructuredData = [
 
       <div class="case-detail-hero__grid">
         <div class="case-detail-hero__copy">
-          <div class="case-detail-label">
+          <div class:list={['case-detail-label', `is-${caseRecordTone}`]}>
             <span>{antecedente.Area || 'Proyecto'}</span>
           </div>
 
@@ -437,8 +451,9 @@ const antecedentePageStructuredData = [
             />
           </figure>
           <div class="case-detail-dossier__body">
-            <span>Dossier del proyecto</span>
+            <span>{caseRecordLabel}</span>
             <strong>{antecedente.Cliente || `ANT-${id}`}</strong>
+            <p>{caseRecordSummary}</p>
             <div class="case-detail-meta">
               {antecedente.Area && (
                 <div>
@@ -463,6 +478,17 @@ const antecedentePageStructuredData = [
     </div>
   </section>
 
+  <section class="case-proof-strip" aria-label="Ficha rápida del antecedente">
+    <div class="um-container case-proof-strip__grid">
+      {caseDossierFacts.map((fact) => (
+        <div>
+          <span>{fact.label}</span>
+          <strong>{fact.value}</strong>
+        </div>
+      ))}
+    </div>
+  </section>
+
   <!-- CONTENT SECTION -->
   <section class="case-detail-main case-detail">
     <div class="um-container case-detail-main__grid">
@@ -473,7 +499,7 @@ const antecedentePageStructuredData = [
         <div class="flex flex-col gap-4 sm:gap-5">
           <div class="case-section-title">
             <span aria-hidden="true"></span>
-            <h2>Contexto y ejecución</h2>
+            <h2>Lectura del antecedente</h2>
           </div>
           <div class="case-detail-body__copy editorial-body">
             {caseDescriptionHtml ? (
@@ -495,7 +521,7 @@ const antecedentePageStructuredData = [
           <div class="flex flex-col gap-4 sm:gap-5">
             <div class="case-section-title">
               <span aria-hidden="true"></span>
-              <h2>Alcance ejecutado</h2>
+              <h2>Alcance documentado</h2>
             </div>
             <ul class="case-scope-list">
               {scopeItems.map((item) => (
@@ -540,6 +566,13 @@ const antecedentePageStructuredData = [
             <a href="/servicios" class="um-click-surface case-service-cards__all">Ver todos los servicios</a>
           </div>
         )}
+
+        <aside class="case-source-note" aria-label="Fuente documental">
+          <span>Fuente documental</span>
+          <p>
+            Datos del antecedente cargados en Directus. Imagen única asociada al registro público ANT-{id}.
+          </p>
+        </aside>
 
         <!-- Gallery (if has additional images from Directus) -->
         {antecedente.Imagenes && antecedente.Imagenes.length > 0 && (
@@ -614,6 +647,11 @@ const antecedentePageStructuredData = [
                 </div>
               </>
             )}
+            <div class="h-px bg-gray-100"></div>
+            <div class="flex flex-col gap-1">
+              <span class="case-info-label">Jerarquía</span>
+              <span class="case-info-value">{caseRecordLabel}</span>
+            </div>
             <div class="h-px bg-gray-100"></div>
             <div class="flex flex-col gap-1">
               <span class="case-info-label">Código Proyecto</span>
@@ -730,6 +768,7 @@ const antecedentePageStructuredData = [
 <style>
   /* Escala editorial única — detalle antecedente (cuerpo 18px, sección ~1.11×) */
   .case-detail-hero,
+  .case-proof-strip,
   .case-detail-main.case-detail,
   .case-related,
   .case-detail-footer-cta {
@@ -753,25 +792,16 @@ const antecedentePageStructuredData = [
     color: #111;
   }
 
-  .case-detail-hero__image,
   .case-detail-hero__wash {
     position: absolute;
     inset: 0;
   }
 
-  .case-detail-hero__image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: center;
-    opacity: 0.1;
-    filter: grayscale(0.18) saturate(0.9) contrast(1.05);
-  }
-
   .case-detail-hero__wash {
     background:
-      linear-gradient(90deg, #fff 0%, rgba(255,255,255,0.96) 48%, rgba(255,255,255,0.74) 100%),
-      linear-gradient(0deg, #fff 0%, rgba(255,255,255,0.48) 72%);
+      linear-gradient(90deg, #fff 0%, rgba(255,255,255,0.98) 52%, rgba(255,255,255,0.9) 100%),
+      linear-gradient(135deg, rgba(220,38,38,0.08) 0 1px, transparent 1px 32px),
+      linear-gradient(0deg, #fff 0%, rgba(255,255,255,0.72) 72%);
   }
 
   .case-detail-hero__content {
@@ -827,6 +857,24 @@ const antecedentePageStructuredData = [
     width: 34px;
     height: 2px;
     background: #DC2626;
+  }
+
+  .case-detail-label.is-documentary-record,
+  .case-detail-label.is-technical-record {
+    color: #4b5563 !important;
+  }
+
+  .case-detail-label.is-documentary-record::before,
+  .case-detail-label.is-technical-record::before {
+    background: #6b7280;
+  }
+
+  .case-detail-label.is-editorial-review {
+    color: #92400e !important;
+  }
+
+  .case-detail-label.is-editorial-review::before {
+    background: #92400e;
   }
 
   .case-detail-hero__copy h1 {
@@ -922,6 +970,13 @@ const antecedentePageStructuredData = [
     text-wrap: balance;
   }
 
+  .case-detail-dossier__body > p {
+    margin: 0.75rem 0 0;
+    color: #4b5563;
+    font-size: 1rem;
+    line-height: 1.58;
+  }
+
   .case-detail-meta {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -957,6 +1012,46 @@ const antecedentePageStructuredData = [
     line-height: 1.35;
     overflow-wrap: anywhere;
     text-transform: none;
+  }
+
+  .case-proof-strip {
+    background: #0b0b0b;
+    color: #fff;
+    border-top: 1px solid rgba(255,255,255,0.08);
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+
+  .case-proof-strip__grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 1px;
+    background: rgba(255,255,255,0.1);
+  }
+
+  .case-proof-strip__grid div {
+    min-width: 0;
+    background: #0b0b0b;
+    padding: clamp(16px, 2vw, 22px) clamp(14px, 1.8vw, 20px);
+  }
+
+  .case-proof-strip__grid span {
+    display: block;
+    color: rgba(255,255,255,0.66);
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .case-proof-strip__grid strong {
+    display: block;
+    margin-top: 8px;
+    color: #fff;
+    font-size: clamp(1.02rem, 1.12vw, 1.16rem);
+    font-weight: 700;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
   }
 
   .case-detail-main {
@@ -1040,6 +1135,29 @@ const antecedentePageStructuredData = [
     font-size: var(--case-body);
     font-weight: 600;
     line-height: 1.45;
+  }
+
+  .case-source-note {
+    border-left: 3px solid #DC2626;
+    background: #f7f8f9;
+    padding: 1.1rem 1.2rem;
+  }
+
+  .case-source-note span {
+    display: block;
+    color: #111;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .case-source-note p {
+    margin: 0.55rem 0 0;
+    color: #4b5563;
+    font-size: var(--case-body);
+    line-height: 1.62;
   }
 
   .case-scope-list {
@@ -1501,6 +1619,10 @@ const antecedentePageStructuredData = [
     .case-detail-side {
       position: static;
     }
+
+    .case-proof-strip__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 
   @media (max-width: 640px) {
@@ -1558,6 +1680,10 @@ const antecedentePageStructuredData = [
     }
 
     .case-detail-meta {
+      grid-template-columns: 1fr;
+    }
+
+    .case-proof-strip__grid {
       grid-template-columns: 1fr;
     }
   }

--- a/src/pages/antecedentes/index.astro
+++ b/src/pages/antecedentes/index.astro
@@ -171,7 +171,9 @@ try {
   let spotlightAntecedentes;
   let archivePool;
 
-  if (pageData.currentPage === 1 && !hasActiveFilters) {
+  const isLandingPage = pageData.currentPage === 1 && !hasActiveFilters;
+
+  if (isLandingPage) {
     const promotableAntecedentes = filteredAntecedentes.filter(isPromotableAntecedente);
     const spotlightSource = promotableAntecedentes.length > 0 ? promotableAntecedentes : filteredAntecedentes;
     featuredAntecedente = pickProtagonistAntecedente(spotlightSource);
@@ -184,8 +186,8 @@ try {
     const spotlightIds = new Set(spotlightAntecedentes.map((item) => item.id));
     archivePool = filteredAntecedentes.filter((item) => !spotlightIds.has(item.id));
   } else {
-    spotlightAntecedentes = filteredAntecedentes.slice(0, 3);
-    archivePool = filteredAntecedentes.slice(3);
+    spotlightAntecedentes = [];
+    archivePool = filteredAntecedentes;
   }
 
   const archiveStartIndex = (pageData.currentPage - 1) * PAGE_SIZE;
@@ -199,6 +201,8 @@ try {
     catalogTotalItems: allAntecedentes.length,
     archiveTotalItems: archivePool.length,
     totalPages: Math.max(1, Math.ceil(archivePool.length / PAGE_SIZE)),
+    hasActiveFilters,
+    isLandingPage,
     error: null,
     isLoading: false
   };
@@ -209,6 +213,8 @@ try {
     antecedentes: [],
     spotlightAntecedentes: [],
     archiveTotalItems: 0,
+    hasActiveFilters: false,
+    isLandingPage: false,
     error: 'Error loading projects',
     isLoading: false
   };
@@ -233,11 +239,56 @@ const filterChips = [
   { id: 'software', name: 'Software', icon: 'code' },
 ];
 
+const hasActiveArchiveFilters = Boolean(searchQuery || areaFilter || unidadFilter || sectorFilter);
+const activeSectorName = sectorFilter
+  ? filterChips.find((chip) => chip.id === sectorFilter)?.name || ''
+  : '';
+const isSearchResultPage = Boolean(searchQuery);
+
+const buildCanonicalPageUrl = (page: number) => {
+  const params = new URLSearchParams();
+  if (!isSearchResultPage) {
+    if (sectorFilter) params.set('sector', sectorFilter);
+    if (areaFilter) params.set('area', areaFilter);
+    if (unidadFilter) params.set('unidad_negocio', unidadFilter);
+  }
+  if (page > 1) params.set('page', String(page));
+  const query = params.toString();
+  return canonicalUrl(`/antecedentes${query ? `?${query}` : ''}`);
+};
+
+const currentCanonicalUrl = isSearchResultPage
+  ? canonicalUrl('/antecedentes')
+  : buildCanonicalPageUrl(pageData.currentPage);
+const previousPageUrl = !isSearchResultPage && pageData.currentPage > 1
+  ? buildCanonicalPageUrl(pageData.currentPage - 1)
+  : '';
+const nextPageUrl = !isSearchResultPage && pageData.currentPage < pageData.totalPages
+  ? buildCanonicalPageUrl(pageData.currentPage + 1)
+  : '';
+
+const pageTitle = pageData.currentPage > 1
+  ? `Archivo de antecedentes - página ${pageData.currentPage} | ULTIMA MILLA`
+  : activeSectorName
+    ? `Antecedentes en ${activeSectorName} | ULTIMA MILLA`
+    : hasActiveArchiveFilters
+      ? 'Archivo filtrado de antecedentes | ULTIMA MILLA'
+      : 'Evidencia operativa documentada | ULTIMA MILLA';
+
+const pageDescription = pageData.currentPage > 1
+  ? `Archivo documental de antecedentes técnicos de ULTIMA MILLA, página ${pageData.currentPage}: registros reales con cliente, sector, fecha e imagen asociada.`
+  : activeSectorName
+    ? `Antecedentes técnicos de ULTIMA MILLA relacionados con ${activeSectorName}: casos y registros reales con cliente, sector, fecha e imagen.`
+    : hasActiveArchiveFilters
+      ? 'Archivo filtrado de antecedentes técnicos de ULTIMA MILLA con registros reales, cliente, sector, fecha e imagen asociada.'
+      : 'Antecedentes técnicos de ULTIMA MILLA: proyectos reales de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.';
+
 const templateVariant = getDevTemplateVariant(Astro.url, import.meta.env.DEV) ?? 'editorial';
 const visibleAntecedentes = [
   ...(pageData.spotlightAntecedentes || []),
   ...(pageData.antecedentes || []),
 ].slice(0, 6);
+const pageOgImage = visibleAntecedentes.find((item: any) => item.imageUrl)?.imageUrl || '/nosotros-tech.jpg';
 const crawlableAntecedenteIndex = allAntecedentesForIndex
   .map((item) => ({
     id: item.id,
@@ -258,36 +309,47 @@ const antecedentesStrategicLinkGroups = buildCaseStrategicLinkGroups({
   })),
 });
 const antecedentesStructuredData = buildStrategicWebPageStructuredData({
-  url: 'https://www.ultimamilla.com.ar/antecedentes',
-  name: 'Evidencia operativa documentada',
-  description: 'Antecedentes técnicos de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.',
+  url: currentCanonicalUrl,
+  name: pageTitle.replace(/\s+\|\s+ULTIMA MILLA$/, ''),
+  description: pageDescription,
   groups: antecedentesStrategicLinkGroups,
 });
+const structuredPageItems = [
+  ...(pageData.spotlightAntecedentes || []),
+  ...(pageData.antecedentes || []),
+];
+const structuredPositionOffset = pageData.currentPage > 1 ? (pageData.currentPage - 1) * PAGE_SIZE : 0;
 const antecedentesCollectionStructuredData = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
-  name: 'Evidencia operativa documentada',
-  description: 'Archivo curado de antecedentes técnicos de ULTIMA MILLA con cliente, sector, fecha, imagen asociada y enlace canónico.',
-  url: canonicalUrl('/antecedentes'),
+  name: pageTitle.replace(/\s+\|\s+ULTIMA MILLA$/, ''),
+  description: pageDescription,
+  url: currentCanonicalUrl,
   inLanguage: 'es-AR',
   mainEntity: {
     '@type': 'ItemList',
     numberOfItems: allAntecedentesForIndex.length,
     itemListOrder: 'https://schema.org/ItemListOrderDescending',
-    itemListElement: allAntecedentesForIndex
-      .filter(isPromotableAntecedente)
-      .slice(0, 48)
-      .map((item, index) => buildAntecedenteListItemStructuredData(item, index + 1)),
+    itemListElement: structuredPageItems
+      .slice(0, 24)
+      .map((item, index) => buildAntecedenteListItemStructuredData(item, structuredPositionOffset + index + 1)),
   },
 };
 ---
 
 <LayoutV4
-  title="Evidencia operativa documentada | ULTIMA MILLA"
-  description="Antecedentes técnicos de ULTIMA MILLA: proyectos reales de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT."
+  title={pageTitle}
+  description={pageDescription}
   keywords="casos exito tecnologia mendoza, proyectos telecomunicaciones, antecedentes cableado estructurado, portfolio seguridad electronica, software a medida casos"
+  image={pageOgImage}
+  canonical={currentCanonicalUrl}
+  noindex={isSearchResultPage}
   structuredData={[antecedentesStructuredData, antecedentesCollectionStructuredData]}
 >
+  <Fragment slot="head">
+    {previousPageUrl && <link rel="prev" href={previousPageUrl} />}
+    {nextPageUrl && <link rel="next" href={nextPageUrl} />}
+  </Fragment>
   {templateVariant === 'atlas' && (
     <AntecedentesTemplateAtlas
       pageData={pageData}

--- a/src/utils/antecedentesCuration.ts
+++ b/src/utils/antecedentesCuration.ts
@@ -7,10 +7,19 @@ export type AntecedenteQuality =
   | 'low-value-candidate'
   | 'data-error-candidate';
 
+export type AntecedenteRecordTone =
+  | 'case'
+  | 'technical-record'
+  | 'documentary-record'
+  | 'editorial-review';
+
 export interface AntecedenteCuration {
   quality: AntecedenteQuality;
   issues: string[];
   isPromotable: boolean;
+  recordTone: AntecedenteRecordTone;
+  recordLabel: string;
+  recordSummary: string;
   displayTitle: string;
   displayDescription: string;
   displayYear: string;
@@ -104,10 +113,48 @@ function fixKnownTextErrors(value: string): string {
     .replace(/\bTecnica\b/g, 'Técnica')
     .replace(/\btelefonico\b/g, 'telefónico')
     .replace(/\bTelefonico\b/g, 'Telefónico')
+    .replace(/\bprovision\b/g, 'provisión')
+    .replace(/\bProvision\b/g, 'Provisión')
     .replace(/\bAmpliacion\b/g, 'Ampliación')
     .replace(/\bampliacion\b/g, 'ampliación')
     .replace(/\bmodulo\b/g, 'módulo')
     .replace(/\bModulo\b/g, 'Módulo');
+}
+
+export function getAntecedenteRecordTone(quality: AntecedenteQuality): {
+  tone: AntecedenteRecordTone;
+  label: string;
+  summary: string;
+} {
+  if (quality === 'strong-case') {
+    return {
+      tone: 'case',
+      label: 'Caso operativo',
+      summary: 'Antecedente con cliente, sector, fecha y alcance suficientes para lectura comercial.',
+    };
+  }
+
+  if (quality === 'low-value-candidate') {
+    return {
+      tone: 'documentary-record',
+      label: 'Registro documental',
+      summary: 'Registro real de provisión o intervención menor; se muestra sin sobredimensionar su alcance.',
+    };
+  }
+
+  if (quality === 'data-error-candidate') {
+    return {
+      tone: 'editorial-review',
+      label: 'Revisión editorial',
+      summary: 'Registro real con señal de error o truncamiento en el dato fuente; requiere revisión en CMS.',
+    };
+  }
+
+  return {
+    tone: 'technical-record',
+    label: 'Registro técnico',
+    summary: 'Antecedente real con información útil, pero sin profundidad completa de caso estratégico.',
+  };
 }
 
 function uniqueIssues(issues: string[]): string[] {
@@ -242,6 +289,7 @@ function classifyAntecedente(item: Record<string, any>, issues: string[]): Antec
 export function curateAntecedente<T extends Record<string, any>>(item: T): CuratedAntecedente<T> {
   const issues = getAntecedenteIssues(item);
   const quality = classifyAntecedente(item, issues);
+  const recordTone = getAntecedenteRecordTone(quality);
   const displayTitle = buildDisplayTitle(item);
   const displayDescription = buildDisplayDescription(item, displayTitle);
   const slug = generateSlug(cleanAntecedenteText(item.Titulo || item.Nombre || displayTitle));
@@ -250,6 +298,9 @@ export function curateAntecedente<T extends Record<string, any>>(item: T): Curat
     quality,
     issues,
     isPromotable: quality === 'strong-case',
+    recordTone: recordTone.tone,
+    recordLabel: recordTone.label,
+    recordSummary: recordTone.summary,
     displayTitle,
     displayDescription,
     displayYear: formatAntecedenteYear(item.Fecha),


### PR DESCRIPTION
Deploy-safe update for /antecedentes and case single pages.\n\nScope:\n- Editorial archive behavior for pagination and filters\n- Honest record classification for weak/strong antecedentes\n- Improved single dossier UI and structured metadata\n- Page-specific canonical/title/description/prev-next SEO\n\nValidation:\n- npm run typecheck\n- npm run lint (0 errors, inherited warnings only)\n- npm run audit:css\n- npm run build\n- npm test -- --runInBand (30 suites, 250 tests)