### PR TITLE
fix: remove internal CMS copy from public surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -202,7 +202,7 @@ White Dossier queda como prototipo principal de mayo 2026 para validar una web d
 - Negro tecnico queda reservado para aperturas criticas, footers, modulos de capacidad o casos protagonistas; no debe ocupar todos los listados.
 - Rojo UMSA se usa como separador, numero, foco activo, flecha o CTA. Quedan prohibidos banners rojos repetidos sobre miniaturas.
 - Servicios se resuelven como dossier: indice compacto de 8 frentes, modulo de criterio operativo, prueba institucional y paquetes comprables sin precios.
-- Antecedentes se resuelven como evidencia: caso protagonista visible temprano, dos secundarios, archivo documental y filtros livianos.
+- Antecedentes se resuelven como evidencia: caso protagonista visible temprano, dos secundarios, archivo tecnico y filtros livianos.
 - Sectores se resuelven como mapa de capacidad: fotos + necesidad operativa + servicios aplicados, no cards apretadas ni overlays iguales.
 - Blog se resuelve como archivo tecnico premium: cada nota usa su `imagen_portada` como miniatura y como imagen destacada; las categorias son sobrias y la lectura queda subordinada al sistema UMSA.
 - Contacto se resuelve como puerta directa: cuatro campos visibles (`nombre`, `email`, `empresa`, `mensaje`), sin selects comerciales ni captcha visible. El antispam corre en segundo plano con honeypot, tiempo minimo, limite de links, validacion de longitud y rate limit.
@@ -324,7 +324,7 @@ Regla operacional: ningun texto visible del sitio publico debe quedar debajo de 
 
 Se agregan dos variantes comparables, solo para desarrollo local:
 
-- `?template=editorial`: composicion editorial con protagonistas, secundarios y archivo documental.
+- `?template=editorial`: composicion editorial con protagonistas, secundarios y archivo tecnico.
 - `?template=atlas`: indice tecnico mas denso, pensado como mapa industrial de evidencia.
 
 Rutas de prueba:

--- a/__tests__/antecedentesCuration.test.ts
+++ b/__tests__/antecedentesCuration.test.ts
@@ -29,7 +29,7 @@ describe('antecedentes curation', () => {
     expect(softwareGobierno.curation.recordLabel).toBe('Caso operativo');
     expect(isPromotableAntecedente(softwareGobierno)).toBe(true);
     expect(pcMonitor.curation.quality).toBe('low-value-candidate');
-    expect(pcMonitor.curation.recordLabel).toBe('Registro documental');
+    expect(pcMonitor.curation.recordLabel).toBe('Proyecto técnico');
     expect(discoDuro.curation.quality).toBe('low-value-candidate');
     expect(isPromotableAntecedente(pcMonitor)).toBe(false);
   });
@@ -52,8 +52,8 @@ describe('antecedentes curation', () => {
     const sorted = sortAntecedentesForPublicList(antecedentes);
 
     expect(sorted.slice(0, 12).every((item) => item.curation.quality === 'strong-case')).toBe(true);
-    expect(formatAntecedenteYear('Invalid Date')).toBe('documentado');
-    expect(formatAntecedenteYear('')).toBe('documentado');
+    expect(formatAntecedenteYear('Invalid Date')).toBe('sin fecha');
+    expect(formatAntecedenteYear('')).toBe('sin fecha');
   });
 
   test('GEO cases prefer curated strong evidence over weak inventory records', () => {

--- a/__tests__/contactModalContract.test.js
+++ b/__tests__/contactModalContract.test.js
@@ -62,6 +62,8 @@ describe('global contact modal contract', () => {
 
     expect(page).toContain('Enviar por email');
     expect(page).toContain('buildFallbackMailto(data = {})');
-    expect(page).toContain('mailto:contacto@ultimamilla.com.ar');
+    expect(page).toContain("['contacto', 'ultimamilla.com.ar'].join('@')");
+    expect(page).toContain("['mai', 'lto:'].join('')");
+    expect(page).not.toContain('mailto:contacto@ultimamilla.com.ar');
   });
 });

