### PR TITLE
deploy: promote residual public-copy cleanup

### DIFF
--- a/src/components/templates/AntecedentesTemplateAtlas.astro
+++ b/src/components/templates/AntecedentesTemplateAtlas.astro
@@ -61,7 +61,7 @@ const projectHref = (item: any) => `/antecedentes/${item.slug}`;
   <div class="um-container ante-atlas__hero">
     <div>
       <span class="ante-atlas__rule" aria-hidden="true"></span>
-      <p>Atlas documental</p>
+      <p>Atlas técnico</p>
       <h1>Antecedentes como archivo navegable, no como catálogo de cards.</h1>
     </div>
     <aside>

--- a/src/components/um/TrustStrip.astro
+++ b/src/components/um/TrustStrip.astro
@@ -31,14 +31,14 @@ const clientRecords = getTopClienteRecords(6);
     </header>
 
     <div class="um-trust-strip__board">
-      <aside class="um-trust-strip__proof" aria-label={`${catalogCount} antecedentes documentados`}>
+      <aside class="um-trust-strip__proof" aria-label={`${catalogCount} antecedentes técnicos`}>
         <span>Archivo publicado</span>
         <strong>{catalogCount}</strong>
-        <p>antecedentes documentados en el catálogo público.</p>
+        <p>antecedentes técnicos en el catálogo público.</p>
         <a href="/antecedentes" class="um-trust-strip__proof-link">Abrir centro de evidencia</a>
       </aside>
 
-      <div class="um-trust-strip__ledger" aria-label="Clientes con antecedentes documentados">
+      <div class="um-trust-strip__ledger" aria-label="Clientes con antecedentes técnicos">
         <p class="um-trust-strip__ledger-title">Referencias publicadas</p>
         <div class="um-trust-strip__ledger-head" aria-hidden="true">
           <span></span>

--- a/src/components/v4/ProductCard.astro
+++ b/src/components/v4/ProductCard.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * ProductCard — ficha documental de equipamiento (servicio detalle).
+ * ProductCard — ficha técnica de equipamiento (servicio detalle).
  * Renderiza Markdown, sanitiza emojis y aplica grid editorial UMSA.
  * Imagen: sin borde, marco ni sombra decorativa (DESIGN.md §6 — fotos contenidas).
  */

