### PR TITLE
fix: refine terminal UI copy

### DIFF
--- a/public/js/UMTerminalAdvanced.js
+++ b/public/js/UMTerminalAdvanced.js
@@ -1,6 +1,6 @@
 /**
  * UMTerminal Advanced Engine v3.0
- * Features: Themes, animations, enhanced commands, Matrix effects, AI-like responses
+ * Features: Themes, animations, enhanced commands, data modes, guided responses
  * Integration of server-side engine with client-side enhancements
  */
 
@@ -200,7 +200,7 @@ class UMTerminalAdvanced {
             this.terminal.setAttribute('data-theme', theme);
         }
         
-        // Special effects for Matrix theme
+        // Data-mode visual effect.
         if (theme === 'matrix') {
             this.startMatrixRain();
         } else {
@@ -245,7 +245,7 @@ class UMTerminalAdvanced {
     }
     
     handleResize() {
-        // Update Matrix canvas size if it exists
+        // Update data-mode canvas size if it exists.
         if (this.matrixCanvas && this.terminal) {
             this.matrixCanvas.width = this.terminal.offsetWidth;
             this.matrixCanvas.height = this.terminal.offsetHeight;
@@ -529,10 +529,10 @@ class UMTerminalAdvanced {
 • ps                   Procesos activos (proyectos)
 • history [número]     Historial de comandos
 
-🎨 EFECTOS Y DIVERSIÓN:
-• matrix               Activar efecto Matrix
-• fortune              Frase inspiracional aleatoria
-• cowsay "mensaje"     Vaca habladora de UM
+🎨 MODOS Y UTILIDADES:
+• matrix               Activar modo datos
+• fortune              Frase operativa aleatoria
+• cowsay "mensaje"     Mensaje ASCII de UM
 
 📞 CONTACTO Y DEMO:
 • contacto [mensaje]   Enviar consulta al equipo
@@ -810,20 +810,20 @@ if __name__ == "__main__":
 # ULTIMA MILLA - Terminal Interactivo
 
 ## 🚀 Descripción
-Terminal empresarial avanzado con IA integrada para explorar 22 años 
-de experiencia en desarrollo tecnológico.
+Terminal empresarial para explorar 22 años de proyectos, clientes
+e infraestructura tecnológica.
 
 ## ⚡ Características
 - **469+ proyectos** documentados y navegables
 - **150+ clientes** del sector público y privado  
-- **Temas visuales** (Matrix, Retro, Neon, Corporate)
+- **Modos visuales** (Datos, Archivo, Diagnostico, Corporativo)
 - **Comandos inteligentes** con autocompletado
 - **Integración en tiempo real** con sistemas UM
 
 ## 🎯 Comandos Principales
 - \`help\` - Lista completa de comandos
 - \`stats\` - Estadísticas empresariales  
-- \`matrix\` - Efecto visual Matrix
+- \`matrix\` - Modo datos
 - \`contacto\` - Formulario de contacto directo
 
 ## 🛠️ Tecnologías
@@ -883,7 +883,7 @@ de experiencia en desarrollo tecnológico.
 💰 Presupuesto: $4.500.000
 ⭐ Resultado: 0 incidentes de seguridad, certificación ISO 27001
 
-💡 Cada proyecto refleja nuestro compromiso con la excelencia
+💡 Cada proyecto refleja continuidad operativa y trazabilidad técnica
 💡 Usa 'grep [cliente]' para buscar proyectos específicos
             `
         };
@@ -995,7 +995,7 @@ ${results.join('\n')}
         
         return {
             output: `
-🟢 INICIANDO MATRIX PROTOCOL...
+INICIANDO MODO DATOS...
 
 U L T I M A   M I L L A   N E T W O R K
 █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░
@@ -1007,17 +1007,17 @@ ${this.servicios.length}   P R O Y E C T O S   A C T I V O S
 █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░ █▓▒░
 2 0 0 3   ─ ─ ─ →   2 0 2 5   ─ ─ ─ →   ∞
 
-🔴 The Matrix has you... 🔴
-¿Tomar la píldora roja o azul? [R/a] 
+ULTIMA MILLA - datos operativos
+¿Ver historial técnico o volver al terminal? [H/v]
 
-💊 PÍLDORA ROJA: Descubre la verdad de 22 años de código
-💊 PÍLDORA AZUL: Regresa al terminal normal
+HISTORIAL: 22 años de proyectos, redes y software
+VOLVER: Regresa al terminal normal
 
-🌐 CONECTANDO A LA MATRIX DE ULTIMA MILLA...
+CONECTANDO A LA RED DE DATOS ULTIMA MILLA...
 ⚡ Cargando datos en tiempo real...
 🔒 Acceso autorizado: NIVEL_DESARROLLADOR
 
-Tip: El efecto Matrix está activo en el fondo 👀
+Tip: el modo datos está activo en el fondo
             `
         };
     }
@@ -1030,7 +1030,7 @@ Tip: El efecto Matrix está activo en el fondo 👀
             "22 años conectando sueños con realidad tecnológica.",
             "No hay problemas de redes que no podamos resolver. - Equipo UM",
             "El código limpio siempre parece que fue escrito por alguien que se preocupa. - Robert C. Martin",
-            "La excelencia tecnológica se construye proyecto a proyecto. - Ultima Milla",
+            "La continuidad operativa se construye proyecto a proyecto. - Ultima Milla",
             "Desde Mendoza para el mundo: conectamos el futuro digitalmente.",
             "Un bug es una feature no documentada. - Desarrolladores UM",
             "En la nube o en tierra, Ultima Milla te conecta donde estés."
@@ -1095,7 +1095,7 @@ Tema activo: ${this.currentTheme}
 • ISO 27001 (Seguridad de la Información)
 • Partner Microsoft & AWS
 
-22 años de excelencia tecnológica 🚀
+22 años de infraestructura operativa
                 `
             };
         }

--- a/public/uiEffects.css
+++ b/public/uiEffects.css
@@ -527,7 +527,7 @@
   }
   
   .control-label {
-    font-size: 0.6em;
+    font-size: 1rem;
   }
 }
 

--- a/src/services/umCliService.js
+++ b/src/services/umCliService.js
@@ -552,10 +552,10 @@ Ejecute 'help' para ver todos los comandos disponibles.
 • history               Historial de comandos
 • ps [--área]           Proyectos activos
 
-🎭 EASTER EGGS:
-• fortune               Frase motivacional
-• matrix                Efecto Matrix UM
-• cowsay [mensaje]      Arte ASCII
+🎭 UTILIDADES:
+• fortune               Frase operativa
+• matrix                Modo datos UM
+• cowsay [mensaje]      Mensaje ASCII
 
 💡 EJEMPLOS:
 • grep "Quilmes"        → Busca proyectos de Quilmes
@@ -607,7 +607,7 @@ Para ayuda específica: help [comando]
   matrix() {
     return {
       output: `
-🔴 Activando Matrix Effect...
+Activando modo datos...
 
 U L T I M A   M I L L A   S Y S T E M S
 █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
@@ -618,7 +618,7 @@ Q U I L M E S   A F I P   G O B I E R N O
 2 0 0 3   →   2 0 2 4   →   ∞
 █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
 
-¿Seguir el conejo blanco? [S/n] _
+¿Ver historial tecnico? [S/n] _
       `
     };
   }


### PR DESCRIPTION
## Summary
- Raises fullscreen terminal control label text from 0.6em to 1rem to comply with the visible-text floor.
- Replaces public terminal fallback copy that read as Matrix/neon/AI demo language with restrained corporate data-mode language.
- Keeps existing command aliases and function names intact to avoid breaking terminal behavior.

## Validation
- node --check public/js/UMTerminalAdvanced.js
- node --check src/services/umCliService.js
- git diff --check
- npm run lint (warnings only, pre-existing)
- npm run audit:css (0 commercial errors, 8 pre-existing shadow warnings)
- npm run typecheck
- npm run test:ci (29 suites, 252 tests)
- npm run build
- local preview HTTP 200 for /, /js/UMTerminalAdvanced.js and /uiEffects.css
- served assets contain new data-mode copy and no old Matrix/AI/excellence copy