--- a/__tests__/visualInformationHubContracts.test.js
+++ b/__tests__/visualInformationHubContracts.test.js
@@ -83,8 +83,8 @@ describe('Information hub visual contracts', () => {
     expect(antecedentesEditorial).toMatch(/\.ante-dossier__sector-rail\s*\{[\s\S]*overflow:\s*hidden;/);
     expect(antecedentesEditorial).toMatch(/\.ante-dossier__sector-rail\s*\{[\s\S]*mask-image:\s*linear-gradient\(90deg,\s*#000 0,\s*#000 calc\(100% - 42px\),\s*transparent 100%\)/);
     expect(antecedentesEditorial).toMatch(/\.ante-dossier__sector-links\s*\{[\s\S]*padding-right:\s*clamp\(32px,\s*5vw,\s*72px\);/);
-    expect(antecedentesEditorial).toMatch(/mask-image:\s*linear-gradient\(90deg,\s*transparent 0,\s*#000 14px,\s*#000 calc\(100% - 28px\),\s*transparent 100%\)/);
-    expect(antecedentesEditorial).toMatch(/window\.matchMedia\('\(max-width: 720px\)'\)\.matches \? 'start' : 'nearest'/);
+    expect(antecedentesEditorial).toMatch(/\.ante-dossier__sector-links\s*\{[\s\S]*overscroll-behavior-inline:\s*contain;/);
+    expect(antecedentesEditorial).toMatch(/rail\.scrollLeft\s*=\s*Math\.max\(0,\s*targetLeft\);/);
   });
 
   test('row hover treatment stays calm and does not add red rails or layout drift', () => {
@@ -191,7 +191,7 @@ describe('Information hub visual contracts', () => {
 
     expect(source).toContain('crawlableAntecedenteIndex');
     expect(source).toContain('Índice completo de antecedentes');
-    expect(source).toContain('Todos los antecedentes documentados');
+    expect(source).toContain('Todos los antecedentes técnicos');
     expect(source).toContain('href={item.href}');
   });
 
@@ -200,7 +200,7 @@ describe('Information hub visual contracts', () => {
     const rowBlock = cssBlock(evidenceRow, '.evidence-case-row');
     const titleBlock = cssBlock(evidenceRow, '.evidence-case-row h3');
 
-    expect(rowBlock).toMatch(/grid-template-columns:\s*3rem 136px minmax\(220px,\s*1fr\) minmax\(148px,\s*0\.45fr\) auto;/);
+    expect(rowBlock).toMatch(/grid-template-columns:\s*3rem minmax\(156px,\s*0\.2fr\) minmax\(240px,\s*1fr\) minmax\(160px,\s*0\.34fr\) auto;/);
     expect(titleBlock).toMatch(/overflow-wrap:\s*normal;/);
     expect(titleBlock).toMatch(/word-break:\s*normal;/);
     expect(titleBlock).toMatch(/hyphens:\s*none;/);
@@ -408,7 +408,7 @@ describe('Information hub visual contracts', () => {
     expect(serviceDetail).toContain('class="service-info-ledger"');
     expect(serviceDetail).not.toContain('<SectionHeader kicker="Ficha técnica" title={sidebarInfoTitle} />');
     expect(cssBlock(serviceDetail, '.service-info-card--dossier')).toMatch(/padding:\s*0;/);
-    expect(cssBlock(serviceDetail, '.service-info-ledger div')).toMatch(/grid-template-columns:\s*minmax\(116px,\s*0\.44fr\) minmax\(0,\s*0\.56fr\);/);
+    expect(cssBlock(serviceDetail, '.service-info-ledger div')).toMatch(/grid-template-columns:\s*minmax\(148px,\s*0\.48fr\) minmax\(0,\s*0\.52fr\);/);
     expect(serviceDetail).toMatch(/:global\(\.service-info-primary\)[\s\S]*width:\s*100%;/);
     expect(serviceDetail).toMatch(/\.service-info-secondary\s*\{[\s\S]*background:\s*transparent;/);
   });

--- a/docs/BLOG_API.md
+++ b/docs/BLOG_API.md
@@ -52,7 +52,7 @@ Content-Type: application/json
 ```json
 { "error": "Campos requeridos: titulo, resumen, contenido" }
 { "error": "Unauthorized" }
-{ "error": "Directus error", "detail": "..." }
+{ "error": "No se pudo completar la publicacion", "detail": "..." }
 ```
 
 ---

--- a/docs/ENTREGA-UMSA-WHITE-DOSSIER.md
+++ b/docs/ENTREGA-UMSA-WHITE-DOSSIER.md
@@ -37,7 +37,7 @@ El rediseño **híbrido ejecutivo** UMSA (hero oscuro acotado + cuerpo editorial
 | `/antecedentes` | 200 | Dossier + `EvidenceCaseRow` |
 | `/nosotros` | 200 | Claro; timeline institucional; fotos reales |
 | `/contacto` | 200 | Claro; proofline 24/7; CTAs por intención |
-| `/blog` | 200 | Tokens UMSA; archivo documental |
+| `/blog` | 200 | Tokens UMSA; archivo tecnico |
 | `/aeropuertos` | 200 | Hero acotado; cuerpo editorial blanco |
 | `/bodegas` | 200 | Idem |
 | `/gobiernosectorpublico` | 200 | Idem |

--- a/docs/UI_WORLD_CLASS_GOAL.md
+++ b/docs/UI_WORLD_CLASS_GOAL.md
@@ -1,0 +1,122 @@
+# UMSA World-Class UI Hardening
+
+Fecha: 2026-06-13
+
+## Objetivo
+
+Convertir la UI publica de ULTIMA MILLA en una interfaz premium de proveedor IT internacional: sobria, tecnica, consistente, rapida de leer y libre de lenguaje interno de CMS, fallback o administracion.
+
+La meta no es decorar. La meta es que cada ruta critica comunique en menos de 30 segundos:
+
+- que problema operativo resuelve UMSA;
+- con que capacidad tecnica;
+- con que evidencia real;
+- cual es el siguiente paso comercial.
+
+## Rutas Criticas
+
+| Prioridad | Ruta | Criterio principal |
+|---|---|---|
+| P0 | `/` | Primer viewport con posicionamiento, imagen premium y CTA claro. |
+| P0 | `/servicios` | Ocho frentes escaneables, sin filtros innecesarios ni cards genericas. |
+| P0 | `/servicios/[id]/[slug]` | Ficha tecnica, alcance, metodo, evidencia y CTA por intencion. |
+| P0 | `/antecedentes` | Evidencia real con jerarquia, imagenes nitidas y filtros sobrios. |
+| P0 | `/antecedentes/[id]/[slug]` | Sin codigos internos visibles, sin lenguaje CMS, con ficha tecnica limpia. |
+| P0 | `/contacto` | Formulario directo, tolerante, con alternativa de correo visible ante error. |
+| P1 | `/nosotros` | Relato institucional serio, imagenes no genericas y prueba operativa. |
+| P1 | `/sectores` y verticales | Mapa de riesgo/capacidad, sin tono consumer ni decoracion por color. |
+| P1 | `/blog` y notas | Producto editorial tecnico alineado al sistema UMSA. |
+| P1 | `/geo/*`, `llms*.txt`, sitemaps | SEO/GEO estable, sin errores publicos con nombres internos de infraestructura. |
+
+## No Negociables
+
+- No puede haber texto visible de fuente interna, datos de carga, registro administrativo, archivo de backend, codigos internos o equivalentes.
+- El CMS puede ser fuente de datos, pero nunca parte del lenguaje publico.
+- Ninguna imagen principal puede verse pixelada, pobre, estirada o decorativa sin funcion.
+- Texto visible minimo: 16px en body, labels, metadata, filtros, botones y tabs.
+- Radius maximo habitual: 8px. Sin cards dentro de cards.
+- Rojo UMSA exacto: `#DC2626`; no variantes de rojo como acento de marca.
+- Sin emojis, gradientes decorativos, overlays rojos repetidos ni estetica SaaS generica.
+- Mobile no puede tener overflow horizontal, solapamientos ni CTAs partidos.
+
+## Fases
+
+### Fase 1: Limpieza de Lenguaje Publico
+
+- Buscar y bloquear lenguaje interno en `src/pages`, `src/components`, `src/data`, `src/utils` y docs operativos.
+- Sanitizar fallbacks que puedan venir de datos pobres.
+- Reemplazar respuestas publicas de error por mensajes de contenido/servicio, sin nombrar infraestructura interna.
+
+### Fase 2: QA Visual por Ruta
+
+- Capturas desktop `1440x900`, laptop `1280x800`, tablet `834x1112`, mobile `390x900`.
+- Revisar primer viewport, alineacion, jerarquia, imagen, CTA, filtros, cards y formularios.
+- Registrar cada hallazgo con ruta, viewport, componente y fix esperado.
+
+### Fase 3: Sistema UI Compartido
+
+- Consolidar botones, metricas, fichas tecnicas, headers de seccion y cards.
+- Eliminar patrones duplicados que generan desalineacion entre home, servicios, antecedentes y sectores.
+- Usar tokens UMSA desde `src/styles/v4.css` y respetar `DESIGN.md`.
+
+### Fase 4: Imagenes y Evidencia
+
+- Auditar portada, `/nosotros`, `/sectores`, servicios y antecedentes.
+- Reemplazar imagenes pobres por assets nitidos, con aspect ratio estable y funcion editorial.
+- Validar `src`, `srcset` o fallbacks para que produccion no degrade a placeholders.
+
+### Fase 5: SEO/GEO y CMS Pleno
+
+- Mantener canonicals, JSON-LD, sitemaps, `llms.txt`, `llms-full.txt` y recursos GEO.
+- Verificar que los datos del CMS alimenten la UI sin exponer nombres internos.
+- Fallbacks solo como continuidad operativa, nunca como copy publico pobre.
+
+### Fase 6: Gate de Produccion
+
+- `npm run lint`
+- `npm test`
+- `npm run build`
+- `npm run audit:css`
+- `npm run audit:visual`
+- Smoke local de rutas P0.
+- Deploy solo por Git Flow: feature -> develop -> master via GitHub Actions.
+
+## Criterios de Aceptacion
+
+Una ruta queda aprobada solo si cumple todo esto:
+
+- HTTP 200 local y, tras deploy, HTTP 200 en produccion.
+- Sin texto interno visible ni en HTML renderizado de rutas P0.
+- Sin imagen rota, pixelada o con placeholder visible.
+- Un solo H1 real y jerarquia estable.
+- CTA primario visible en rutas comerciales.
+- Sin overflow horizontal en 390px, 768px y 1440px.
+- Contraste AA en texto normal y controles.
+- Build y lint sin errores.
+
+## Comandos de Control
+
+```bash
+rg -n -i "<patron-de-lenguaje-interno>" src/pages src/components src/data src/utils
+npm run lint
+npm test
+npm run build
+npm run audit:css
+npm run audit:visual
+```
+
+## Primer Sprint Recomendado
+
+Ejecutar un fix pack sobre:
+
+- `/`
+- `/antecedentes`
+- `/antecedentes/3067/mantenimiento-critico-de-sistemas-de-deteccion-torre-thays`
+- `/servicios`
+- una single de servicio critica
+- `/contacto`
+- `/nosotros`
+- `/sectores`
+- tres verticales de sector con mas valor comercial
+
+Salida esperada: PR unico de hardening visual con capturas, checklist de rutas y pruebas reproducibles.

--- a/src/components/templates/AntecedentesTemplateEditorial.astro
+++ b/src/components/templates/AntecedentesTemplateEditorial.astro
@@ -1,12 +1,16 @@
 ---
 import EvidenceCaseRow from '../um/EvidenceCaseRow.astro';
 import SectionHeader from '../um/SectionHeader.astro';
-import { truncateEditorialText } from '../../utils/editorialContent';
+import {
+  applyDisplayNameReplacements,
+  formatDisplayName,
+  truncateEditorialText,
+} from '../../utils/editorialContent';
 import { resolveReplicaH1 } from '../../utils/replicaProdCopy';
 import { extractCaseMetricsFromAntecedente } from '../../utils/caseMetrics';
 
 const antecedentesPath = `${Astro.url.pathname}${Astro.url.search}`;
-const antecedentesIndexH1 = resolveReplicaH1(antecedentesPath, 'Evidencia operativa documentada.');
+const antecedentesIndexH1 = resolveReplicaH1(antecedentesPath, 'Evidencia operativa real.');
 
 interface Props {
   pageData: any;
@@ -85,20 +89,31 @@ const paginationPages = computePaginationPages();
 
 const truncate = (value: unknown, length = 170) => truncateEditorialText(value, length);
 const projectHref = (item: any) => `/antecedentes/${item.slug}`;
-const projectTitle = (item: any) => item?.displayTitle || item?.Titulo || item?.Cliente || 'Antecedente UMSA';
-const projectDescription = (item: any) => item?.displayDescription || item?.Descripcion || item?.Titulo || '';
+const projectTitle = (item: any) =>
+  applyDisplayNameReplacements(item?.displayTitle || item?.Titulo || item?.Cliente || 'Antecedente UMSA', [item?.Cliente]);
+const projectDescription = (item: any) =>
+  applyDisplayNameReplacements(item?.displayDescription || item?.Descripcion || item?.Titulo || '', [item?.Cliente]);
 const projectScope = (item: any) => item?.Area || item?.Unidad_de_negocio || 'Servicios IT';
-const projectRecordLabel = (item: any) => item?.curation?.recordLabel || 'Registro técnico';
+const projectClient = (item: any) => formatDisplayName(item?.Cliente) || 'Proyecto UMSA';
+const publicRecordLabel = (value: unknown) => {
+  const label = String(value || '')
+    .replace(/\bRegistro\s+[\p{L}]+\b/giu, 'Proyecto técnico')
+    .replace(/\bRegistro\b/gi, 'Proyecto')
+    .replace(/\bDoc[\p{L}]*\b/giu, 'Técnico')
+    .trim();
+  return label || 'Proyecto técnico';
+};
+const projectRecordLabel = (item: any) => publicRecordLabel(item?.curation?.recordLabel);
 const projectRecordTone = (item: any) => item?.curation?.recordTone || 'technical-record';
 const projectYear = (item: any) => {
   if (item?.displayYear && item.displayYear !== 'Invalid Date') return item.displayYear;
   const raw = item?.Fecha || item?.fecha || item?.anio || item?.year;
-  if (!raw) return 'documentado';
-  if (/invalid date/i.test(String(raw))) return 'documentado';
+  if (!raw) return 'sin fecha';
+  if (/invalid date/i.test(String(raw))) return 'sin fecha';
   const date = new Date(raw);
   if (!Number.isNaN(date.getTime())) return String(date.getFullYear());
   const year = String(raw).match(/\b(19\d{2}|20\d{2})\b/)?.[1];
-  return year || 'documentado';
+  return year || 'sin fecha';
 };
 const heroImages = [
   feature,
@@ -110,11 +125,11 @@ const heroImages = [
 const archiveTitle = isLandingPage
   ? 'Centro de evidencia operativa'
   : currentPage > 1
-    ? `Archivo documental - página ${currentPage}`
-    : 'Archivo documental filtrado';
+    ? `Proyectos técnicos - página ${currentPage}`
+    : 'Proyectos técnicos filtrados';
 const archiveText = isLandingPage
   ? 'Lectura ejecutiva por cliente, alcance, sector y año para abrir cada dossier con contexto comercial claro.'
-  : 'Registros reales cargados desde Directus, con imagen asociada, cliente, sector, año y jerarquía documental.';
+  : 'Proyectos reales de ULTIMA MILLA, ordenados por cliente, sector, año e imagen asociada.';
 ---
 
 <section class="ante-dossier">
@@ -129,14 +144,14 @@ const archiveText = isLandingPage
             en redes, seguridad electrónica, telecomunicaciones, software, soporte y energía para IT.
           </p>
           <div class="ante-dossier__actions">
-            <a href="#archivo-antecedentes">Ver archivo documental</a>
+            <a href="#archivo-antecedentes">Ver proyectos</a>
             <a href="/contacto">Solicitar relevamiento</a>
           </div>
         </div>
 
         <aside class="ante-dossier__hero-panel" aria-label="Resumen visual de antecedentes">
           {heroImages.length > 0 && (
-            <div class="ante-dossier__image-wall" aria-label="Imágenes generadas de antecedentes documentados">
+            <div class="ante-dossier__image-wall" aria-label="Imágenes de antecedentes técnicos">
               {heroImages.map((item: any, index: number) => (
                 <figure class={index === 0 ? 'is-main' : ''}>
                   <img
@@ -176,35 +191,35 @@ const archiveText = isLandingPage
       <div class="um-container ante-dossier__archive-intro-grid">
         <div>
           <span class="ante-dossier__mark" aria-hidden="true"></span>
-          <h1>{currentPage > 1 ? `Archivo documental de antecedentes. Página ${currentPage}.` : 'Archivo documental de antecedentes.'}</h1>
+          <h1>{currentPage > 1 ? `Antecedentes técnicos. Página ${currentPage}.` : 'Antecedentes técnicos.'}</h1>
           <p>
-            Registros reales cargados desde Directus, ordenados para consultar cliente, sector,
-            año, imagen asociada y calidad documental sin repetir la portada institucional.
+            Proyectos reales de ULTIMA MILLA, ordenados para consultar cliente, sector,
+            año e imagen asociada sin repetir la portada institucional.
           </p>
         </div>
         <aside aria-label="Estado del archivo">
           <span>{showingStart}-{showingEnd}</span>
-          <strong>{hasActiveFilters ? `${totalItems} coincidencias` : `${institutionalProofShort} registros`}</strong>
+          <strong>{hasActiveFilters ? `${totalItems} coincidencias` : `${institutionalProofShort} proyectos`}</strong>
           <em>{currentPage > 1 ? `Página ${currentPage} de ${totalPages}` : 'Vista filtrada'}</em>
         </aside>
       </div>
     </header>
   )}
 
-  <section class="ante-dossier__controls" aria-label="Índice documental de antecedentes">
+  <section class="ante-dossier__controls" aria-label="Índice de antecedentes técnicos">
       <div class="um-container ante-dossier__controls-grid">
         <div class="ante-dossier__range">
           <strong>{showingStart}-{showingEnd}</strong>
           <span>
             {hasActiveFilters
-              ? `de ${totalItems} coincidencias en archivo`
-              : `de ${institutionalProofShort} en archivo`}
+              ? `de ${totalItems} coincidencias`
+              : `de ${institutionalProofShort} proyectos`}
           </span>
         </div>
 
       <form method="get" action="/antecedentes" class="ante-dossier__search">
         {preservedSearchParams.map(([key, value]) => <input type="hidden" name={key} value={value} />)}
-        <label for="ante-dossier-search">Afinar archivo</label>
+        <label for="ante-dossier-search">Afinar búsqueda</label>
         <div>
           <input id="ante-dossier-search" type="search" name="q" value={searchQuery} placeholder="Cliente o alcance" />
           <button type="submit">Buscar</button>
@@ -263,14 +278,14 @@ const archiveText = isLandingPage
                   </div>
                   <div>
                     <dt>Cliente</dt>
-                    <dd>{feature.Cliente || `ANT-${feature.id}`}</dd>
+                    <dd>{projectClient(feature)}</dd>
                   </div>
                   <div>
                     <dt>Año</dt>
                     <dd>{projectYear(feature)}</dd>
                   </div>
                 </dl>
-                <strong>Ver dossier del proyecto</strong>
+                <strong>Ver proyecto</strong>
               </div>
             </a>
           )}
@@ -307,7 +322,7 @@ const archiveText = isLandingPage
   )}
 
   {archive.length > 0 && (
-    <section class="um-container ante-dossier__archive" id="archivo-antecedentes" aria-labelledby="archivo-antecedentes-title">
+    <section class="um-container ante-dossier__archive ante-dossier__archive--compact" id="archivo-antecedentes" aria-labelledby="archivo-antecedentes-title">
       <div class="ante-dossier__archive-head">
         <h2 id="archivo-antecedentes-title">{archiveTitle}</h2>
         <p>{archiveText}</p>
@@ -336,6 +351,23 @@ const archiveText = isLandingPage
             metrics={extractCaseMetricsFromAntecedente(item)}
           />
         ))}
+      </div>
+    </section>
+  )}
+
+  {archive.length === 0 && !isLandingPage && (
+    <section class="um-container ante-dossier__archive ante-dossier__archive--empty" id="archivo-antecedentes" aria-labelledby="archivo-antecedentes-title">
+      <div class="ante-dossier__empty ante-dossier__empty--archive">
+        <span class="ante-dossier__mark" aria-hidden="true"></span>
+        <h2 id="archivo-antecedentes-title">Vista temporalmente sin proyectos visibles</h2>
+        <p>
+          El índice no pudo cargar antecedentes para esta vista. Podés volver al listado completo
+          o pedir un relevamiento técnico con contexto de sector y alcance.
+        </p>
+        <div class="ante-dossier__empty-actions">
+          <a href="/antecedentes">Reintentar listado</a>
+          <a href="/contacto">Solicitar relevamiento</a>
+        </div>
       </div>
     </section>
   )}
@@ -376,14 +408,14 @@ const archiveText = isLandingPage
   .ante-dossier__hero {
     background: var(--ante-section);
     border-bottom: 0;
-    padding: clamp(28px, 3.8vw, 48px) 0 clamp(20px, 2.7vw, 30px);
+    padding: clamp(28px, 3.4vw, 46px) 0 clamp(22px, 2.8vw, 34px);
   }
 
   .ante-dossier__hero-grid {
     display: grid;
     grid-template-columns: minmax(0, 0.54fr) minmax(360px, 0.46fr);
-    gap: clamp(30px, 6vw, 86px);
-    align-items: center;
+    gap: clamp(28px, 5vw, 68px);
+    align-items: start;
   }
 
   .ante-dossier__hero-copy {
@@ -481,9 +513,11 @@ const archiveText = isLandingPage
     grid-template-columns: minmax(160px, 1.25fr) repeat(2, minmax(90px, 0.75fr));
     grid-template-rows: repeat(2, minmax(118px, 1fr));
     gap: 8px;
-    height: clamp(260px, 25vw, 344px);
+    height: clamp(240px, 22vw, 310px);
     min-width: 0;
+    border-radius: 6px;
     background: #0b0b0b;
+    box-shadow: 0 18px 46px rgba(15, 23, 42, 0.1);
   }
 
   .ante-dossier__image-wall figure {
@@ -509,15 +543,18 @@ const archiveText = isLandingPage
   .ante-dossier__proof {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0;
+    gap: 10px;
     background: transparent;
     color: var(--ante-text);
   }
 
   .ante-dossier__proof div {
     min-width: 0;
-    padding: clamp(15px, 2vw, 22px);
-    background: #fff;
+    padding: clamp(13px, 1.6vw, 18px);
+    border-left: 3px solid var(--um-red);
+    border-radius: 4px;
+    background: var(--ante-page);
+    box-shadow: 0 10px 26px rgba(15, 23, 42, 0.045);
   }
 
   .ante-dossier__proof span {
@@ -618,8 +655,8 @@ const archiveText = isLandingPage
     grid-template-columns: minmax(180px, 0.28fr) minmax(320px, 0.72fr);
     gap: clamp(18px, 4vw, 56px);
     align-items: center;
-    padding-top: 14px;
-    padding-bottom: 10px;
+    padding-top: clamp(16px, 2vw, 24px);
+    padding-bottom: clamp(14px, 1.8vw, 20px);
   }
 
   .ante-dossier__range strong {
@@ -722,8 +759,8 @@ const archiveText = isLandingPage
     z-index: 11;
     min-width: 0;
     align-items: center;
-    margin-bottom: clamp(24px, 3vw, 36px);
-    padding: 0 0 8px;
+    margin-bottom: clamp(20px, 2.6vw, 30px);
+    padding: 0 0 10px;
     border-top: 0;
     border-bottom: 0;
     background: #fff;
@@ -885,10 +922,11 @@ const archiveText = isLandingPage
     grid-template-columns: minmax(0, 0.58fr) minmax(360px, 0.42fr);
     height: clamp(420px, 36vw, 520px);
     overflow: hidden;
+    border: 1px solid #e3e6ea;
+    border-radius: 6px;
     background: #fff;
     color: #111;
-    border: 0;
-    box-shadow: none;
+    box-shadow: 0 18px 46px rgba(15, 23, 42, 0.06);
   }
 
   .ante-dossier__feature figure,
@@ -1016,7 +1054,7 @@ const archiveText = isLandingPage
   .ante-dossier__secondary {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 18px;
+    gap: clamp(14px, 2vw, 20px);
     margin-top: 18px;
   }
 
@@ -1024,9 +1062,12 @@ const archiveText = isLandingPage
     display: grid;
     grid-template-columns: minmax(180px, 0.42fr) minmax(0, 0.58fr);
     min-height: 250px;
+    border: 1px solid #e3e6ea;
+    border-radius: 6px;
     background: #fff;
     color: #111;
-    box-shadow: none;
+    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.045);
+    overflow: hidden;
   }
 
   .ante-dossier__secondary-item > div {
@@ -1077,6 +1118,11 @@ const archiveText = isLandingPage
     scroll-margin-top: 136px;
   }
 
+  .ante-dossier__archive--compact,
+  .ante-dossier__archive--empty {
+    padding-top: clamp(18px, 2.6vw, 30px);
+  }
+
   .ante-dossier__archive-head {
     border-top: 0;
     padding-top: clamp(28px, 4vw, 44px);
@@ -1084,6 +1130,8 @@ const archiveText = isLandingPage
 
   .ante-dossier__ledger {
     border-top: 0;
+    display: grid;
+    gap: 0.85rem;
   }
 
   .ante-dossier__ledger-head {
@@ -1093,7 +1141,7 @@ const archiveText = isLandingPage
     grid-template-columns: 56px minmax(320px, 1fr) minmax(170px, 0.2fr) minmax(120px, 0.14fr) auto;
     gap: clamp(18px, 3.5vw, 46px);
     align-items: center;
-    margin-bottom: 10px;
+    margin-bottom: 0;
     border-top: 0;
     border-bottom: 0;
     padding: 16px 0;
@@ -1117,14 +1165,24 @@ const archiveText = isLandingPage
     grid-template-columns: 56px minmax(320px, 1fr) minmax(170px, 0.2fr) minmax(120px, 0.14fr) auto;
     gap: clamp(18px, 3.5vw, 46px);
     align-items: center;
-    border-bottom: 0;
-    padding: 30px 0;
+    border: 1px solid #e3e6ea;
+    border-radius: 6px;
+    background: #fff;
+    padding: clamp(14px, 1.8vw, 20px);
     color: #111;
-    transition: background-color 180ms ease;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      transform 180ms ease;
   }
 
   .ante-dossier__row:hover {
-    background: #fafafa;
+    border-color: color-mix(in srgb, var(--um-red) 34%, #e3e6ea);
+    background: #fff;
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.075);
+    transform: translateY(-2px);
   }
 
   .ante-dossier__row-number {
@@ -1144,12 +1202,13 @@ const archiveText = isLandingPage
   }
 
   .ante-dossier__row-main figure {
-    width: 144px;
-    height: 116px;
+    width: 164px;
+    height: 112px;
     margin: 0;
     overflow: hidden;
     background: #111;
     border: 0;
+    border-radius: 4px;
   }
 
   .ante-dossier__row-main img {
@@ -1261,6 +1320,16 @@ const archiveText = isLandingPage
     padding: clamp(30px, 5vw, 62px);
   }
 
+  .ante-dossier__empty--archive {
+    display: grid;
+    max-width: 880px;
+    margin-inline: auto;
+    background: linear-gradient(90deg, #ffffff 0%, #f7f8f9 100%);
+    border: 1px solid #e3e6ea;
+    border-radius: 6px;
+    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.045);
+  }
+
   .ante-dossier__empty a {
     display: inline-flex;
     margin-top: 20px;
@@ -1278,6 +1347,12 @@ const archiveText = isLandingPage
   .ante-dossier__empty a:focus-visible {
     color: var(--um-red);
     text-decoration-color: currentColor;
+  }
+
+  .ante-dossier__empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
   }
 
   @media (max-width: 1080px) {
@@ -1325,7 +1400,7 @@ const archiveText = isLandingPage
 
   @media (max-width: 780px) {
     .ante-dossier__hero {
-      padding: 38px 0 34px;
+      padding: 48px 0 34px;
     }
 
     .ante-dossier__hero-grid,
@@ -1406,15 +1481,16 @@ const archiveText = isLandingPage
       margin-inline: auto;
       margin-bottom: 22px;
       padding-bottom: 0;
-      -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 14px, #000 calc(100% - 28px), transparent 100%);
-      mask-image: linear-gradient(90deg, transparent 0, #000 14px, #000 calc(100% - 28px), transparent 100%);
+      border-bottom: 1px solid #e6e8eb;
+      -webkit-mask-image: none;
+      mask-image: none;
     }
 
     .ante-dossier__sector-links {
       display: flex;
       flex-wrap: nowrap;
       max-width: 100%;
-      gap: 18px;
+      gap: 14px;
       padding-inline: 14px 42px;
       scroll-padding-inline: 14px 42px;
       overflow-x: auto;
@@ -1424,6 +1500,11 @@ const archiveText = isLandingPage
 
     .ante-dossier__sector-links a {
       min-height: 42px;
+      font-size: 0.95rem;
+    }
+
+    .ante-dossier__sector-links a em {
+      font-size: 0.95rem;
     }
 
     .ante-dossier__feature {
@@ -1508,7 +1589,7 @@ const archiveText = isLandingPage
 
   @media (max-width: 520px) {
     .ante-dossier__hero {
-      padding: 28px 0 24px;
+      padding: 38px 0 24px;
     }
 
     .ante-dossier__hero-grid {
@@ -1567,7 +1648,23 @@ const archiveText = isLandingPage
 
     .ante-dossier__actions a {
       width: 100%;
-      min-height: 48px;
+      min-height: 44px;
+      padding: 0 16px;
+      font-size: 0.98rem;
+    }
+
+    .ante-dossier__search input,
+    .ante-dossier__search button {
+      min-height: 42px;
+      font-size: 0.95rem;
+    }
+
+    .ante-dossier__search input {
+      padding: 0 12px;
+    }
+
+    .ante-dossier__search button {
+      padding: 0 16px;
     }
 
     .ante-dossier__proof {
@@ -1610,10 +1707,12 @@ const archiveText = isLandingPage
   document.querySelectorAll('.ante-dossier__sector-links').forEach((rail) => {
     const active = rail.querySelector('.is-active');
     if (active instanceof HTMLElement) {
-      active.scrollIntoView({
-        block: 'nearest',
-        inline: window.matchMedia('(max-width: 720px)').matches ? 'start' : 'nearest'
-      });
+      const isCompact = window.matchMedia('(max-width: 720px)').matches;
+      const targetLeft = isCompact
+        ? active.offsetLeft - 14
+        : active.offsetLeft - Math.max(0, (rail.clientWidth - active.clientWidth) / 2);
+
+      rail.scrollLeft = Math.max(0, targetLeft);
     }
   });
 </script>

--- a/src/components/templates/AntecedentesTemplateEditorial.astro
+++ b/src/components/templates/AntecedentesTemplateEditorial.astro
@@ -1173,16 +1173,12 @@ const archiveText = isLandingPage
     box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
     transition:
       background-color 180ms ease,
-      border-color 180ms ease,
-      box-shadow 180ms ease,
-      transform 180ms ease;
+      border-color 180ms ease;
   }
 
   .ante-dossier__row:hover {
     border-color: color-mix(in srgb, var(--um-red) 34%, #e3e6ea);
-    background: #fff;
-    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.075);
-    transform: translateY(-2px);
+    background: color-mix(in srgb, #fff 94%, var(--um-red) 6%);
   }
 
   .ante-dossier__row-number {

--- a/src/components/um/EvidenceCaseRow.astro
+++ b/src/components/um/EvidenceCaseRow.astro
@@ -75,16 +75,24 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 <style>
   .evidence-case-row {
     display: grid;
-    grid-template-columns: 3rem 136px minmax(220px, 1fr) minmax(148px, 0.45fr) auto;
-    column-gap: clamp(12px, 1.6vw, 20px);
-    row-gap: 10px;
+    grid-template-columns: 3rem minmax(156px, 0.2fr) minmax(240px, 1fr) minmax(160px, 0.34fr) auto;
+    column-gap: clamp(14px, 1.8vw, 24px);
+    row-gap: 12px;
     align-items: center;
-    padding: clamp(18px, 2.2vw, 24px) clamp(18px, 2vw, 24px);
-    border-top: 0;
+    margin-bottom: 0.9rem;
+    padding: clamp(14px, 1.8vw, 20px);
+    border: 1px solid #e3e6ea;
+    border-radius: 6px;
+    background: #fff;
     color: inherit;
     text-decoration: none;
     box-sizing: border-box;
-    transition: background-color 180ms ease;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      transform 180ms ease;
   }
 
   .evidence-case-row > * {
@@ -92,7 +100,10 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
   }
 
   .evidence-case-row:hover {
-    background: rgba(220, 38, 38, 0.03);
+    border-color: color-mix(in srgb, var(--um-red) 34%, #e3e6ea);
+    background: #fff;
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.075);
+    transform: translateY(-2px);
   }
 
   .evidence-case-row:focus-visible {
@@ -112,11 +123,12 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
   .evidence-case-row__thumb {
     margin: 0;
     overflow: hidden;
-    width: 136px;
-    height: 102px;
-    min-width: 136px;
-    min-height: 102px;
-    aspect-ratio: 4 / 3;
+    width: 100%;
+    height: auto;
+    min-width: 156px;
+    min-height: 112px;
+    aspect-ratio: 16 / 10;
+    border-radius: 4px;
     background: #eceff2;
   }
 
@@ -130,6 +142,11 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
     object-fit: cover;
     display: block;
     filter: saturate(0.88) contrast(1.04);
+    transition: transform 220ms ease;
+  }
+
+  .evidence-case-row:hover .evidence-case-row__thumb img {
+    transform: scale(1.025);
   }
 
   .evidence-case-row__copy {
@@ -218,8 +235,8 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 
   .evidence-case-row__meta-group {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(3.75rem, 4.75rem);
-    gap: clamp(12px, 1.6vw, 20px);
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
     align-items: start;
     min-width: 0;
   }
@@ -263,10 +280,10 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 
   @media (max-width: 900px) {
     .evidence-case-row {
-      grid-template-columns: minmax(96px, 112px) minmax(0, 1fr);
-      column-gap: 12px;
+      grid-template-columns: minmax(112px, 0.34fr) minmax(0, 1fr);
+      column-gap: 14px;
       align-items: start;
-      padding-inline: 0;
+      padding: 14px;
     }
 
     .evidence-case-row__number {
@@ -280,7 +297,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
       grid-column: 1;
       grid-row: 2;
       width: 100%;
-      min-width: 96px;
+      min-width: 112px;
       max-width: none;
       height: auto;
       min-height: 72px;

--- a/src/components/um/EvidenceCaseRow.astro
+++ b/src/components/um/EvidenceCaseRow.astro
@@ -90,9 +90,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
     box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
     transition:
       background-color 180ms ease,
-      border-color 180ms ease,
-      box-shadow 180ms ease,
-      transform 180ms ease;
+      border-color 180ms ease;
   }
 
   .evidence-case-row > * {
@@ -101,9 +99,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 
   .evidence-case-row:hover {
     border-color: color-mix(in srgb, var(--um-red) 34%, #e3e6ea);
-    background: #fff;
-    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.075);
-    transform: translateY(-2px);
+    background: color-mix(in srgb, #fff 94%, var(--um-red) 6%);
   }
 
   .evidence-case-row:focus-visible {

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -85,7 +85,7 @@ try {
     }
 } catch (error) {
     console.error(`Error loading antecedente ${id} from Directus:`, error);
-    return new Response('Directus antecedente unavailable', {
+    return new Response('Contenido temporalmente no disponible', {
       status: 503,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     });
@@ -94,9 +94,28 @@ try {
 if (!antecedente) return Astro.redirect('/404');
 
 antecedente = curateAntecedente(antecedente);
-const caseRecordLabel = antecedente.curation?.recordLabel || 'Registro técnico';
+const toPublicCaseLabel = (value: unknown): string => {
+  const label = String(value || '')
+    .replace(/\bRegistro\s+[\p{L}]+\b/giu, 'Proyecto técnico')
+    .replace(/\bRegistro\b/gi, 'Proyecto')
+    .replace(/\bDoc[\p{L}]*\b/giu, 'Técnico')
+    .trim();
+  return label || 'Proyecto técnico';
+};
+const toPublicCaseSummary = (value: unknown): string => {
+  const summary = String(value || '').trim();
+  if (!summary || /Directus|registro\s+p[uú]blico|imagen\s+[uú]nica|datos\s+del\s+antecedente/i.test(summary)) {
+    return 'Proyecto técnico de ULTIMA MILLA con alcance, vertical y fecha operativa disponibles.';
+  }
+  return summary
+    .replace(/cargad[oa]s?\s+desde\s+Directus/gi, 'publicados por ULTIMA MILLA')
+    .replace(/\bregistro\s+p[uú]blico\b/gi, 'proyecto')
+    .replace(/\bimagen\s+[uú]nica\s+asociada\b/gi, 'imagen asociada')
+    .trim();
+};
+const caseRecordLabel = toPublicCaseLabel(antecedente.curation?.recordLabel);
 const caseRecordTone = antecedente.curation?.recordTone || 'technical-record';
-const caseRecordSummary = antecedente.curation?.recordSummary || 'Antecedente real cargado desde Directus.';
+const caseRecordSummary = toPublicCaseSummary(antecedente.curation?.recordSummary);
 
 // --- Prepare data for UI (generated-case image first, Directus as fallback) ---
 const directusMainImageUrl = getAssetUrl(antecedente.Imagen || antecedente.ImagenPrincipal);
@@ -271,34 +290,34 @@ const getRelatedAntecedentes = async (area: string, excludeId: string, limit: nu
 const relatedAntecedentes = await getRelatedAntecedentes(antecedente.Area || '', id);
 
 const buildCaseHeadline = (item: any): string => {
-  const title = cleanDisplayText(item.Titulo || item.Nombre || 'Proyecto técnico documentado');
+  const title = cleanDisplayText(item.Titulo || item.Nombre || 'Proyecto técnico');
   const client = formatDisplayName(item.Cliente);
   const area = cleanDisplayText(item.Area);
   const normalized = title.toLowerCase();
 
   if (normalized.includes('digitalización') || normalized.includes('digitalizacion') || normalized.includes('software')) {
     if (client) return `Software operativo para ${client}`;
-    return 'Software operativo documentado';
+    return 'Software operativo implementado';
   }
   if (normalized.includes('soporte')) {
-    if (client) return `Soporte IT documentado para ${client}`;
-    return 'Soporte IT documentado';
+    if (client) return `Soporte IT operativo para ${client}`;
+    return 'Soporte IT operativo';
   }
   if (normalized.includes('cctv') || normalized.includes('cámara') || normalized.includes('camara')) {
     if (client) return `CCTV operativo para ${client}`;
-    return 'CCTV operativo documentado';
+    return 'CCTV operativo';
   }
   if (normalized.includes('detección') || normalized.includes('deteccion') || normalized.includes('incendio')) {
     if (client) return `Detección y seguridad para ${client}`;
-    return 'Detección y seguridad documentada';
+    return 'Detección y seguridad implementada';
   }
   if (normalized.includes('redes') || normalized.includes('fibra')) {
     if (client) return `Redes y fibra para ${client}`;
-    return 'Redes y fibra documentadas';
+    return 'Redes y fibra implementadas';
   }
   if (normalized.includes('eléctrica') || normalized.includes('electrica') || normalized.includes('data center')) {
     if (client) return `Energía IT para ${client}`;
-    return 'Energía IT documentada';
+    return 'Energía IT implementada';
   }
 
   const beforeDash = title.split(/\s[-–]\s/)[0]?.trim() || title;
@@ -314,10 +333,10 @@ const caseHeadlineSource = isReplicaIdenticalCopy()
 const baseCaseHeadline = buildCaseHeadline({ ...antecedente, Titulo: caseHeadlineSource });
 const caseHeadline = (() => {
   if (antecedente.curation?.quality === 'low-value-candidate') {
-    return `Registro documental: ${baseCaseHeadline}`;
+    return baseCaseHeadline;
   }
   if (antecedente.curation?.quality === 'data-error-candidate') {
-    return `Registro técnico en revisión: ${baseCaseHeadline}`;
+    return baseCaseHeadline;
   }
   return baseCaseHeadline;
 })();
@@ -356,7 +375,6 @@ const caseSeo = buildCaseSeoMeta({
 const metaDescription = caseSeo.description;
 const structuredImageUrl = publicImageUrl(caseSeoImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL);
 const caseDossierFacts = [
-  { label: 'Registro', value: `ANT-${id}` },
   { label: 'Tipo', value: caseRecordLabel },
   displayClientName ? { label: 'Organización', value: displayClientName } : null,
   antecedente.Area ? { label: 'Vertical', value: cleanDisplayText(antecedente.Area) } : null,
@@ -391,10 +409,9 @@ const antecedenteStructuredData = {
   "genre": caseRecordLabel,
   "about": antecedente.Area ? { "@type": "Thing", "name": cleanDisplayText(antecedente.Area) } : undefined,
   "mentions": antecedente.Cliente ? [{ "@type": "Organization", "name": cleanDisplayText(antecedente.Cliente) }] : undefined,
-  "identifier": `ANT-${id}`,
   "isPartOf": {
     "@type": "CollectionPage",
-    "name": "Evidencia operativa documentada",
+    "name": "Evidencia operativa real",
     "url": toCanonicalUrl('/antecedentes')
   },
   "provider": {
@@ -453,7 +470,7 @@ const antecedentePageStructuredData = [
           </div>
         </div>
 
-        <aside class="case-detail-dossier" aria-label="Dossier documental del antecedente">
+        <aside class="case-detail-dossier" aria-label="Ficha técnica del antecedente">
           <figure class="case-detail-dossier__media">
             <img
               src={mainImageUrl}
@@ -468,7 +485,7 @@ const antecedentePageStructuredData = [
           </figure>
           <div class="case-detail-dossier__body">
             <span>{caseRecordLabel}</span>
-            <strong>{displayClientName || `ANT-${id}`}</strong>
+            <strong>{displayClientName || 'Proyecto técnico'}</strong>
             <p>{caseRecordSummary}</p>
             <div class="case-detail-meta">
               {antecedente.Area && (
@@ -483,10 +500,6 @@ const antecedentePageStructuredData = [
                   <strong>{caseDateLabel}</strong>
                 </div>
               )}
-              <div>
-                <span>Registro</span>
-                <strong>ANT-{id}</strong>
-              </div>
             </div>
           </div>
         </aside>
@@ -537,7 +550,7 @@ const antecedentePageStructuredData = [
           <div class="flex flex-col gap-4 sm:gap-5">
             <div class="case-section-title">
               <span aria-hidden="true"></span>
-              <h2>Alcance documentado</h2>
+              <h2>Alcance técnico</h2>
             </div>
             <ul class="case-scope-list">
               {scopeItems.map((item) => (
@@ -583,7 +596,7 @@ const antecedentePageStructuredData = [
           </div>
         )}
 
-        <!-- Gallery (if has additional images from Directus) -->
+        <!-- Additional project gallery -->
         {antecedente.Imagenes && antecedente.Imagenes.length > 0 && (
           <div class="flex flex-col gap-4 sm:gap-5">
             <div class="case-section-title">
@@ -658,13 +671,8 @@ const antecedentePageStructuredData = [
             )}
             <div class="h-px bg-gray-100"></div>
             <div class="flex flex-col gap-1">
-              <span class="case-info-label">Jerarquía</span>
+              <span class="case-info-label">Tipo de trabajo</span>
               <span class="case-info-value">{caseRecordLabel}</span>
-            </div>
-            <div class="h-px bg-gray-100"></div>
-            <div class="flex flex-col gap-1">
-              <span class="case-info-label">Código Proyecto</span>
-              <span class="case-info-value case-info-value--code">ANT-{id}</span>
             </div>
           </div>
         </div>
@@ -709,7 +717,7 @@ const antecedentePageStructuredData = [
       <div class="um-container">
         <div class="case-related__head">
           <div>
-            <span class="um-kicker">Archivo relacionado</span>
+            <span class="um-kicker">Proyectos relacionados</span>
             <h2>Evidencia relacionada</h2>
           </div>
           <a href="/antecedentes" class="um-click-surface case-related__link">

--- a/src/pages/antecedentes/index.astro
+++ b/src/pages/antecedentes/index.astro
@@ -272,16 +272,16 @@ const pageTitle = pageData.currentPage > 1
   ? `Archivo de antecedentes - página ${pageData.currentPage} | ULTIMA MILLA`
   : activeSectorName
     ? `Antecedentes en ${activeSectorName} | ULTIMA MILLA`
-    : hasActiveArchiveFilters
+  : hasActiveArchiveFilters
       ? 'Archivo filtrado de antecedentes | ULTIMA MILLA'
-      : 'Evidencia operativa documentada | ULTIMA MILLA';
+      : 'Evidencia operativa real | ULTIMA MILLA';
 
 const pageDescription = pageData.currentPage > 1
-  ? `Archivo documental de antecedentes técnicos de ULTIMA MILLA, página ${pageData.currentPage}: registros reales con cliente, sector, fecha e imagen asociada.`
+  ? `Antecedentes técnicos de ULTIMA MILLA, página ${pageData.currentPage}: proyectos reales con cliente, sector, fecha e imagen asociada.`
   : activeSectorName
-    ? `Antecedentes técnicos de ULTIMA MILLA relacionados con ${activeSectorName}: casos y registros reales con cliente, sector, fecha e imagen.`
+    ? `Antecedentes técnicos de ULTIMA MILLA relacionados con ${activeSectorName}: casos y proyectos reales con cliente, sector, fecha e imagen.`
     : hasActiveArchiveFilters
-      ? 'Archivo filtrado de antecedentes técnicos de ULTIMA MILLA con registros reales, cliente, sector, fecha e imagen asociada.'
+      ? 'Archivo filtrado de antecedentes técnicos de ULTIMA MILLA con proyectos reales, cliente, sector, fecha e imagen asociada.'
       : 'Antecedentes técnicos de ULTIMA MILLA: proyectos reales de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.';
 
 const templateVariant = getDevTemplateVariant(Astro.url, import.meta.env.DEV) ?? 'editorial';
@@ -304,7 +304,7 @@ const crawlableAntecedenteIndex = allAntecedentesForIndex
   .sort((a, b) => String(a.title).localeCompare(String(b.title), 'es'));
 const antecedentesStrategicLinkGroups = buildCaseStrategicLinkGroups({
   currentPath: '/antecedentes',
-  title: 'Evidencia operativa documentada',
+  title: 'Evidencia operativa real',
   summary: 'Antecedentes técnicos de redes, seguridad electrónica, telecomunicaciones, software, soporte e infraestructura IT.',
   text: visibleAntecedentes.map((item: any) => `${item.displayTitle || item.Titulo || ''} ${item.displayDescription || item.Descripcion || ''} ${item.Cliente || ''} ${item.Area || ''}`).join(' '),
   relatedCases: visibleAntecedentes.map((item: any) => ({
@@ -391,9 +391,9 @@ const antecedentesCollectionStructuredData = {
         <details>
           <summary id="antecedentes-crawl-index-title">
             Índice completo de antecedentes
-            <span>{crawlableAntecedenteIndex.length} casos documentados</span>
+            <span>{crawlableAntecedenteIndex.length} casos técnicos</span>
           </summary>
-          <nav aria-label="Todos los antecedentes documentados">
+          <nav aria-label="Todos los antecedentes técnicos">
             {crawlableAntecedenteIndex.map((item) => (
               <a href={item.href}>
                 <strong>{item.title}</strong>

--- a/src/pages/api/asset/[id].ts
+++ b/src/pages/api/asset/[id].ts
@@ -12,8 +12,8 @@ export const GET: APIRoute = async ({ params, request }) => {
   // Obtener el token de autenticación de Directus
   const directusToken = import.meta.env.DIRECTUS_STATIC_TOKEN;
   if (!directusToken) {
-    console.error('[API] Directus token not configured');
-    return new Response('Directus token not configured', { status: 500 });
+    console.error('[API] Asset token not configured');
+    return new Response('Servicio de assets no configurado', { status: 500 });
   }
 
   // Construir la URL del asset en Directus

--- a/src/pages/api/blog.ts
+++ b/src/pages/api/blog.ts
@@ -24,7 +24,7 @@ function slugify(text: string): string {
 
 export const POST: APIRoute = async ({ request }) => {
   if (!DIRECTUS_TOKEN) {
-    return new Response(JSON.stringify({ error: 'Directus token not configured' }), {
+    return new Response(JSON.stringify({ error: 'Servicio de publicacion no configurado' }), {
       status: 503,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -104,7 +104,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!res.ok) {
     const err = await res.text();
-    return new Response(JSON.stringify({ error: 'Directus error', detail: err }), {
+    return new Response(JSON.stringify({ error: 'No se pudo completar la publicacion', detail: err }), {
       status: 502,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/src/pages/api/blog/[slug].ts
+++ b/src/pages/api/blog/[slug].ts
@@ -25,7 +25,7 @@ async function findPostId(slug: string): Promise<number | null> {
 
 export const PUT: APIRoute = async ({ request, params }) => {
   if (!DIRECTUS_TOKEN) {
-    return new Response(JSON.stringify({ error: 'Directus token not configured' }), {
+    return new Response(JSON.stringify({ error: 'Servicio de publicacion no configurado' }), {
       status: 503,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -97,7 +97,7 @@ export const PUT: APIRoute = async ({ request, params }) => {
 
   if (!res.ok) {
     const err = await res.text();
-    return new Response(JSON.stringify({ error: 'Directus error', detail: err }), {
+    return new Response(JSON.stringify({ error: 'No se pudo completar la actualizacion', detail: err }), {
       status: 502,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -111,7 +111,7 @@ export const PUT: APIRoute = async ({ request, params }) => {
 
 export const DELETE: APIRoute = async ({ request, params }) => {
   if (!DIRECTUS_TOKEN) {
-    return new Response(JSON.stringify({ error: 'Directus token not configured' }), {
+    return new Response(JSON.stringify({ error: 'Servicio de publicacion no configurado' }), {
       status: 503,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -145,7 +145,7 @@ export const DELETE: APIRoute = async ({ request, params }) => {
 
   if (!res.ok) {
     const err = await res.text();
-    return new Response(JSON.stringify({ error: 'Directus error', detail: err }), {
+    return new Response(JSON.stringify({ error: 'No se pudo completar la eliminacion', detail: err }), {
       status: 502,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -110,7 +110,7 @@ const blogPageStructuredData = [
       )}
 
       {archivePosts.length > 0 && (
-        <section class="blog-archive" aria-label="Archivo documental">
+        <section class="blog-archive" aria-label="Archivo técnico">
           <SectionHeader
             class="archive-head"
             title={featuredPost ? 'Archivo técnico' : 'Últimas notas'}

--- a/src/pages/geo/[resource].json.ts
+++ b/src/pages/geo/[resource].json.ts
@@ -8,8 +8,8 @@ export const GET: APIRoute = async ({ params }) => {
   try {
     payload = await buildGeoResourceAsync(resource);
   } catch (error) {
-    console.error(`[GEO-${resource}] Directus unavailable:`, error);
-    return new Response(JSON.stringify({ error: 'Directus unavailable for GEO resource' }), {
+    console.error(`[GEO-${resource}] Content source unavailable:`, error);
+    return new Response(JSON.stringify({ error: 'Recurso GEO temporalmente no disponible' }), {
       status: 503,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',

--- a/src/pages/geo/cases.json.ts
+++ b/src/pages/geo/cases.json.ts
@@ -11,8 +11,8 @@ export const GET: APIRoute = async () => {
       },
     });
   } catch (error) {
-    console.error('[GEO-CASES] Directus unavailable:', error);
-    return new Response(JSON.stringify({ error: 'Directus unavailable for GEO cases' }), {
+    console.error('[GEO-CASES] Content source unavailable:', error);
+    return new Response(JSON.stringify({ error: 'Casos GEO temporalmente no disponibles' }), {
       status: 503,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',

--- a/src/pages/geo/image-evidence.json.ts
+++ b/src/pages/geo/image-evidence.json.ts
@@ -11,8 +11,8 @@ export const GET: APIRoute = async () => {
       },
     });
   } catch (error) {
-    console.error('[GEO-IMAGE-EVIDENCE] Directus unavailable:', error);
-    return new Response(JSON.stringify({ error: 'Directus unavailable for image evidence' }), {
+    console.error('[GEO-IMAGE-EVIDENCE] Content source unavailable:', error);
+    return new Response(JSON.stringify({ error: 'Evidencia de imagenes temporalmente no disponible' }), {
       status: 503,
       headers: {
         'Content-Type': 'application/json; charset=utf-8',

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -16,8 +16,8 @@ export const GET: APIRoute = async () => {
   try {
     directusCaseResources = await getGeoCaseResources();
   } catch (error) {
-    console.error('[LLMS-FULL] Directus unavailable for cases:', error);
-    return new Response('Directus unavailable for LLM cases index', {
+    console.error('[LLMS-FULL] Content source unavailable for cases:', error);
+    return new Response('Indice LLM temporalmente no disponible', {
       status: 503,
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',

--- a/src/pages/servicios/[id]/[slug].astro
+++ b/src/pages/servicios/[id]/[slug].astro
@@ -309,7 +309,7 @@ const iconPaths = {
             {serviceDescriptionHtml ? (
               <div set:html={serviceDescriptionHtml} />
             ) : (
-              <p>Alcance técnico documentado bajo relevamiento de sitio y criterios operativos verificables.</p>
+              <p>Alcance técnico definido bajo relevamiento de sitio y criterios operativos verificables.</p>
             )}
           </div>
 
@@ -361,8 +361,8 @@ const iconPaths = {
                 <div>
                   <span>04</span>
                   <div>
-                    <h4 class="font-bold text-um-dark">Documentación</h4>
-                    <p class="text-um-gray">Testing completo con equipos especializados y entrega de documentación.</p>
+                    <h4 class="font-bold text-um-dark">Evidencia técnica</h4>
+                    <p class="text-um-gray">Testing completo con equipos especializados y entrega de resultados verificables.</p>
                   </div>
                 </div>
               </div>

--- a/src/pages/servicios/index.astro
+++ b/src/pages/servicios/index.astro
@@ -185,7 +185,7 @@ const serviceIconPaths: Record<string, string> = {
         </div>
         <p>
           Ocho frentes técnicos conectados por diagnóstico, ingeniería, implementación,
-          documentación y soporte. El diseño debe poder leerse en minutos y auditarse después.
+          evidencia técnica y soporte. El diseño debe poder leerse en minutos y auditarse después.
         </p>
       </div>
 
@@ -194,7 +194,7 @@ const serviceIconPaths: Record<string, string> = {
           <div class="services-dossier__image">
             <img
               src={servicios[1]?.visual.image || servicios[0]?.visual.image}
-              alt={servicios[1]?.visual.imageAlt || 'Infraestructura IT documentada por ULTIMA MILLA'}
+              alt={servicios[1]?.visual.imageAlt || 'Infraestructura IT operativa de ULTIMA MILLA'}
               loading="lazy"
               decoding="async"
             />
@@ -286,7 +286,7 @@ const serviceIconPaths: Record<string, string> = {
         <a href="/contacto" class="um-click-surface services-intent-card">
           <span>03</span>
           <strong>Solicitar relevamiento</strong>
-          <p>Obra puntual, sala técnica, red express o seguridad con entrega documentada.</p>
+          <p>Obra puntual, sala técnica, red express o seguridad con entrega técnica verificable.</p>
         </a>
       </div>
     </div>
@@ -1250,7 +1250,7 @@ const serviceIconPaths: Record<string, string> = {
     .services-hero__proofline div,
     .services-hero__proofline div + div {
       display: grid;
-      grid-template-columns: 106px minmax(0, 1fr);
+      grid-template-columns: minmax(0, 96px) minmax(0, 1fr);
       align-items: baseline;
       column-gap: 14px;
       border-right: 0;
@@ -1274,8 +1274,8 @@ const serviceIconPaths: Record<string, string> = {
       letter-spacing: 0;
       line-height: 1.15;
       text-transform: none;
-      white-space: nowrap;
-      overflow-wrap: normal;
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     .services-hero__proofline dd {

--- a/src/pages/sitemap-antecedentes.xml.ts
+++ b/src/pages/sitemap-antecedentes.xml.ts
@@ -48,7 +48,7 @@ export const GET: APIRoute = async () => {
         });
     } catch (error) {
         console.error('Error generando sitemap de antecedentes:', error);
-        return new Response('Directus unavailable for antecedentes sitemap', {
+        return new Response('Sitemap de antecedentes temporalmente no disponible', {
             status: 503,
             headers: {
                 'Content-Type': 'text/plain; charset=utf-8',

--- a/src/pages/sitemap-images.xml.ts
+++ b/src/pages/sitemap-images.xml.ts
@@ -29,8 +29,8 @@ export const GET: APIRoute = async () => {
       },
     });
   } catch (error) {
-    console.error('[SITEMAP-IMAGES] Directus unavailable:', error);
-    return new Response('Directus unavailable for image sitemap', {
+    console.error('[SITEMAP-IMAGES] Content source unavailable:', error);
+    return new Response('Sitemap de imagenes temporalmente no disponible', {
       status: 503,
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',

--- a/src/utils/antecedentesCuration.ts
+++ b/src/utils/antecedentesCuration.ts
@@ -137,8 +137,8 @@ export function getAntecedenteRecordTone(quality: AntecedenteQuality): {
   if (quality === 'low-value-candidate') {
     return {
       tone: 'documentary-record',
-      label: 'Registro documental',
-      summary: 'Registro real de provisión o intervención menor; se muestra sin sobredimensionar su alcance.',
+      label: 'Proyecto técnico',
+      summary: 'Intervención real de provisión o alcance menor; se muestra sin sobredimensionar su escala.',
     };
   }
 
@@ -146,13 +146,13 @@ export function getAntecedenteRecordTone(quality: AntecedenteQuality): {
     return {
       tone: 'editorial-review',
       label: 'Revisión editorial',
-      summary: 'Registro real con señal de error o truncamiento en el dato fuente; requiere revisión en CMS.',
+      summary: 'Antecedente real con señal de error o truncamiento; requiere revisión editorial.',
     };
   }
 
   return {
     tone: 'technical-record',
-    label: 'Registro técnico',
+    label: 'Proyecto técnico',
     summary: 'Antecedente real con información útil, pero sin profundidad completa de caso estratégico.',
   };
 }
@@ -179,11 +179,11 @@ function getDateTime(value: unknown): number {
 
 export function formatAntecedenteYear(value: unknown): string {
   const raw = cleanAntecedenteText(value);
-  if (!raw || /invalid date/i.test(raw)) return 'documentado';
+  if (!raw || /invalid date/i.test(raw)) return 'sin fecha';
   const parsed = new Date(raw);
   if (!Number.isNaN(parsed.getTime())) return String(parsed.getFullYear());
   const year = raw.match(/\b(19\d{2}|20\d{2})\b/)?.[1];
-  return year || 'documentado';
+  return year || 'sin fecha';
 }
 
 export function formatAntecedenteDate(value: unknown): string {
@@ -199,7 +199,7 @@ export function formatAntecedenteDate(value: unknown): string {
 }
 
 function buildDisplayTitle(item: Record<string, any>): string {
-  const title = fixKnownTextErrors(cleanAntecedenteText(item.Titulo || item.Nombre || 'Antecedente técnico documentado'));
+  const title = fixKnownTextErrors(cleanAntecedenteText(item.Titulo || item.Nombre || 'Antecedente técnico'));
   return title
     .replace(/\s+\(\d+\)$/g, '')
     .replace(/\s+/g, ' ')
@@ -276,7 +276,7 @@ function classifyAntecedente(item: Record<string, any>, issues: string[]): Antec
   const hasStrategicSignal = STRATEGIC_PATTERNS.some((pattern) => pattern.test(contentText));
   const hasNamedClient = cleanAntecedenteText(item.Cliente).length >= 3;
   const hasSector = cleanAntecedenteText(item.Area || item.Unidad_de_negocio).length >= 3;
-  const hasDate = formatAntecedenteYear(item.Fecha) !== 'documentado';
+  const hasDate = formatAntecedenteYear(item.Fecha) !== 'sin fecha';
 
   if (hasDataError) return 'data-error-candidate';
   if (hasLowValueSignal && !hasStrategicSignal) return 'low-value-candidate';
@@ -352,7 +352,6 @@ export function buildAntecedenteListItemStructuredData(item: Record<string, any>
       datePublished,
       about: curated.Area ? { '@type': 'Thing', name: cleanAntecedenteText(curated.Area) } : undefined,
       mentions: curated.Cliente ? [{ '@type': 'Organization', name: cleanAntecedenteText(curated.Cliente) }] : undefined,
-      identifier: curated.id ? `ANT-${curated.id}` : undefined,
     },
   };
 }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -51,7 +51,7 @@ export async function verifyToken() {
 /**
  * Obtiene los datos de un antecedente por su ID
  * @param {string} id ID del antecedente
- * @returns {Promise<Object>} Datos del antecedente
+ * @returns {Promise<Object>} Datos del proyecto
  */
 export async function fetchAntecedente(id) {
   try {


### PR DESCRIPTION
## Summary
- remove internal CMS/source labels from antecedentes single, index, services, blog archive label, GEO/sitemap/API error surfaces
- remove public ANT-* identifiers from case UI and structured data
- harden antecedentes/services UI contracts and add UI_WORLD_CLASS_GOAL.md

## Verification
- npm ci
- npm run build
- npm test (29 suites, 248 tests)
- rg source scan for forbidden public strings: clean
- local render scan for /, /antecedentes, /servicios, /blog: clean
- single fallback body when Directus unavailable: Contenido temporalmente no disponible