### PR TITLE
fix: normalize terminal advanced visual fallbacks

### DIFF
--- a/public/UMCliPlugin.js
+++ b/public/UMCliPlugin.js
@@ -367,10 +367,10 @@ ${filteredResults.map((result, index) =>
 </div>`;
     
     if (args.includes('email')) {
-      window.open('mailto:info@ultimamilla.com.ar?subject=Consulta desde Terminal CLI');
+      window.open('mailto:info@ultimamilla.com.ar?subject=Consulta desde sitio web ULTIMA MILLA');
     }
     if (args.includes('wa')) {
-      window.open('https://wa.me/5492611234567?text=Hola! Vengo desde el terminal CLI de su sitio web');
+      window.open('https://wa.me/5492611234567?text=Hola! Vengo desde el sitio web de ULTIMA MILLA');
     }
     
     return contactInfo;

--- a/public/UMTerminalEngine.js
+++ b/public/UMTerminalEngine.js
@@ -810,7 +810,7 @@ ${this.getASCIILogo()}
 
 💬 WHATSAPP COMERCIAL:
    📱 +54 261 555 0123
-   💭 Mensaje sugerido: "Hola! Vengo desde su terminal CLI"
+   Mensaje sugerido: "Hola, vengo desde el sitio web de ULTIMA MILLA"
 
 ⏰ HORARIOS DE ATENCIÓN:
    📅 Lunes a Viernes: 9:00 - 18:00
@@ -834,7 +834,7 @@ ${this.getASCIILogo()}
     if (args.includes('email')) {
       setTimeout(() => {
         if (typeof window !== 'undefined') {
-          window.open('mailto:info@ultimamilla.com.ar?subject=Consulta desde Terminal CLI&body=Hola! Los contacto desde el terminal CLI de su sitio web.');
+          window.open('mailto:info@ultimamilla.com.ar?subject=Consulta desde sitio web ULTIMA MILLA&body=Hola. Los contacto desde el sitio web de ULTIMA MILLA.');
         }
       }, 500);
     }
@@ -842,7 +842,7 @@ ${this.getASCIILogo()}
     if (args.includes('wa')) {
       setTimeout(() => {
         if (typeof window !== 'undefined') {
-          window.open('https://wa.me/5492615550123?text=Hola! Los contacto desde el terminal CLI de su sitio web. Me interesa conocer más sobre sus servicios.');
+          window.open('https://wa.me/5492615550123?text=Hola. Los contacto desde el sitio web de ULTIMA MILLA. Me interesa conocer más sobre sus servicios.');
         }
       }, 500);
     }
@@ -863,20 +863,20 @@ ${this.getASCIILogo()}
     }
 
     return this.formatSuccess(`
-🔴 EFECTO MATRIX - DATOS ULTIMA MILLA
+MODO DATOS - ULTIMA MILLA
 ═══════════════════════════════════════════════════════════════════
 
-<div class="matrix-effect" style="font-family: monospace; color: #00ff00; background: #000; padding: 20px; animation: matrix 2s linear infinite;">
+<div class="matrix-effect" style="font-family: Open Sans, Arial, system-ui, sans-serif; color: #ffffff; background: #111111; border-left: 3px solid #DC2626; padding: 20px;">
 ${matrix}
 </div>
 
-🎭 DECODIFICANDO INFORMACIÓN EMPRESARIAL...
+DECODIFICANDO INFORMACIÓN EMPRESARIAL...
    💾 Proyectos: ${this.companyData.estadisticas.proyectosCompletados}
    👥 Clientes: ${this.companyData.estadisticas.clientesActivos}  
    🕐 Uptime: 99.9%
    🌐 Cobertura: Nacional
 
-⚡ "No hay Matrix, solo código que conecta el futuro" - ULTIMA MILLA
+"No hay Matrix, solo infraestructura que sostiene continuidad operativa" - ULTIMA MILLA
 
 ═══════════════════════════════════════════════════════════════════
     `);

--- a/public/js/UMTerminalAdvanced.js
+++ b/public/js/UMTerminalAdvanced.js
@@ -216,11 +216,11 @@ class UMTerminalAdvanced {
 
     updatePromptStyle() {
         const colors = {
-            default: '#00ffaa',
-            matrix: '#00ff00',
-            retro: '#ff00ff',
-            neon: '#00ffff',
-            corporate: '#fbbf24'
+            default: '#DC2626',
+            matrix: '#DC2626',
+            retro: '#DC2626',
+            neon: '#DC2626',
+            corporate: '#DC2626'
         };
         
         if (this.prompt) {
@@ -232,11 +232,11 @@ class UMTerminalAdvanced {
         if (!this.themeSelector) return;
         
         const colors = {
-            default: '#00ffaa',
-            matrix: '#00ff00',
-            retro: '#ff00ff',
-            neon: '#00ffff',
-            corporate: '#fbbf24'
+            default: '#DC2626',
+            matrix: '#DC2626',
+            retro: '#DC2626',
+            neon: '#DC2626',
+            corporate: '#DC2626'
         };
         
         const currentColor = colors[this.currentTheme] || colors.default;
@@ -278,8 +278,8 @@ class UMTerminalAdvanced {
             ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
             ctx.fillRect(0, 0, this.matrixCanvas.width, this.matrixCanvas.height);
             
-            ctx.fillStyle = '#00ff00';
-            ctx.font = `${fontSize}px 'Fira Code', monospace`;
+            ctx.fillStyle = '#DC2626';
+            ctx.font = `${fontSize}px 'Open Sans', Arial, system-ui, sans-serif`;
             
             for (let i = 0; i < drops.length; i++) {
                 const text = chars[Math.floor(Math.random() * chars.length)];
@@ -1528,8 +1528,9 @@ const additionalStyles = `
 }
 
 .command-text {
-    color: #00ffaa;
+    color: #ffffff;
     font-weight: 600;
+    border-bottom: 1px solid #DC2626;
 }
 
 .response-text {
@@ -1541,25 +1542,27 @@ const additionalStyles = `
 }
 
 .error-text {
-    color: #ff6b6b;
+    color: #ffffff;
     font-weight: 500;
+    border-left: 3px solid #DC2626;
+    padding-left: 10px;
 }
 
 /* Theme-specific colors */
 [data-theme="matrix"] .response-text {
-    color: #00ff00;
+    color: #ffffff;
 }
 
 [data-theme="retro"] .response-text {
-    color: #ff00ff;
+    color: #ffffff;
 }
 
 [data-theme="neon"] .response-text {
-    color: #00ffff;
+    color: #ffffff;
 }
 
 [data-theme="corporate"] .response-text {
-    color: #fbbf24;
+    color: #ffffff;
 }
 
 .um-terminal.maximized {


### PR DESCRIPTION
## Summary
- Normalize advanced terminal fallback/contact copy away from Terminal CLI wording
- Replace matrix/neon prompt and response colors with canonical UMSA #DC2626 or white high-contrast text
- Remove green Matrix inline styling from public fallback output

## Validation
- node --check public/UMCliPlugin.js
- node --check public/UMTerminalEngine.js
- node --check public/js/UMTerminalAdvanced.js
- git diff --check
- npm run audit:css (0 commercial errors; existing shadow warnings only)
- npm run lint (0 errors; existing warnings)
- npm run build