### PR TITLE
fix: restore antecedentes and cli routes after slug permission regression

### DIFF
--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -223,7 +223,6 @@ export async function getServiciosV4(): Promise<ServicioV4[]> {
           'Area',
           'Cliente',
           'Productos',
-          'slug',
         ],
         sort: ['id']
       })
@@ -268,7 +267,6 @@ export async function getServicioConProductos(id: number | string): Promise<Serv
           'Area',
           'Cliente',
           'Productos',
-          'slug',
         ]
       })
     );
@@ -654,7 +652,6 @@ export async function getAllAntecedentes(): Promise<AntecedenteV4[]> {
       'Fecha',
       'Presupuesto',
       'original_id',
-      'slug',
     ].join(',');
     const response = await requestDirectusJson<{ data?: AntecedenteV4[] }>(
       `/items/Antecedentes?fields=${encodeURIComponent(fields)}&sort[]=-Fecha&sort[]=-id&limit=-1`,

--- a/src/utils/cliDirectus.ts
+++ b/src/utils/cliDirectus.ts
@@ -1,7 +1,8 @@
 import { getDirectusInternalUrl, getDirectusToken } from '../config/runtime';
+import { generateSlug } from './slugUtils.js';
 
-export const CLI_ANTECEDENTES_FIELDS = 'id,Titulo,Nombre,Descripcion,Cliente,Fecha,slug';
-export const CLI_SERVICIOS_FIELDS = 'id,Titulo,Descripcion,slug';
+export const CLI_ANTECEDENTES_FIELDS = 'id,Titulo,Nombre,Descripcion,Cliente,Fecha';
+export const CLI_SERVICIOS_FIELDS = 'id,Titulo,Descripcion';
 export const PUBLIC_SITE_URL = 'https://www.ultimamilla.com.ar';
 
 export type CliAntecedente = {
@@ -159,7 +160,7 @@ export function antecedenteClient(item: CliAntecedente): string | null {
 }
 
 export function antecedenteUrl(item: CliAntecedente): string {
-  const slug = cleanText(item.slug);
+  const slug = cleanText(item.slug) || generateSlug(antecedenteTitle(item));
   return slug ? absolutePath(`/antecedentes/${slug}`) : absolutePath('/antecedentes');
 }
 
@@ -176,6 +177,6 @@ export function servicioDescription(item: CliServicio, length = 280): string {
 }
 
 export function servicioUrl(item: CliServicio): string {
-  const slug = cleanText(item.slug);
+  const slug = cleanText(item.slug) || generateSlug(servicioTitle(item));
   return slug ? absolutePath(`/servicios/${item.id}/${slug}`) : absolutePath('/servicios');
 }


### PR DESCRIPTION
Summary
- promote the develop hotfix that stops requesting slug from Directus in production-facing antecedentes and servicios queries
- derive public slugs locally from titles instead
- restore antecedentes listing, umcli payloads and CLI search routes after the regression introduced by PR #126

Validation
- npm run lint
- npm run typecheck
- npm run test:ci
- npm run build
- production regression observed after deploy 27617157834: antecedentes showed 0 projects, umcli returned 502, and the smoke test failed because no antecedentes links rendered