### PR TITLE
fix: publish mapped service product images

### DIFF
--- a/__tests__/cctvAiProductContract.test.js
+++ b/__tests__/cctvAiProductContract.test.js
@@ -51,6 +51,19 @@ describe('CCTV AI product contract', () => {
     expect(fs.existsSync(path.join(root, 'public', imagePath))).toBe(true);
   });
 
+  test('directus image resolver prefers mapped public product assets before private /assets URLs', () => {
+    const directusSource = fs.readFileSync(path.join(root, 'src/lib/directus.ts'), 'utf8');
+    const mapLookupIndex = directusSource.indexOf('const localPath = imageLocalMap[imageId]');
+    const assetsFallbackIndex = directusSource.indexOf('return `/assets/${imageId}?v=${IMAGE_CACHE_VERSION}`');
+    const imageMap = require('../src/data/image-local-map.json');
+
+    expect(mapLookupIndex).toBeGreaterThan(-1);
+    expect(assetsFallbackIndex).toBeGreaterThan(-1);
+    expect(mapLookupIndex).toBeLessThan(assetsFallbackIndex);
+    expect(imageMap['07007b33-b8bd-4647-be53-ad7c97ef3ca6']).toBe('/images/services/productos/seguridad/2.1.png');
+    expect(fs.existsSync(path.join(root, 'public', imageMap['07007b33-b8bd-4647-be53-ad7c97ef3ca6']))).toBe(true);
+  });
+
   test('surfaces Producto on the services index', () => {
     const source = fs.readFileSync(path.join(root, 'src/pages/servicios/index.astro'), 'utf8');
 

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -537,8 +537,8 @@ export type { ServicioV4, ProductoV4, AntecedenteV4, AntecedenteServicioRelation
  * Convierte un UUID de imagen de Directus a URL utilizable.
  *
  * Estrategia:
- * 1. Si Directus disponible → /assets/{uuid} (Nginx proxy, 518 imágenes únicas)
- * 2. Si Directus caído → fallback a imagen local mapeada (image-local-map.json)
+ * 1. Si existe copia pública local mapeada → usarla (servicios, productos, hero)
+ * 2. Si no está mapeada y Directus disponible → /assets/{uuid} (Nginx proxy)
  *
  * El mapa local se genera con: node scripts/generate-image-map.mjs
  */
@@ -582,15 +582,16 @@ export function getDirectusImageUrl(imageId: string | null | undefined): string 
     return '';
   }
 
-  // Prioridad 1: Directus /assets/ en runtime público.
-  if (directusAssetsAvailable) {
-    return `/assets/${imageId}?v=${IMAGE_CACHE_VERSION}`;
-  }
-
-  // Prioridad 2: fallback local si Directus no disponible
+  // Prioridad 1: copia pública local cuando existe.
+  // Productos/servicios tienen UUIDs privados en Directus; /assets puede responder 403 en producción.
   const localPath = imageLocalMap[imageId];
   if (localPath) {
     return localPath;
+  }
+
+  // Prioridad 2: Directus /assets/ en runtime público cuando no hay copia local.
+  if (directusAssetsAvailable) {
+    return `/assets/${imageId}?v=${IMAGE_CACHE_VERSION}`;
   }
 
   // Réplica: convención pública de prod (/uploads/antecedentes/{uuid}.jpg)


### PR DESCRIPTION
## Qué pasa a producción
- Corrige el resolver de imágenes para priorizar assets públicos mapeados antes de usar /assets/{uuid}.
- Repara las imágenes de productos del servicio 102 que en producción resolvían a UUIDs privados con HTTP 403.
- Agrega test contractual para bloquear regresión.

## Verificación
- PR #103 hacia develop: CI completo exitoso.
- Local: npm test -- --runInBand.
- Local: npm run build.
- Preview SSR de /servicios/102/... emite /images/services/productos/seguridad/2.1.png a 2.8.png y /images/services/productos/cctv-ai/cctv-ai-forense-telefono.webp.
- Assets públicos principales responden HTTP 200.