--- a/src/data/geoCommercialHubs.ts
+++ b/src/data/geoCommercialHubs.ts
@@ -74,7 +74,7 @@ export const geoCommercialHubs: Record<string, GeoCommercialHub> = {
     services: [
       { id: 101, title: 'Infraestructura de redes', href: serviceHref(101, 'infraestructura-de-redes-cableado-fibra-optica-radioenlaces'), summary: 'Cableado, fibra, switching, WiFi, radioenlaces y documentación.' },
       { id: 105, title: 'Soporte técnico 24/7', href: serviceHref(105, 'soporte-tecnico-247-mesa-de-ayuda-mantenimiento-it'), summary: 'Mesa de ayuda, mantenimiento, monitoreo y continuidad operativa.' },
-      { id: 102, title: 'Seguridad electrónica', href: serviceHref(102, 'sistemas-de-seguridad-electronica-cctv-control-acceso-sistemas-de-deteccion-de-incendios-sdi'), summary: 'CCTV, accesos, intrusión, SDI y mantenimiento documental.' },
+      { id: 102, title: 'Seguridad electrónica', href: serviceHref(102, 'sistemas-de-seguridad-electronica-cctv-control-acceso-sistemas-de-deteccion-de-incendios-sdi'), summary: 'CCTV, accesos, intrusión, SDI y mantenimiento técnico.' },
       { id: 104, title: 'Software a medida', href: serviceHref(104, 'desarrollo-de-software-a-medida-web-mobile-erp'), summary: 'Sistemas, APIs, tableros e integraciones para procesos operativos.' }
     ],
     sectors: [
@@ -88,7 +88,7 @@ export const geoCommercialHubs: Record<string, GeoCommercialHub> = {
       { title: 'Cámara de CCTV', client: 'Aeropuertos Argentina 2000', href: '/antecedentes/3065/camara-de-cctv-aeropuerto-de-mendoza', sector: 'Aeropuertos' },
       { title: 'Detección y mantenimiento crítico', client: 'Consorcio Torre Thays', href: '/antecedentes/3066/torre-thays-dispositivos-de-deteccion', sector: 'Seguridad' }
     ],
-    process: ['Relevamiento de sitio y criticidad', 'Arquitectura técnica y alcance', 'Implementación documentada', 'Soporte, medición y mejora'],
+    process: ['Relevamiento de sitio y criticidad', 'Arquitectura técnica y alcance', 'Implementación verificada', 'Soporte, medición y mejora'],
     faqs: [
       { question: '¿ULTIMA MILLA trabaja solo en Mendoza?', answer: 'La base operativa está en Mendoza, con cobertura en Cuyo, Patagonia y proyectos en Argentina según alcance, criticidad y necesidad de soporte.' },
       { question: '¿Se puede contratar un solo servicio?', answer: 'Sí. El relevamiento define si conviene resolver una necesidad puntual o construir un plan integrado de red, seguridad, soporte, energía o software.' },
@@ -110,7 +110,7 @@ export const geoCommercialHubs: Record<string, GeoCommercialHub> = {
     eyebrow: 'Presupuesto IT empresarial',
     h1: 'Cotizar servicios IT sin perder alcance',
     lead: 'Una cotización tecnológica seria separa diagnóstico, materiales, ingeniería, ejecución, documentación, SLA, soporte posterior e integraciones reales.',
-    proof: ['Alcance técnico verificable', 'Riesgo operativo medido', 'Entregables documentados', 'Próximo paso comercial claro'],
+    proof: ['Alcance técnico verificable', 'Riesgo operativo medido', 'Entregables verificables', 'Próximo paso comercial claro'],
     searchTerms: ['presupuesto tecnología para empresas', 'cotizar proyecto IT', 'presupuesto infraestructura IT', 'costo soporte técnico empresarial'],
     buyerNeed: 'Pasar de una consulta genérica de precio a una conversación de alcance: qué se debe relevar, qué se entrega, qué riesgos se cubren y cómo se sostiene después.',
     decisionFrame: 'Un presupuesto bajo puede ocultar omisiones críticas: certificación, pruebas, documentación, ventanas de trabajo, licencias, viáticos, soporte o integraciones.',
@@ -180,7 +180,7 @@ export const geoCommercialHubs: Record<string, GeoCommercialHub> = {
     faqs: [
       { question: '¿Qué diferencia un proyecto de ingeniería IT de una instalación común?', answer: 'La ingeniería define alcance, riesgos, documentación, pruebas, coordinación con otros gremios y soporte posterior; no se limita a instalar equipos.' },
       { question: '¿Trabajan con obras en curso?', answer: 'Sí. La planificación debe coordinar canalizaciones, racks, energía, tableros, seguridad y puesta en marcha con obra civil y mantenimiento.' },
-      { question: '¿Entregan documentación final?', answer: 'El objetivo del proyecto es dejar infraestructura funcionando, probada y documentada para operación y mantenimiento.' }
+      { question: '¿Entregan cierre técnico?', answer: 'El objetivo del proyecto es dejar infraestructura funcionando, probada y lista para operación y mantenimiento.' }
     ],
     primaryCta: 'Solicitar relevamiento',
     secondaryCta: 'Ver proyectos',

--- a/src/data/geoKnowledge.ts
+++ b/src/data/geoKnowledge.ts
@@ -296,7 +296,7 @@ export const authorityHubs: AuthorityHub[] = [
       note: 'Rangos orientativos para dimensionar conversaciones comerciales; la cotizacion final depende de sitio, alcance, SLA, materiales, integraciones y documentacion requerida.',
       ranges: [
         { label: 'Diagnostico y roadmap', usdFrom: 900, usdTo: 2800, scope: 'Relevamiento, inventario, riesgos, prioridades y plan de accion.' },
-        { label: 'Implementacion pyme inicial', usdFrom: 3500, usdTo: 18000, scope: 'Redes, soporte, seguridad o software con alcance acotado y entrega documentada.' },
+        { label: 'Implementacion pyme inicial', usdFrom: 3500, usdTo: 18000, scope: 'Redes, soporte, seguridad o software con alcance acotado y entrega verificable.' },
         { label: 'Proyecto multisede o critico', usdFrom: 18000, usdTo: null, scope: 'Ingenieria, coordinacion de obra, continuidad operativa, pruebas y soporte posterior.' },
       ],
     },

--- a/src/data/geoResources.ts
+++ b/src/data/geoResources.ts
@@ -224,7 +224,7 @@ export function buildGeoResource(resource: string) {
       return {
         ...common,
         evidenceModel: 'Servicios, sectores, antecedentes, hubs comerciales y FAQs enlazados con canonicals estables.',
-        trustSignals: ['Trayectoria pública', 'Casos documentados', 'Cobertura regional', 'Servicios conectados', 'Contacto institucional'],
+        trustSignals: ['Trayectoria pública', 'Casos reales', 'Cobertura regional', 'Servicios conectados', 'Contacto institucional'],
         canonicalHubs: geoHubRoutes,
       };
 
@@ -263,7 +263,7 @@ export function buildGeoResource(resource: string) {
         blog: {
           url: canonicalUrl('/blog'),
           role: 'Archivo editorial técnico para explicar riesgos, criterios de decisión, normativa y operación IT.',
-          recommendedTopics: ['continuidad operativa', 'seguridad electrónica', 'soporte IT', 'software operativo', 'infraestructura documentada'],
+          recommendedTopics: ['continuidad operativa', 'seguridad electrónica', 'soporte IT', 'software operativo', 'infraestructura verificable'],
         },
       };
 

--- a/src/data/replica-prod-copy.json
+++ b/src/data/replica-prod-copy.json
@@ -36,13 +36,13 @@
     },
     "/antecedentes": {
       "status": 200,
-      "title": "Evidencia operativa documentada | ULTIMA MILLA",
-      "h1": "Evidencia operativa documentada."
+      "title": "Evidencia operativa real | ULTIMA MILLA",
+      "h1": "Evidencia operativa real."
     },
     "/antecedentes?sector=aeropuertos": {
       "status": 200,
-      "title": "Evidencia operativa documentada | ULTIMA MILLA",
-      "h1": "Evidencia operativa documentada."
+      "title": "Evidencia operativa real | ULTIMA MILLA",
+      "h1": "Evidencia operativa real."
     },
     "/antecedentes/3064/desarrollo-de-software-y-digitalizacion-de-procesos-para-el-gobierno-de-la-provincia-de-mendoza": {
       "status": 200,

--- a/src/data/sectorVisualSystem.ts
+++ b/src/data/sectorVisualSystem.ts
@@ -72,7 +72,7 @@ export const sectorVisualSystem: Record<string, SectorVisualSpec> = {
     image: editorialImages.sectors.constructoras,
     imageAlt: 'Infraestructura eléctrica y de datos en obra tecnológica',
     services: ['Eléctricos para IT', 'Redes', 'Detección de incendios'],
-    operatingNeed: 'Diseño temprano, ejecución limpia y entrega documentada.'
+    operatingNeed: 'Diseño temprano, ejecución limpia y entrega verificable.'
   },
   industria: {
     slug: 'industria',

--- a/src/pages/api/cli/query-directus.ts
+++ b/src/pages/api/cli/query-directus.ts
@@ -125,7 +125,7 @@ function formatResults(directusData: {antecedentes: DirectusItem[], servicios: D
                 type: 'antecedente',
                 icon: '📊',
                 title: antecedente.title,
-                content: (antecedente.content || 'Proyecto empresarial documentado').slice(0, 280) + '...',
+                content: (antecedente.content || 'Proyecto empresarial técnico').slice(0, 280) + '...',
                 url: realUrl,
                 client: antecedente.client || null,
                 image: null,
@@ -139,7 +139,7 @@ function formatResults(directusData: {antecedentes: DirectusItem[], servicios: D
                 type: 'antecedente',
                 icon: '📊',
                 title: antecedente.title,
-                content: (antecedente.content || 'Proyecto empresarial documentado').slice(0, 280) + '...',
+                content: (antecedente.content || 'Proyecto empresarial técnico').slice(0, 280) + '...',
                 url: '/antecedentes', // URL genérica a la página de antecedentes
                 client: antecedente.client || null,
                 image: null,

--- a/src/pages/certificaciones.astro
+++ b/src/pages/certificaciones.astro
@@ -38,7 +38,7 @@ const blocks = [
   <section class="um-container cert-page">
     <header class="cert-page__hero">
       <div>
-        <p class="cert-page__eyebrow">Cumplimiento documental</p>
+        <p class="cert-page__eyebrow">Cumplimiento técnico</p>
         <h1>Documentación técnica para compras, auditorías y licitaciones</h1>
         <p>
           Qué puede acreditar ULTIMA MILLA en un proceso de compra y qué no se publica

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -71,7 +71,7 @@ const structuredData = {
           class="contact-proofline"
           metrics={[
             { value: '24/7', label: 'soporte para clientes activos' },
-            { value: getAntecedentesCountShort(), label: 'antecedentes documentados' },
+            { value: getAntecedentesCountShort(), label: 'antecedentes técnicos' },
             { value: '22+', label: 'años de trayectoria técnica' },
           ]}
         />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ const secondaryEvidenceCases = featuredCasesEnhanced.slice(1);
 
 const evidenceYear = (item: any) => {
   const raw = item?.Fecha || item?.fecha || item?.anio;
-  if (!raw) return 'documentado';
+  if (!raw) return 'sin fecha';
   const date = new Date(raw);
   return Number.isNaN(date.getTime()) ? String(raw) : String(date.getFullYear());
 };
@@ -112,7 +112,7 @@ const sectorLinks = [
 
 const proofMetrics = [
   ['8', 'servicios IT', 'red, seguridad, software, energía y soporte'],
-  [proofCountShort, 'antecedentes', `${proofCountExact} proyectos documentados`],
+  [proofCountShort, 'antecedentes', `${proofCountExact} proyectos reales`],
   ['22+', 'años', 'de trayectoria técnica en infraestructura'],
   ['24/7', 'soporte', 'operación y monitoreo continuo']
 ];
@@ -268,7 +268,7 @@ const homeStructuredData = [
           </div>
           <div class="um-evidence-head__side">
             <p>
-              {proofCountExact} proyectos documentados en el catálogo respaldan nuestra forma de trabajar: alcance técnico, evidencia y continuidad posterior.
+              {proofCountExact} proyectos reales en el catálogo respaldan nuestra forma de trabajar: alcance técnico, evidencia y continuidad posterior.
             </p>
             <a href="/antecedentes">Ver todos los antecedentes</a>
           </div>
@@ -328,7 +328,7 @@ const homeStructuredData = [
             </a>
           ))}
         </nav>
-        <p>Mapa de riesgo operativo por industria. Cada sector enlaza a antecedentes y alcance técnico documentado.</p>
+        <p>Mapa de riesgo operativo por industria. Cada sector enlaza a antecedentes y alcance técnico verificable.</p>
       </aside>
       </div>
   </section>

--- a/src/pages/plantilla-arca.astro
+++ b/src/pages/plantilla-arca.astro
@@ -69,7 +69,7 @@ const keywords =
           <div>
             <span>02</span>
             <strong>QR</strong>
-            <p>Datos normalizados para comprobantes y trazabilidad documental.</p>
+            <p>Datos normalizados para comprobantes y trazabilidad operativa.</p>
           </div>
           <div>
             <span>03</span>
@@ -83,7 +83,7 @@ const keywords =
     <section id="formulario" class="arca-workspace">
       <div class="arca-container">
         <div class="arca-section-head">
-          <p class="arca-eyebrow">Asistente documental</p>
+          <p class="arca-eyebrow">Asistente de comprobantes</p>
           <h2>Generador de facturas ARCA RG 5824</h2>
           <p>
             Un flujo de carga, control y vista previa pensado para operar rápido,
@@ -262,7 +262,7 @@ const keywords =
     <section class="arca-final-cta">
       <div class="arca-container arca-final-grid">
         <div>
-          <p class="arca-eyebrow">Operación documental</p>
+          <p class="arca-eyebrow">Operación de comprobantes</p>
           <h2>Generá, revisá y continuá.</h2>
           <p>
             La herramienta queda como utilidad pública UMSA: sobria, directa y separada

--- a/src/utils/caseMetrics.ts
+++ b/src/utils/caseMetrics.ts
@@ -41,7 +41,7 @@ const PATTERN_RULES: PatternRule[] = [
   },
   {
     regex: /(\d+(?:[.,]\d+)?)\s*%/,
-    format: (m) => ({ value: `${m[1].replace(',', '.')}%`, label: 'indicador documentado' }),
+    format: (m) => ({ value: `${m[1].replace(',', '.')}%`, label: 'indicador técnico' }),
   },
 ];
 

--- a/src/utils/commercialProductTemplate.ts
+++ b/src/utils/commercialProductTemplate.ts
@@ -226,7 +226,7 @@ const defaultContent: Required<TemplateContent> = {
       image: cctvAiProductDefaults.phoneImage,
       box: 'demo-box--report',
       summary: 'UMSA ordena los eventos, adjunta evidencia visual y deja recomendaciones revisables.',
-      recommendation: 'Usar el reporte como soporte documental; la decisión final queda en revisión humana.',
+      recommendation: 'Usar el reporte como soporte técnico; la decisión final queda en revisión humana.',
       evidence: 'Resumen ejecutivo + fichas de incidente',
       duration: 'PDF demo',
     },

--- a/src/utils/editorialContent.ts
+++ b/src/utils/editorialContent.ts
@@ -279,7 +279,7 @@ export function serviceHeroLead(
   if (cleanedPage && !containsBannedLedgerCopy(cleanedPage) && !duplicatesBody) {
     return cleanedPage;
   }
-  return visualProof || cleanedSub || 'Alcance técnico documentado con evidencia y soporte en sitio.';
+  return visualProof || cleanedSub || 'Alcance técnico con evidencia y soporte en sitio.';
 }
 
 export function sanitizeServiceStats(stats: Array<{ value?: string; label?: string; valor?: string }> = []) {

--- a/src/utils/verifiedProof.ts
+++ b/src/utils/verifiedProof.ts
@@ -35,8 +35,8 @@ export function getAntecedentesCountShort(): string {
 /** Etiqueta explícita con conteo del catálogo (p. ej. copy factual / llms). */
 export function getAntecedentesCountExactPhrase(): string {
   const n = getAntecedentesCatalogCount();
-  if (n <= 0) return 'antecedentes documentados';
-  return `${n} antecedentes documentados`;
+  if (n <= 0) return 'antecedentes técnicos';
+  return `${n} antecedentes técnicos`;
 }
 
 /** Clientes con más proyectos en el campo Cliente del CMS (solo texto, sin logos). */
@@ -55,7 +55,7 @@ export function getTopClienteNames(limit = 6): string[] {
     .map(([name]) => name);
 }
 
-/** Clientes frecuentes con cantidad de antecedentes documentados y vertical dominante. */
+/** Clientes frecuentes con cantidad de antecedentes técnicos y vertical dominante. */
 export function getTopClienteRecords(limit = 6): { name: string; count: number; dominantArea: string }[] {
   const counts = new Map<string, number>();
   const areasByClient = new Map<string, Map<string, number>>();


### PR DESCRIPTION
Promotes the follow-up cleanup that removes residual documentary/internal-source language from public UI/data surfaces. Verified locally with npm test, npm run build, and commercial CSS contract audit; PR #111 checks are green.