### PR TITLE
fix: remove internal source note from case pages

### DIFF
--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -583,13 +583,6 @@ const antecedentePageStructuredData = [
           </div>
         )}
 
-        <aside class="case-source-note" aria-label="Fuente documental">
-          <span>Fuente documental</span>
-          <p>
-            Datos del antecedente cargados en Directus. Imagen única asociada al registro público ANT-{id}.
-          </p>
-        </aside>
-
         <!-- Gallery (if has additional images from Directus) -->
         {antecedente.Imagenes && antecedente.Imagenes.length > 0 && (
           <div class="flex flex-col gap-4 sm:gap-5">
@@ -1157,29 +1150,6 @@ const antecedentePageStructuredData = [
     font-size: var(--case-body);
     font-weight: 600;
     line-height: 1.45;
-  }
-
-  .case-source-note {
-    border-left: 3px solid #DC2626;
-    background: #f7f8f9;
-    padding: 1.1rem 1.2rem;
-  }
-
-  .case-source-note span {
-    display: block;
-    color: #111;
-    font-size: 1rem;
-    font-weight: 700;
-    line-height: 1.3;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  .case-source-note p {
-    margin: 0.55rem 0 0;
-    color: #4b5563;
-    font-size: var(--case-body);
-    line-height: 1.62;
   }
 
   .case-scope-list {


### PR DESCRIPTION
## Summary
- Removes the public 'Fuente documental' block from antecedente detail pages.
- Removes the unused CSS for that block.

## Why
The block exposed internal CMS/source wording ('Directus', 'ANT-*') as visible marketing copy. It was template text, not a Directus field.

## Validation
- npx eslint src/pages/antecedentes/[id]/[slug].astro
- npm run build
- rg confirms the visible source-note copy no longer exists in the template