### PR TITLE
fix: restore directus-backed api routes

### DIFF
--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -190,13 +190,13 @@ async function obtenerContenidoPublicado<T = unknown>(
 
 // 6. Funciones específicas para cada colección (LEGACY - mantener por compatibilidad)
 export const getServicios = async (limite: number = 10) =>
-  obtenerContenidoPublicado('servicios', { limite });
+  (await getServiciosV4()).slice(0, limite);
 
 export const getBlogPosts = async (limite: number = 10) =>
   obtenerContenidoPublicado('blog_posts', { limite });
 
 export const getCasosExito = async (limite: number = 10) =>
-  obtenerContenidoPublicado('casos_de_exito', { limite });
+  (await getAllAntecedentes()).slice(0, limite);
 
 // ==========================================
 // 7. FUNCIONES V4 - Sistema de Diseño V4
@@ -222,7 +222,8 @@ export async function getServiciosV4(): Promise<ServicioV4[]> {
           'PorQueElegirnos',
           'Area',
           'Cliente',
-          'Productos'
+          'Productos',
+          'slug',
         ],
         sort: ['id']
       })
@@ -266,7 +267,8 @@ export async function getServicioConProductos(id: number | string): Promise<Serv
           'PorQueElegirnos',
           'Area',
           'Cliente',
-          'Productos'
+          'Productos',
+          'slug',
         ]
       })
     );
