### PR TITLE
fix: normalize terminal effect modes

### DIFF
--- a/public/UMCliPlugin.js
+++ b/public/UMCliPlugin.js
@@ -352,7 +352,7 @@ ${filteredResults.map((result, index) =>
 
 💬 WHATSAPP COMERCIAL:
    📱 +54 261 123 4567
-   💭 "Hola! Vengo desde su terminal CLI"
+   💭 "Hola! Vengo desde el sitio web de ULTIMA MILLA"
 
 ⏰ HORARIOS DE ATENCIÓN:
    📅 Lunes a Viernes: 9:00 - 18:00
@@ -791,10 +791,10 @@ class UMCliPlugin {
         border-left: 3px solid #DC2626;
         padding-left: 10px;
         text-shadow: none;
-        animation: matrix-glow 1s infinite alternate;
+        animation: um-data-pulse 1s infinite alternate;
       }
 
-      @keyframes matrix-glow {
+      @keyframes um-data-pulse {
         from { opacity: 0.8; }
         to { opacity: 1; }
       }

--- a/public/terminalEnhanced.js
+++ b/public/terminalEnhanced.js
@@ -369,7 +369,7 @@ class EnhancedTerminal {
   • export               - Exportar datos (en desarrollo)
 
 🎨 PERSONALIZACIÓN:
-  • theme [tema]         - Cambiar tema visual (professional|matrix|retro|hacker)
+  • theme [tema]         - Cambiar modo visual (professional|datos|archivo|diagnostico)
   • fullscreen           - Modo pantalla completa
 
 ⚡ OPTIMIZACIÓN Y RENDIMIENTO:
@@ -702,11 +702,11 @@ Clientes activos: 150+ | Tasa de satisfacción: 98%
         } else {
             // Fallback to basic theming
             if (args.length === 0) {
-                return `<span class="command-info">Tema actual: dark. Disponibles: dark, light, matrix</span>`;
+                return `<span class="command-info">Tema actual: dark. Disponibles: dark, light, datos</span>`;
             }
 
             const theme = args[0].toLowerCase();
-            const validThemes = ['dark', 'light', 'matrix'];
+            const validThemes = ['dark', 'light', 'datos', 'matrix'];
 
             if (validThemes.includes(theme)) {
                 this.applyTheme(theme);
@@ -718,6 +718,13 @@ Clientes activos: 150+ | Tasa de satisfacción: 98%
     }
 
     applyTheme(theme) {
+        const aliases = {
+            datos: 'matrix',
+            archivo: 'retro',
+            diagnostico: 'hacker'
+        };
+        theme = aliases[theme] || theme;
+
         const terminal = this.container.querySelector('.um-terminal-enhanced');
         if (terminal) {
             terminal.className = terminal.className.replace(/theme-\w+/g, '');
@@ -800,7 +807,8 @@ Clientes activos: 150+ | Tasa de satisfacción: 98%
             'whoami', 'date', 'echo', 'history', 'contacto', 'contact',
             'servicios', 'services', 'antecedentes', 'casos', 'projects',
             'stats', 'estadisticas', 'theme', 'fullscreen',
-            'theme professional', 'theme matrix', 'theme retro', 'theme hacker',
+            'theme professional', 'theme datos', 'theme archivo', 'theme diagnostico',
+            'theme matrix', 'theme retro', 'theme hacker',
             'performance', 'perf', 'cache', 'memory',
             'performance metrics', 'performance clear', 'performance optimize',
             'cache status', 'cache clear', 'cache info',

--- a/public/uiEffects.css
+++ b/public/uiEffects.css
@@ -74,7 +74,7 @@
   padding: 8px 12px;
   margin: 4px 0;
   border-radius: 6px;
-  font-size: 0.9em;
+  font-size: 1rem;
   opacity: 0;
   transform: translateX(-20px);
   transition: opacity var(--animation-speed) ease-out, transform var(--animation-speed) ease-out;
@@ -219,16 +219,16 @@
   box-shadow: 0 0 8px var(--terminal-glow);
 }
 
-/* Matrix Loader */
+/* Data Loader */
 .matrix-loader {
-  font-family: monospace;
-  font-size: 1.2em;
+  font-family: Open Sans, Arial, system-ui, sans-serif;
+  font-size: 1rem;
   color: var(--terminal-primary);
 }
 
 .matrix-loader span {
   animation: matrix-spin 1s linear infinite;
-  text-shadow: 0 0 8px var(--terminal-glow);
+  text-shadow: none;
 }
 
 @keyframes matrix-spin {
@@ -241,7 +241,7 @@
 
 /* Loading Message */
 .loading-message {
-  font-size: 0.9em;
+  font-size: 1rem;
   color: var(--terminal-text);
   text-align: center;
   opacity: 0.8;
@@ -275,9 +275,9 @@
   padding: 8px 12px;
   border-bottom: 1px solid var(--terminal-border);
   display: flex;
-  justify-content: between;
+  justify-content: space-between;
   align-items: center;
-  font-size: 0.8em;
+  font-size: 1rem;
   color: var(--terminal-secondary);
 }
 
@@ -293,7 +293,7 @@
   color: var(--terminal-text);
   padding: 2px 6px;
   border-radius: 10px;
-  font-size: 0.8em;
+  font-size: 1rem;
   min-width: 20px;
   text-align: center;
 }
@@ -315,30 +315,30 @@
 
 .suggestion-item:hover,
 .suggestion-item.active {
-  background: rgba(0, 212, 170, 0.1);
+  background: rgba(220, 38, 38, 0.12);
   border-left-color: var(--terminal-primary);
 }
 
 .suggestion-icon {
-  font-size: 0.9em;
+  font-size: 1rem;
   opacity: 0.7;
 }
 
 .suggestion-text {
   flex: 1;
-  font-family: 'Fira Code', monospace;
-  font-size: 0.9em;
+  font-family: Open Sans, Arial, system-ui, sans-serif;
+  font-size: 1rem;
 }
 
 .suggestion-text mark {
   background: var(--terminal-primary);
-  color: #000;
+  color: #ffffff;
   border-radius: 2px;
   padding: 0 2px;
 }
 
 .suggestion-shortcut {
-  font-size: 0.7em;
+  font-size: 1rem;
   opacity: 0.6;
   background: var(--terminal-border);
   padding: 2px 4px;
@@ -347,7 +347,7 @@
 
 /* THEME SPECIFIC STYLES */
 
-/* Matrix Theme */
+/* Data Theme */
 .theme-matrix {
   --terminal-bg: #050505;
   --terminal-primary: #DC2626;
@@ -374,7 +374,7 @@
   z-index: 1;
 }
 
-/* Retro Theme */
+/* Archive Theme */
 .theme-retro {
   --terminal-bg: #18181b;
   --terminal-primary: #DC2626;
@@ -403,7 +403,7 @@
   z-index: 2;
 }
 
-/* Hacker Theme */
+/* Diagnostics Theme */
 .theme-hacker {
   --terminal-bg: #050505;
   --terminal-primary: #DC2626;
@@ -461,7 +461,7 @@
 }
 
 .fullscreen-control-item:hover {
-  background: rgba(0, 212, 170, 0.2);
+  background: rgba(220, 38, 38, 0.14);
   border-color: var(--terminal-primary);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px var(--terminal-glow);
@@ -472,7 +472,7 @@
 }
 
 .control-label {
-  font-size: 0.7em;
+  font-size: 1rem;
   color: var(--terminal-text);
   opacity: 0.8;
   text-transform: uppercase;
@@ -499,12 +499,12 @@
   }
   
   .command-feedback {
-    font-size: 0.8em;
+    font-size: 1rem;
     padding: 6px 10px;
   }
   
   #input-suggestions {
-    font-size: 0.9em;
+    font-size: 1rem;
   }
   
   .suggestion-item {

--- a/public/uiEffectsSystem.js
+++ b/public/uiEffectsSystem.js
@@ -28,7 +28,7 @@ class UIEffectsSystem {
                 glow: 'rgba(220, 38, 38, 0.36)'
             },
             matrix: {
-                name: 'Matrix',
+                name: 'Modo datos',
                 background: '#050505',
                 primary: '#DC2626',
                 secondary: '#ffffff',
@@ -38,7 +38,7 @@ class UIEffectsSystem {
                 glow: 'rgba(220, 38, 38, 0.36)'
             },
             retro: {
-                name: 'Retro',
+                name: 'Archivo',
                 background: '#18181b',
                 primary: '#DC2626',
                 secondary: '#f5f5f5',
@@ -48,7 +48,7 @@ class UIEffectsSystem {
                 glow: 'rgba(220, 38, 38, 0.34)'
             },
             hacker: {
-                name: 'Hacker',
+                name: 'Diagnostico',
                 background: '#050505',
                 primary: '#DC2626',
                 secondary: '#ffffff',
@@ -288,7 +288,7 @@ class UIEffectsSystem {
                 
             case 'matrix':
                 loaderContent = `
-                    <div class="matrix-loader">
+                    <div class="matrix-loader" aria-label="Modo datos">
                         <span>|</span><span>/</span><span>-</span><span>\\</span>
                     </div>
                     <div class="loading-message">${message}</div>
@@ -331,6 +331,13 @@ class UIEffectsSystem {
 
     // THEME SYSTEM
     switchTheme(themeName) {
+        const aliases = {
+            datos: 'matrix',
+            archivo: 'retro',
+            diagnostico: 'hacker'
+        };
+        themeName = aliases[themeName] || themeName;
+
         if (!this.themes[themeName]) {
             console.warn(`Theme ${themeName} not found`);
             return false;
@@ -385,7 +392,7 @@ class UIEffectsSystem {
                 
             case 'hacker':
                 terminal.classList.add('hacker-glitch');
-                this.startHackerGlitch();
+                this.startDiagnosticsSignal();
                 break;
         }
     }
@@ -412,9 +419,9 @@ class UIEffectsSystem {
             canvas.width = terminal.offsetWidth;
             canvas.height = terminal.offsetHeight;
 
-            const matrix = '01ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+            const signal = '01UMSAREDESSERVICIOSDATOS';
             const drops = [];
-            const columns = canvas.width / 15;
+            const columns = canvas.width / 16;
 
             for (let i = 0; i < columns; i++) {
                 drops[i] = 1;
@@ -425,13 +432,13 @@ class UIEffectsSystem {
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
 
                 ctx.fillStyle = '#DC2626';
-                ctx.font = '15px monospace';
+                ctx.font = '16px Open Sans, Arial, system-ui, sans-serif';
 
                 for (let i = 0; i < drops.length; i++) {
-                    const text = matrix[Math.floor(Math.random() * matrix.length)];
-                    ctx.fillText(text, i * 15, drops[i] * 15);
+                    const text = signal[Math.floor(Math.random() * signal.length)];
+                    ctx.fillText(text, i * 16, drops[i] * 16);
 
-                    if (drops[i] * 15 > canvas.height && Math.random() > 0.975) {
+                    if (drops[i] * 16 > canvas.height && Math.random() > 0.975) {
                         drops[i] = 0;
                     }
                     drops[i]++;
@@ -445,23 +452,23 @@ class UIEffectsSystem {
         }
     }
 
-    startHackerGlitch() {
+    startDiagnosticsSignal() {
         const terminal = document.getElementById('um-terminal-enhanced');
         if (!terminal) return;
 
-        const glitch = () => {
-            if (Math.random() < 0.1) {
-                terminal.style.filter = 'hue-rotate(' + Math.random() * 360 + 'deg) saturate(2)';
-                terminal.style.transform = 'translate(' + (Math.random() * 4 - 2) + 'px, ' + (Math.random() * 4 - 2) + 'px)';
+        const diagnostics = () => {
+            if (Math.random() < 0.08) {
+                terminal.style.filter = 'contrast(1.04)';
+                terminal.style.transform = 'translateY(-1px)';
                 
                 setTimeout(() => {
                     terminal.style.filter = '';
                     terminal.style.transform = '';
-                }, 100);
+                }, 120);
             }
         };
 
-        const glitchInterval = setInterval(glitch, 500);
+        const glitchInterval = setInterval(diagnostics, 700);
         terminal.dataset.glitchInterval = glitchInterval;
     }
 


### PR DESCRIPTION
## Summary
- replace remaining terminal contact copy with site-web wording
- rename public terminal effect labels to corporate data/archive/diagnostics modes while preserving legacy aliases
- remove off-brand cyan hover/glitch treatment and raise visible microtext to 1rem
- fix invalid CSS justify-content value in suggestions header

## Verification
- node --check public/UMCliPlugin.js
- node --check public/terminalEnhanced.js
- node --check public/uiEffectsSystem.js
- git diff --check
- npm run audit:css
- npm run lint
- npm run build
- npm test -- --runInBand