@@ -652,6 +654,7 @@ export async function getAllAntecedentes(): Promise<AntecedenteV4[]> {
       'Fecha',
       'Presupuesto',
       'original_id',
+      'slug',
     ].join(',');
     const response = await requestDirectusJson<{ data?: AntecedenteV4[] }>(
       `/items/Antecedentes?fields=${encodeURIComponent(fields)}&sort[]=-Fecha&sort[]=-id&limit=-1`,

--- a/src/pages/api/cli/query-directus.ts
+++ b/src/pages/api/cli/query-directus.ts
@@ -1,17 +1,20 @@
 import type { APIRoute } from 'astro';
-
-// CONEXIÓN DIRECTA CON DIRECTUS REAL - SEGÚN PREMISAS PLAN.MD
-// OBJETIVO: Acceso a TODOS los 469 antecedentes + 9 servicios con URLs reales
-
-interface DirectusItem {
-    id: number;
-    title: string;
-    content?: string;
-    description?: string;
-    client?: string;
-    slug?: string;
-    date_created?: string;
-}
+import {
+    CLI_ANTECEDENTES_FIELDS,
+    CLI_SERVICIOS_FIELDS,
+    antecedenteClient,
+    antecedenteDescription,
+    antecedenteTitle,
+    antecedenteUrl,
+    getCliDirectusHeaders,
+    getCliDirectusRuntime,
+    readCliSearchQuery,
+    servicioDescription,
+    servicioTitle,
+    servicioUrl,
+    type CliAntecedente,
+    type CliServicio,
+} from '../../../utils/cliDirectus';
 
 interface FormattedResult {
     id: number;
@@ -27,22 +30,16 @@ interface FormattedResult {
 }
 
 // DIRECTUS API CONNECTION - REAL DATA ACCESS
-async function queryDirectusReal(searchQuery: string): Promise<{antecedentes: DirectusItem[], servicios: DirectusItem[]}> {
+async function queryDirectusReal(searchQuery: string): Promise<{antecedentes: CliAntecedente[], servicios: CliServicio[]}> {
     try {
-        const token = import.meta.env.DIRECTUS_STATIC_TOKEN || import.meta.env.PUBLIC_DIRECTUS_TOKEN || '';
-        const directusUrl = import.meta.env.DIRECTUS_INTERNAL_URL || import.meta.env.PUBLIC_DIRECTUS_URL || 'http://localhost:8055';
-        if (!token) return { antecedentes: [], servicios: [] };
+        const { directusUrl, token } = getCliDirectusRuntime();
+        const headers = getCliDirectusHeaders(token);
         
         // BUSCAR EN ANTECEDENTES REALES (469 registros) - AMPLIO ALCANCE
-        const antecedentesUrl = `${directusUrl}/items/Antecedentes?limit=20&search=${encodeURIComponent(searchQuery)}&fields=id,title,content,client,date_created,slug&sort=-date_created`;
+        const antecedentesUrl = `${directusUrl}/items/Antecedentes?limit=20&search=${encodeURIComponent(searchQuery)}&fields=${CLI_ANTECEDENTES_FIELDS}&sort=-Fecha`;
         
         // BUSCAR EN SERVICIOS REALES (9 registros)
-        const serviciosUrl = `${directusUrl}/items/Servicios?limit=10&search=${encodeURIComponent(searchQuery)}&fields=id,title,description,slug`;
-        
-        const headers = {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-        };
+        const serviciosUrl = `${directusUrl}/items/Servicios?limit=10&search=${encodeURIComponent(searchQuery)}&fields=${CLI_SERVICIOS_FIELDS}`;
         
         // PARALLEL REQUESTS para máximo rendimiento
         const [antecedentesResponse, serviciosResponse] = await Promise.all([
@@ -88,101 +85,45 @@ function expandSearchQuery(query: string): string[] {
 }
 
 // FORMAT RESULTS WITH REAL URLs - SOLO URLs QUE EXISTEN VERIFICADAMENTE
-function formatResults(directusData: {antecedentes: DirectusItem[], servicios: DirectusItem[]}, originalQuery: string): FormattedResult[] {
+function formatResults(directusData: {antecedentes: CliAntecedente[], servicios: CliServicio[]}): FormattedResult[] {
     const results: FormattedResult[] = [];
-    
-    // ⚠️ CRÍTICO: SOLO usar URLs que sabemos que EXISTEN
-    // Basado en las URLs reales verificadas en las memorias del proyecto
-    
-    // URLs REALES CONOCIDAS (de las memorias):
-    const knownValidUrls: Record<string, string> = {
-        // ANTECEDENTES VERIFICADOS
-        '10769': 'ministerio-de-deportes-gobierno-de-mendoza-redes-y',
-        '10771': 'bodega-domaine-bousquet-redes-y-comunicaciones', 
-        '10775': 'municipalidad-de-maipu-redes-y-comunicaciones',
-        '10777': 'cnn-software-a-medida',
-        '10787': 'verde-pimienta-espana-software-a-medida',
-        
-        // SERVICIOS VERIFICADOS  
-        '1': 'servicios-it',
-        '2': 'redes-de-datos',
-        '3': 'seguridad-informatica', 
-        '4': 'servicios-gestionados',
-        '5': 'consultoria-tecnologica',
-        '11': 'servicios-web'
-    };
-    
-    // FORMATEAR ANTECEDENTES - SOLO URLs VERIFICADAS
+
+    // FORMATEAR ANTECEDENTES - usar slug real del CMS o índice genérico
     directusData.antecedentes.forEach((antecedente) => {
-        const knownSlug = knownValidUrls[antecedente.id.toString()];
-        
-        // SOLO incluir si tenemos el slug verificado, sino NO generar URL falsa
-        if (knownSlug) {
-            const realUrl = `https://www.ultimamilla.com.ar/antecedentes/${antecedente.id}/${knownSlug}`;
-            
-            results.push({
-                id: antecedente.id,
-                type: 'antecedente',
-                icon: '📊',
-                title: antecedente.title,
-                content: (antecedente.content || 'Proyecto empresarial técnico').slice(0, 280) + '...',
-                url: realUrl,
-                client: antecedente.client || null,
-                image: null,
-                email_link: `/api/cli/email?type=antecedente&id=${antecedente.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre: ${antecedente.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa conocer más sobre el proyecto: ${antecedente.title}\n\nVer detalles: ${realUrl}\n\nSaludos cordiales`)}`
-            });
-        } else {
-            // NO GENERAR URL FALSA - Solo incluir sin URL hasta verificar
-            results.push({
-                id: antecedente.id,
-                type: 'antecedente',
-                icon: '📊',
-                title: antecedente.title,
-                content: (antecedente.content || 'Proyecto empresarial técnico').slice(0, 280) + '...',
-                url: '/antecedentes', // URL genérica a la página de antecedentes
-                client: antecedente.client || null,
-                image: null,
-                email_link: `/api/cli/email?type=antecedente&id=${antecedente.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre: ${antecedente.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa conocer más sobre el proyecto: ${antecedente.title}\n\nMás información en: https://www.ultimamilla.com.ar/antecedentes\n\nSaludos cordiales`)}`
-            });
-        }
+        const title = antecedenteTitle(antecedente);
+        const realUrl = antecedenteUrl(antecedente);
+
+        results.push({
+            id: antecedente.id,
+            type: 'antecedente',
+            icon: '📊',
+            title,
+            content: antecedenteDescription(antecedente),
+            url: realUrl,
+            client: antecedenteClient(antecedente),
+            image: null,
+            email_link: `/api/cli/email?type=antecedente&id=${antecedente.id}`,
+            mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa conocer más sobre el proyecto: ${title}\n\nVer detalles: ${realUrl}\n\nSaludos cordiales`)}`
+        });
     });
     
-    // FORMATEAR SERVICIOS - SOLO URLs VERIFICADAS
+    // FORMATEAR SERVICIOS - usar slug real del CMS o índice genérico
     directusData.servicios.forEach((servicio) => {
-        const knownSlug = knownValidUrls[servicio.id.toString()];
-        
-        if (knownSlug) {
-            const realUrl = `https://www.ultimamilla.com.ar/servicios/${servicio.id}/${knownSlug}`;
-            
-            results.push({
-                id: servicio.id,
-                type: 'servicio',
-                icon: '🛠️',
-                title: servicio.title,
-                content: (servicio.description || 'Servicio profesional especializado').slice(0, 280) + '...',
-                url: realUrl,
-                client: null,
-                image: null,
-                email_link: `/api/cli/email?type=servicio&id=${servicio.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre servicio: ${servicio.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa contratar el servicio: ${servicio.title}\n\nVer información: ${realUrl}\n\nAguardo su contacto`)}`
-            });
-        } else {
-            // URL genérica a servicios si no conocemos el slug específico
-            results.push({
-                id: servicio.id,
-                type: 'servicio',
-                icon: '🛠️',
-                title: servicio.title,
-                content: (servicio.description || 'Servicio profesional especializado').slice(0, 280) + '...',
-                url: '/servicios',
-                client: null,
-                image: null,
-                email_link: `/api/cli/email?type=servicio&id=${servicio.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre servicio: ${servicio.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa contratar el servicio: ${servicio.title}\n\nMás información en: https://www.ultimamilla.com.ar/servicios\n\nAguardo su contacto`)}`
-            });
-        }
+        const title = servicioTitle(servicio);
+        const realUrl = servicioUrl(servicio);
+
+        results.push({
+            id: servicio.id,
+            type: 'servicio',
+            icon: '🛠️',
+            title,
+            content: servicioDescription(servicio),
+            url: realUrl,
+            client: null,
+            image: null,
+            email_link: `/api/cli/email?type=servicio&id=${servicio.id}`,
+            mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta sobre servicio: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa contratar el servicio: ${title}\n\nVer información: ${realUrl}\n\nAguardo su contacto`)}`
+        });
     });
     
     return results;
@@ -191,31 +132,21 @@ function formatResults(directusData: {antecedentes: DirectusItem[], servicios: D
 // MAIN API ENDPOINT - AMPLIADO SEGÚN PLAN.MD
 export const POST: APIRoute = async ({ request }) => {
     try {
-        const { query } = await request.json();
-        
-        if (!query || query.trim().length < 2) {
-            return new Response(JSON.stringify({
-                error: true,
-                message: 'Query muy corta. Mínimo 2 caracteres.',
-                fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto']
-            }), { 
-                status: 400,
-                headers: { 'Content-Type': 'application/json' }
-            });
-        }
-        
-        const searchQuery = query.toLowerCase().trim();
-        console.log(`[UM-CLI] Processing query: "${searchQuery}"`);
+        const parsed = await readCliSearchQuery(request);
+        if (!parsed.ok) return parsed.response;
+
+        const searchQuery = parsed.query.toLowerCase();
+        console.warn(`[UM-CLI] Processing query: "${searchQuery}"`);
         
         // EXPANDED SEARCH según premisas PLAN.MD
         const expandedTerms = expandSearchQuery(searchQuery);
-        console.log(`[UM-CLI] Expanded terms:`, expandedTerms);
+        console.warn(`[UM-CLI] Expanded terms:`, expandedTerms);
         
         // QUERY DIRECTUS REAL DATA
         const directusData = await queryDirectusReal(searchQuery);
         
         // FORMAT WITH REAL URLs
-        const formattedResults = formatResults(directusData, searchQuery);
+        const formattedResults = formatResults(directusData);
         
         // RESPONSE CON ESTADÍSTICAS EXPANDIDAS
         const response = {
@@ -232,7 +163,7 @@ export const POST: APIRoute = async ({ request }) => {
             }
         };
         
-        console.log(`[UM-CLI] Response: ${formattedResults.length} results for "${searchQuery}"`);
+        console.warn(`[UM-CLI] Response: ${formattedResults.length} results for "${searchQuery}"`);
         
         return new Response(JSON.stringify(response), {
             status: 200,

--- a/src/pages/api/cli/query-real-only.ts
+++ b/src/pages/api/cli/query-real-only.ts
@@ -1,16 +1,20 @@
 import type { APIRoute } from 'astro';
-
-// CRÍTICO: SOLO URLs REALES - NUNCA INVENTAR URLs
-// Basado en corrección por violación de orden del usuario
-
-interface DirectusResult {
-    id: number;
-    title: string;
-    content?: string;
-    client?: string;
-    description?: string;
-    slug?: string;
-}
+import {
+    CLI_ANTECEDENTES_FIELDS,
+    CLI_SERVICIOS_FIELDS,
+    antecedenteClient,
+    antecedenteDescription,
+    antecedenteTitle,
+    antecedenteUrl,
+    getCliDirectusHeaders,
+    getCliDirectusRuntime,
+    readCliSearchQuery,
+    servicioDescription,
+    servicioTitle,
+    servicioUrl,
+    type CliAntecedente,
+    type CliServicio,
+} from '../../../utils/cliDirectus';
 
 interface FormattedResult {
     id: number;
@@ -27,43 +31,17 @@ interface FormattedResult {
 // CONEXIÓN DIRECTA A DIRECTUS REAL - SOLO URLs VERIFICADAS
 async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResult[]> {
     try {
-        const token = import.meta.env.DIRECTUS_STATIC_TOKEN || import.meta.env.PUBLIC_DIRECTUS_TOKEN || '';
-        const directusUrl = import.meta.env.DIRECTUS_INTERNAL_URL || import.meta.env.PUBLIC_DIRECTUS_URL || 'http://localhost:8055';
-        if (!token) return [];
-        
-        // ⚠️ CRÍTICO: URLs REALES CONOCIDAS (de memorias del proyecto)
-        // NO GENERAR URLs INVENTADAS - SOLO ESTAS VERIFICADAS
-        const knownValidUrls: Record<string, string> = {
-            // ANTECEDENTES VERIFICADOS EN PRODUCCIÓN
-            '10769': 'ministerio-de-deportes-gobierno-de-mendoza-redes-y',
-            '10771': 'bodega-domaine-bousquet-redes-y-comunicaciones', 
-            '10775': 'municipalidad-de-maipu-redes-y-comunicaciones',
-            '10777': 'cnn-software-a-medida',
-            '10787': 'verde-pimienta-espana-software-a-medida',
-            
-            // SERVICIOS VERIFICADOS EN PRODUCCIÓN 
-            '1': 'servicios-it',
-            '2': 'redes-de-datos',
-            '3': 'seguridad-informatica', 
-            '4': 'servicios-gestionados',
-            '5': 'consultoria-tecnologica',
-            '11': 'servicios-web'
-        };
-        
+        const { directusUrl, token } = getCliDirectusRuntime();
+        const headers = getCliDirectusHeaders(token);
+
         // BUSCAR EN ANTECEDENTES REALES
-        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=10&search=${encodeURIComponent(searchQuery)}&fields=id,title,content,client&sort=-id`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=10&search=${encodeURIComponent(searchQuery)}&fields=${CLI_ANTECEDENTES_FIELDS}&sort=-Fecha`, {
+            headers,
         });
         
         // BUSCAR EN SERVICIOS REALES
-        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=5&search=${encodeURIComponent(searchQuery)}&fields=id,title,description&sort=id`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=5&search=${encodeURIComponent(searchQuery)}&fields=${CLI_SERVICIOS_FIELDS}&sort=id`, {
+            headers,
         });
         
         const results: FormattedResult[] = [];
@@ -71,26 +49,22 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
         // PROCESAR ANTECEDENTES
         if (antecedentesResponse.ok) {
             const antecedentesData = await antecedentesResponse.json();
-            const antecedentes: DirectusResult[] = antecedentesData.data || [];
+            const antecedentes: CliAntecedente[] = antecedentesData.data || [];
             
             antecedentes.forEach((ant) => {
-                const knownSlug = knownValidUrls[ant.id.toString()];
-                
-                // SOLO URLs REALES O GENÉRICAS - NUNCA INVENTADAS
-                const realUrl = knownSlug 
-                    ? `https://www.ultimamilla.com.ar/antecedentes/${ant.id}/${knownSlug}`
-                    : 'https://www.ultimamilla.com.ar/antecedentes'; // Página genérica si no conocemos slug específico
+                const title = antecedenteTitle(ant);
+                const realUrl = antecedenteUrl(ant);
                 
                 results.push({
                     id: ant.id,
                     type: 'antecedente',
                     icon: '📊',
-                    title: ant.title,
-                    content: (ant.content || 'Información disponible en el sitio web').slice(0, 250) + '...',
+                    title,
+                    content: antecedenteDescription(ant, 250),
                     url: realUrl,
-                    client: ant.client || null,
+                    client: antecedenteClient(ant),
                     image: null,
-                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta: ${ant.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el proyecto: ${ant.title}\n\nVer más información: ${realUrl}\n\nSaludos`)}`
+                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el proyecto: ${title}\n\nVer más información: ${realUrl}\n\nSaludos`)}`
                 });
             });
         }
@@ -98,26 +72,22 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
         // PROCESAR SERVICIOS
         if (serviciosResponse.ok) {
             const serviciosData = await serviciosResponse.json();
-            const servicios: DirectusResult[] = serviciosData.data || [];
+            const servicios: CliServicio[] = serviciosData.data || [];
             
             servicios.forEach((serv) => {
-                const knownSlug = knownValidUrls[serv.id.toString()];
-                
-                // SOLO URLs REALES O GENÉRICAS - NUNCA INVENTADAS
-                const realUrl = knownSlug 
-                    ? `https://www.ultimamilla.com.ar/servicios/${serv.id}/${knownSlug}`
-                    : 'https://www.ultimamilla.com.ar/servicios'; // Página genérica si no conocemos slug específico
+                const title = servicioTitle(serv);
+                const realUrl = servicioUrl(serv);
                 
                 results.push({
                     id: serv.id,
                     type: 'servicio',
                     icon: '🛠️',
-                    title: serv.title,
-                    content: (serv.description || 'Servicio profesional disponible').slice(0, 250) + '...',
+                    title,
+                    content: servicioDescription(serv, 250),
                     url: realUrl,
                     client: null,
                     image: null,
-                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta servicio: ${serv.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el servicio: ${serv.title}\n\nVer más información: ${realUrl}\n\nAguardo su contacto`)}`
+                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta servicio: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el servicio: ${title}\n\nVer más información: ${realUrl}\n\nAguardo su contacto`)}`
                 });
             });
         }
@@ -133,21 +103,11 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
 // API ENDPOINT CORREGIDO - SOLO URLs REALES
 export const POST: APIRoute = async ({ request }) => {
     try {
-        const { query } = await request.json();
-        
-        if (!query || query.trim().length < 2) {
-            return new Response(JSON.stringify({
-                error: true,
-                message: 'Query muy corta. Mínimo 2 caracteres.',
-                fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto']
-            }), { 
-                status: 400,
-                headers: { 'Content-Type': 'application/json' }
-            });
-        }
-        
-        const searchQuery = query.toLowerCase().trim();
-        console.log(`[CLI] Processing: "${searchQuery}"`);
+        const parsed = await readCliSearchQuery(request);
+        if (!parsed.ok) return parsed.response;
+
+        const searchQuery = parsed.query.toLowerCase();
+        console.warn(`[CLI] Processing: "${searchQuery}"`);
         
         // CONSULTAR DIRECTUS CON URLs REALES SOLAMENTE
         const results = await queryDirectusRealOnly(searchQuery);
@@ -165,7 +125,7 @@ export const POST: APIRoute = async ({ request }) => {
             }
         };
         
-        console.log(`[CLI] Response: ${results.length} results (REAL URLs only)`);
+        console.warn(`[CLI] Response: ${results.length} results (REAL URLs only)`);
         
         return new Response(JSON.stringify(response), {
             status: 200,

--- a/src/pages/api/cli/query-simple.ts
+++ b/src/pages/api/cli/query-simple.ts
@@ -1,6 +1,22 @@
 import type { APIRoute } from 'astro';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import {
+    CLI_ANTECEDENTES_FIELDS,
+    CLI_SERVICIOS_FIELDS,
+    antecedenteClient,
+    antecedenteDescription,
+    antecedenteTitle,
+    antecedenteUrl,
+    getCliDirectusHeaders,
+    getCliDirectusRuntime,
+    readCliSearchQuery,
+    servicioDescription,
+    servicioTitle,
+    servicioUrl,
+    type CliAntecedente,
+    type CliServicio,
+} from '../../../utils/cliDirectus';
 
 // Enable server-side rendering for this endpoint
 export const prerender = false;
@@ -29,24 +45,17 @@ async function queryDatabase(sql: string, params: string[] = []) {
 // CONECTAR DIRECTAMENTE CON DIRECTUS REAL - 469 antecedentes + 9 servicios
 async function queryDirectusAPI(searchQuery: string): Promise<any> {
     try {
-        const token = import.meta.env.DIRECTUS_STATIC_TOKEN || import.meta.env.PUBLIC_DIRECTUS_TOKEN || '';
-        const directusUrl = import.meta.env.DIRECTUS_INTERNAL_URL || import.meta.env.PUBLIC_DIRECTUS_URL || 'http://localhost:8055';
-        if (!token) return { antecedentes: [], servicios: [] };
+        const { directusUrl, token } = getCliDirectusRuntime();
+        const headers = getCliDirectusHeaders(token);
         
         // BUSCAR EN ANTECEDENTES REALES (469 registros)
-        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=50&search=${encodeURIComponent(searchQuery)}&fields=id,title,content,client,date_created,slug`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=50&search=${encodeURIComponent(searchQuery)}&fields=${CLI_ANTECEDENTES_FIELDS}&sort=-Fecha`, {
+            headers,
         });
         
         // BUSCAR EN SERVICIOS REALES (9 registros)
-        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=10&search=${encodeURIComponent(searchQuery)}&fields=id,title,description,slug`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=10&search=${encodeURIComponent(searchQuery)}&fields=${CLI_SERVICIOS_FIELDS}`, {
+            headers,
         });
         
         const antecedentes = antecedentesResponse.ok ? (await antecedentesResponse.json()).data : [];
@@ -61,18 +70,10 @@ async function queryDirectusAPI(searchQuery: string): Promise<any> {
 
 export const POST: APIRoute = async ({ request }) => {
     try {
-        const { query } = await request.json();
-        
-        if (!query || query.trim().length < 2) {
-            return new Response(JSON.stringify({
-                error: 'Query muy corta. Mínimo 2 caracteres.'
-            }), { 
-                status: 400,
-                headers: { 'Content-Type': 'application/json' }
-            });
-        }
-        
-        const searchQuery = query.toLowerCase().trim();
+        const parsed = await readCliSearchQuery(request);
+        if (!parsed.ok) return parsed.response;
+
+        const searchQuery = parsed.query.toLowerCase();
         
         // CONSULTAR DIRECTUS REAL - 469 antecedentes + 9 servicios
         const directusData = await queryDirectusAPI(searchQuery);
@@ -80,38 +81,40 @@ export const POST: APIRoute = async ({ request }) => {
         const formattedResults: any[] = [];
         
         // FORMATEAR ANTECEDENTES REALES CON URLs REALES
-        directusData.antecedentes.forEach((antecedente: any) => {
-            const realUrl = `https://www.ultimamilla.com.ar/antecedentes/${antecedente.id}/${antecedente.slug || 'detalle'}`;
+        directusData.antecedentes.forEach((antecedente: CliAntecedente) => {
+            const title = antecedenteTitle(antecedente);
+            const realUrl = antecedenteUrl(antecedente);
             
             formattedResults.push({
                 id: antecedente.id,
                 type: 'antecedente',
                 icon: '📊',
-                title: antecedente.title,
-                content: (antecedente.content || 'Información no disponible').slice(0, 300) + '...',
+                title,
+                content: antecedenteDescription(antecedente, 300),
                 url: realUrl,
-                client: antecedente.client || null,
+                client: antecedenteClient(antecedente),
                 image: null,
                 email_link: `/api/cli/query?action=email&id=${antecedente.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Información sobre: ${antecedente.title}`)}&body=${encodeURIComponent(`Hola,\n\nTe envío información sobre el proyecto: ${antecedente.title}\n\nMás detalles: ${realUrl}\n\nSaludos,\nEquipo Ultima Milla`)}`
+                mailto_link: `mailto:?subject=${encodeURIComponent(`Información sobre: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nTe envío información sobre el proyecto: ${title}\n\nMás detalles: ${realUrl}\n\nSaludos,\nEquipo Ultima Milla`)}`
             });
         });
         
         // FORMATEAR SERVICIOS REALES CON URLs REALES  
-        directusData.servicios.forEach((servicio: any) => {
-            const realUrl = `https://www.ultimamilla.com.ar/servicios/${servicio.id}/${servicio.slug || 'detalle'}`;
+        directusData.servicios.forEach((servicio: CliServicio) => {
+            const title = servicioTitle(servicio);
+            const realUrl = servicioUrl(servicio);
             
             formattedResults.push({
                 id: servicio.id,
                 type: 'servicio',
                 icon: '🛠️',
-                title: servicio.title,
-                content: (servicio.description || 'Información no disponible').slice(0, 300) + '...',
+                title,
+                content: servicioDescription(servicio, 300),
                 url: realUrl,
                 client: null,
                 image: null,
                 email_link: `/api/cli/query?action=email&id=${servicio.id}`,
-                mailto_link: `mailto:?subject=${encodeURIComponent(`Información sobre: ${servicio.title}`)}&body=${encodeURIComponent(`Hola,\n\nTe envío información sobre el servicio: ${servicio.title}\n\nMás detalles: ${realUrl}\n\nSaludos,\nEquipo Ultima Milla`)}`
+                mailto_link: `mailto:?subject=${encodeURIComponent(`Información sobre: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nTe envío información sobre el servicio: ${title}\n\nMás detalles: ${realUrl}\n\nSaludos,\nEquipo Ultima Milla`)}`
             });
         });
         
@@ -153,7 +156,7 @@ export const POST: APIRoute = async ({ request }) => {
                 suggestions.push({
                     type: 'help',
                     icon: '💡',
-                    title: `Sin resultados para "${query}"`,
+                    title: `Sin resultados para "${searchQuery}"`,
                     content: 'Intenta con: "seguridad", "redes", "desarrollo", "cámaras", "wifi" o "antecedentes"',
                     url: '/servicios'
                 });

--- a/src/pages/api/cli/query.ts
+++ b/src/pages/api/cli/query.ts
@@ -1,16 +1,20 @@
 import type { APIRoute } from 'astro';
-
-// CRÍTICO: SOLO URLs REALES - NUNCA INVENTAR URLs
-// Basado en corrección por violación de orden del usuario
-
-interface DirectusResult {
-    id: number;
-    title: string;
-    content?: string;
-    client?: string;
-    description?: string;
-    slug?: string;
-}
+import {
+    CLI_ANTECEDENTES_FIELDS,
+    CLI_SERVICIOS_FIELDS,
+    antecedenteClient,
+    antecedenteDescription,
+    antecedenteTitle,
+    antecedenteUrl,
+    getCliDirectusHeaders,
+    getCliDirectusRuntime,
+    readCliSearchQuery,
+    servicioDescription,
+    servicioTitle,
+    servicioUrl,
+    type CliAntecedente,
+    type CliServicio,
+} from '../../../utils/cliDirectus';
 
 interface FormattedResult {
     id: number;
@@ -27,43 +31,17 @@ interface FormattedResult {
 // CONEXIÓN DIRECTA A DIRECTUS REAL - SOLO URLs VERIFICADAS
 async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResult[]> {
     try {
-        const token = import.meta.env.DIRECTUS_STATIC_TOKEN || import.meta.env.PUBLIC_DIRECTUS_TOKEN || '';
-        const directusUrl = import.meta.env.DIRECTUS_INTERNAL_URL || import.meta.env.PUBLIC_DIRECTUS_URL || 'http://localhost:8055';
-        if (!token) return [];
-        
-        // ⚠️ CRÍTICO: URLs REALES CONOCIDAS (de memorias del proyecto)
-        // NO GENERAR URLs INVENTADAS - SOLO ESTAS VERIFICADAS
-        const knownValidUrls: Record<string, string> = {
-            // ANTECEDENTES VERIFICADOS EN PRODUCCIÓN
-            '10769': 'ministerio-de-deportes-gobierno-de-mendoza-redes-y',
-            '10771': 'bodega-domaine-bousquet-redes-y-comunicaciones', 
-            '10775': 'municipalidad-de-maipu-redes-y-comunicaciones',
-            '10777': 'cnn-software-a-medida',
-            '10787': 'verde-pimienta-espana-software-a-medida',
-            
-            // SERVICIOS VERIFICADOS EN PRODUCCIÓN 
-            '1': 'servicios-it',
-            '2': 'redes-de-datos',
-            '3': 'seguridad-informatica', 
-            '4': 'servicios-gestionados',
-            '5': 'consultoria-tecnologica',
-            '11': 'servicios-web'
-        };
-        
+        const { directusUrl, token } = getCliDirectusRuntime();
+        const headers = getCliDirectusHeaders(token);
+
         // BUSCAR EN ANTECEDENTES REALES
-        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=10&search=${encodeURIComponent(searchQuery)}&fields=id,title,content,client&sort=-id`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const antecedentesResponse = await fetch(`${directusUrl}/items/Antecedentes?limit=10&search=${encodeURIComponent(searchQuery)}&fields=${CLI_ANTECEDENTES_FIELDS}&sort=-Fecha`, {
+            headers,
         });
         
         // BUSCAR EN SERVICIOS REALES
-        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=5&search=${encodeURIComponent(searchQuery)}&fields=id,title,description&sort=id`, {
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            }
+        const serviciosResponse = await fetch(`${directusUrl}/items/Servicios?limit=5&search=${encodeURIComponent(searchQuery)}&fields=${CLI_SERVICIOS_FIELDS}&sort=id`, {
+            headers,
         });
         
         const results: FormattedResult[] = [];
@@ -71,26 +49,22 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
         // PROCESAR ANTECEDENTES
         if (antecedentesResponse.ok) {
             const antecedentesData = await antecedentesResponse.json();
-            const antecedentes: DirectusResult[] = antecedentesData.data || [];
+            const antecedentes: CliAntecedente[] = antecedentesData.data || [];
             
             antecedentes.forEach((ant) => {
-                const knownSlug = knownValidUrls[ant.id.toString()];
-                
-                // SOLO URLs REALES O GENÉRICAS - NUNCA INVENTADAS
-                const realUrl = knownSlug 
-                    ? `https://www.ultimamilla.com.ar/antecedentes/${ant.id}/${knownSlug}`
-                    : 'https://www.ultimamilla.com.ar/antecedentes'; // Página genérica si no conocemos slug específico
+                const title = antecedenteTitle(ant);
+                const realUrl = antecedenteUrl(ant);
                 
                 results.push({
                     id: ant.id,
                     type: 'antecedente',
                     icon: '📊',
-                    title: ant.title,
-                    content: (ant.content || 'Información disponible en el sitio web').slice(0, 250) + '...',
+                    title,
+                    content: antecedenteDescription(ant, 250),
                     url: realUrl,
-                    client: ant.client || null,
+                    client: antecedenteClient(ant),
                     image: null,
-                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta: ${ant.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el proyecto: ${ant.title}\n\nVer más información: ${realUrl}\n\nSaludos`)}`
+                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el proyecto: ${title}\n\nVer más información: ${realUrl}\n\nSaludos`)}`
                 });
             });
         }
@@ -98,26 +72,22 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
         // PROCESAR SERVICIOS
         if (serviciosResponse.ok) {
             const serviciosData = await serviciosResponse.json();
-            const servicios: DirectusResult[] = serviciosData.data || [];
+            const servicios: CliServicio[] = serviciosData.data || [];
             
             servicios.forEach((serv) => {
-                const knownSlug = knownValidUrls[serv.id.toString()];
-                
-                // SOLO URLs REALES O GENÉRICAS - NUNCA INVENTADAS
-                const realUrl = knownSlug 
-                    ? `https://www.ultimamilla.com.ar/servicios/${serv.id}/${knownSlug}`
-                    : 'https://www.ultimamilla.com.ar/servicios'; // Página genérica si no conocemos slug específico
+                const title = servicioTitle(serv);
+                const realUrl = servicioUrl(serv);
                 
                 results.push({
                     id: serv.id,
                     type: 'servicio',
                     icon: '🛠️',
-                    title: serv.title,
-                    content: (serv.description || 'Servicio profesional disponible').slice(0, 250) + '...',
+                    title,
+                    content: servicioDescription(serv, 250),
                     url: realUrl,
                     client: null,
                     image: null,
-                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta servicio: ${serv.title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el servicio: ${serv.title}\n\nVer más información: ${realUrl}\n\nAguardo su contacto`)}`
+                    mailto_link: `mailto:?subject=${encodeURIComponent(`Consulta servicio: ${title}`)}&body=${encodeURIComponent(`Hola,\n\nMe interesa el servicio: ${title}\n\nVer más información: ${realUrl}\n\nAguardo su contacto`)}`
                 });
             });
         }
@@ -133,21 +103,11 @@ async function queryDirectusRealOnly(searchQuery: string): Promise<FormattedResu
 // API ENDPOINT CORREGIDO - SOLO URLs REALES
 export const POST: APIRoute = async ({ request }) => {
     try {
-        const { query } = await request.json();
-        
-        if (!query || query.trim().length < 2) {
-            return new Response(JSON.stringify({
-                error: true,
-                message: 'Query muy corta. Mínimo 2 caracteres.',
-                fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto']
-            }), { 
-                status: 400,
-                headers: { 'Content-Type': 'application/json' }
-            });
-        }
-        
-        const searchQuery = query.toLowerCase().trim();
-        console.log(`[CLI] Processing: "${searchQuery}"`);
+        const parsed = await readCliSearchQuery(request);
+        if (!parsed.ok) return parsed.response;
+
+        const searchQuery = parsed.query.toLowerCase();
+        console.warn(`[CLI] Processing: "${searchQuery}"`);
         
         // CONSULTAR DIRECTUS CON URLs REALES SOLAMENTE
         const results = await queryDirectusRealOnly(searchQuery);
@@ -165,7 +125,7 @@ export const POST: APIRoute = async ({ request }) => {
             }
         };
         
-        console.log(`[CLI] Response: ${results.length} results (REAL URLs only)`);
+        console.warn(`[CLI] Response: ${results.length} results (REAL URLs only)`);
         
         return new Response(JSON.stringify(response), {
             status: 200,

--- a/src/pages/api/get-articles.ts
+++ b/src/pages/api/get-articles.ts
@@ -1,12 +1,24 @@
-// src/pages/api/get-articles.ts
-export async function get() {
-    const { getItems } = await import('../../lib/directus');
-    const articles = await getItems('articles');
-    
-    return new Response(JSON.stringify(articles), {
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+  try {
+    const { getBlogPosts } = await import('../../lib/directus');
+    const articles = await getBlogPosts(20);
+
+    return new Response(JSON.stringify({ success: true, data: articles }), {
       status: 200,
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+      },
+    });
+  } catch {
+    return new Response(JSON.stringify({ success: false, error: 'articles_unavailable' }), {
+      status: 502,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
     });
   }
+};

--- a/src/pages/api/umcli.json.ts
+++ b/src/pages/api/umcli.json.ts
@@ -37,10 +37,9 @@ export const GET: APIRoute = async ({ request }) => {
     return new Response(
       JSON.stringify({ success: false, error: error?.message || 'unknown_error' }),
       {
-        status: 200,
+        status: 502,
         headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' }
       }
     );
   }
 };
-

--- a/src/utils/cliDirectus.ts
+++ b/src/utils/cliDirectus.ts
@@ -1,0 +1,181 @@
+import { getDirectusInternalUrl, getDirectusToken } from '../config/runtime';
+
+export const CLI_ANTECEDENTES_FIELDS = 'id,Titulo,Nombre,Descripcion,Cliente,Fecha,slug';
+export const CLI_SERVICIOS_FIELDS = 'id,Titulo,Descripcion,slug';
+export const PUBLIC_SITE_URL = 'https://www.ultimamilla.com.ar';
+
+export type CliAntecedente = {
+  id: number;
+  Titulo?: string;
+  Nombre?: string;
+  Descripcion?: string;
+  Cliente?: string;
+  Fecha?: string;
+  slug?: string;
+  title?: string;
+  content?: string;
+  client?: string;
+};
+
+export type CliServicio = {
+  id: number;
+  Titulo?: string;
+  Descripcion?: string;
+  slug?: string;
+  title?: string;
+  description?: string;
+};
+
+export type CliQueryParseResult =
+  | {
+      ok: true;
+      query: string;
+    }
+  | {
+      ok: false;
+      response: Response;
+    };
+
+function jsonResponse(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function getCliDirectusRuntime() {
+  return {
+    directusUrl: getDirectusInternalUrl().replace(/\/$/, ''),
+    token: getDirectusToken(),
+  };
+}
+
+export function getCliDirectusHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+export async function readCliSearchQuery(request: Request): Promise<CliQueryParseResult> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: jsonResponse(
+        {
+          error: true,
+          message: 'JSON inválido.',
+          fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto'],
+        },
+        400,
+      ),
+    };
+  }
+
+  const rawQuery = body.query;
+  if (typeof rawQuery !== 'string') {
+    return {
+      ok: false,
+      response: jsonResponse(
+        {
+          error: true,
+          message: 'Query requerida.',
+          fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto'],
+        },
+        400,
+      ),
+    };
+  }
+
+  const query = rawQuery.trim();
+  if (query.length < 2) {
+    return {
+      ok: false,
+      response: jsonResponse(
+        {
+          error: true,
+          message: 'Query muy corta. Mínimo 2 caracteres.',
+          fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto'],
+        },
+        400,
+      ),
+    };
+  }
+
+  if (query.length > 120) {
+    return {
+      ok: false,
+      response: jsonResponse(
+        {
+          error: true,
+          message: 'Query demasiado larga. Máximo 120 caracteres.',
+          fallback_commands: ['help', 'servicios', 'antecedentes', 'contacto'],
+        },
+        400,
+      ),
+    };
+  }
+
+  return { ok: true, query };
+}
+
+function cleanText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function excerpt(value: string, fallback: string, length: number): string {
+  const text = cleanText(value) || fallback;
+  return text.length > length ? `${text.slice(0, length)}...` : text;
+}
+
+function absolutePath(path: string): string {
+  return `${PUBLIC_SITE_URL}${path}`;
+}
+
+export function antecedenteTitle(item: CliAntecedente): string {
+  return cleanText(item.Titulo) || cleanText(item.Nombre) || cleanText(item.title) || `Antecedente ${item.id}`;
+}
+
+export function antecedenteDescription(item: CliAntecedente, length = 280): string {
+  return excerpt(
+    cleanText(item.Descripcion) || cleanText(item.content),
+    'Información disponible en el sitio web',
+    length,
+  );
+}
+
+export function antecedenteClient(item: CliAntecedente): string | null {
+  return cleanText(item.Cliente) || cleanText(item.client) || null;
+}
+
+export function antecedenteUrl(item: CliAntecedente): string {
+  const slug = cleanText(item.slug);
+  return slug ? absolutePath(`/antecedentes/${slug}`) : absolutePath('/antecedentes');
+}
+
+export function servicioTitle(item: CliServicio): string {
+  return cleanText(item.Titulo) || cleanText(item.title) || `Servicio ${item.id}`;
+}
+
+export function servicioDescription(item: CliServicio, length = 280): string {
+  return excerpt(
+    cleanText(item.Descripcion) || cleanText(item.description),
+    'Servicio profesional disponible',
+    length,
+  );
+}
+
+export function servicioUrl(item: CliServicio): string {
+  const slug = cleanText(item.slug);
+  return slug ? absolutePath(`/servicios/${item.id}/${slug}`) : absolutePath('/servicios');
+}


### PR DESCRIPTION
Summary
- restore the public get-articles API handler with the current Astro GET export
- route legacy servicios and casos helpers through the real Servicios and Antecedentes sources
- update the UM CLI API routes to query the current Directus schema and shared runtime config

Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- pre-patch production checks showed get-articles returning 404, umcli returning empty servicios and antecedentes, and CLI Directus searches returning empty results for real queries