### PR TITLE
release: promote seo and umcli contract alignment

### DIFF
--- a/__tests__/i18nRoutes.test.js
+++ b/__tests__/i18nRoutes.test.js
@@ -1,0 +1,19 @@
+const {
+  resolveEnglishPath,
+  resolvePageLanguage,
+  resolveSpanishPath,
+} = require('../src/config/i18nRoutes.ts');
+
+describe('i18nRoutes', () => {
+  test('detects english paths consistently for layout and SEO metadata', () => {
+    expect(resolvePageLanguage('/')).toBe('es');
+    expect(resolvePageLanguage('/contacto')).toBe('es');
+    expect(resolvePageLanguage('/en')).toBe('en');
+    expect(resolvePageLanguage('/en/services')).toBe('en');
+  });
+
+  test('keeps alternate path mappings stable', () => {
+    expect(resolveSpanishPath('/en/about')).toBe('/nosotros');
+    expect(resolveEnglishPath('/contacto')).toBe('/en/contacto');
+  });
+});

--- a/__tests__/umcliApi.test.js
+++ b/__tests__/umcliApi.test.js
@@ -1,0 +1,73 @@
+const directus = require('../src/lib/directus');
+
+jest.mock('../src/lib/directus', () => ({
+  getServicios: jest.fn(),
+  getAllAntecedentes: jest.fn(),
+  getBlogPosts: jest.fn(),
+}));
+
+class TestResponse {
+  constructor(body, init = {}) {
+    this.body = body;
+    this.status = init.status || 200;
+    this.headers = init.headers || {};
+  }
+
+  async json() {
+    return JSON.parse(this.body);
+  }
+}
+
+describe('UM CLI JSON API', () => {
+  const originalResponse = global.Response;
+
+  beforeEach(() => {
+    global.Response = TestResponse;
+    directus.getServicios.mockReset();
+    directus.getAllAntecedentes.mockReset();
+    directus.getBlogPosts.mockReset();
+  });
+
+  afterAll(() => {
+    global.Response = originalResponse;
+  });
+
+  test('returns a non-2xx status when Directus payload generation fails', async () => {
+    directus.getServicios.mockRejectedValueOnce(new Error('Directus down'));
+    directus.getAllAntecedentes.mockResolvedValueOnce([]);
+    directus.getBlogPosts.mockResolvedValueOnce([]);
+
+    const { GET } = require('../src/pages/api/umcli.json.ts');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.success).toBe(false);
+  });
+
+  test('returns full antecedente counts with legacy-friendly fields', async () => {
+    directus.getServicios.mockResolvedValueOnce([
+      { id: 101, Titulo: 'Infraestructura de Redes', Descripcion: 'Redes y fibra', Area: 'Redes' },
+    ]);
+    directus.getAllAntecedentes.mockResolvedValueOnce([
+      { id: 3064, Titulo: 'Caso A', Descripcion: 'Resumen A', Fecha: '2026-06-01', Cliente: 'Cliente A', Area: 'Gobierno' },
+      { id: 3065, Titulo: 'Caso B', Descripcion: 'Resumen B', Fecha: '2026-06-02', Cliente: 'Cliente B', Area: 'Salud' },
+    ]);
+    directus.getBlogPosts.mockResolvedValueOnce([
+      { id: 1, titulo: 'Post A' },
+    ]);
+
+    const { GET } = require('../src/pages/api/umcli.json.ts');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.estadisticas.totalServicios).toBe(1);
+    expect(body.data.estadisticas.totalAntecedentes).toBe(2);
+    expect(body.data.estadisticas.totalCasosExito).toBe(2);
+    expect(body.data.servicios[0].titulo).toBe('Infraestructura de Redes');
+    expect(body.data.casos_de_exito[0].titulo).toBe('Caso A');
+    expect(body.data.casos_de_exito[0].fecha_publicacion).toBe('2026-06-01');
+  });
+});

--- a/src/components/SEO/SEOHead.astro
+++ b/src/components/SEO/SEOHead.astro
@@ -9,7 +9,7 @@
  * Font links, GA4 tracking, and <style> blocks stay in the layout.
  */
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION, BUSINESS_ADDRESS } from '../../config/seo';
-import { resolveEnglishPath, resolveSpanishPath } from '../../config/i18nRoutes';
+import { resolveEnglishPath, resolvePageLanguage, resolveSpanishPath } from '../../config/i18nRoutes';
 import { editorialImages, editorialImageDimensions } from '../../data/editorialImageSystem';
 import { canonicalUrl as toCanonicalUrl, clampText, publicImageUrl, stripWww } from '../../utils/seoUrl';
 
@@ -61,6 +61,10 @@ const currentUrl = canonical
   : toCanonicalUrl(Astro.url.pathname);
 
 const pathname = Astro.url.pathname;
+const pageLang = resolvePageLanguage(pathname);
+const pageLanguageTag = pageLang === 'en' ? 'en' : 'es-AR';
+const dcLanguage = pageLang === 'en' ? 'en' : 'es';
+const ogLocale = pageLang === 'en' ? 'en_US' : 'es_AR';
 const spanishPath = resolveSpanishPath(pathname);
 const englishPath = resolveEnglishPath(pathname);
 const hreflangEsUrl = toCanonicalUrl(spanishPath);
@@ -122,7 +126,7 @@ const organizationSchema = {
   url: SITE_URL,
   logo: `${SITE_URL}/images/um-logo.png`,
   description: SITE_DESCRIPTION,
-  inLanguage: "es-AR",
+  inLanguage: pageLanguageTag,
   foundingDate: "2000",
   address: {
     "@type": "PostalAddress",
@@ -158,7 +162,7 @@ const localBusinessSchema = {
   "@type": "LocalBusiness",
   name: SITE_NAME,
   description: SITE_DESCRIPTION,
-  inLanguage: "es-AR",
+  inLanguage: pageLanguageTag,
   url: SITE_URL,
   email: "contacto@ultimamilla.com.ar",
   address: {
@@ -221,7 +225,7 @@ const serviceSchema = service
       "@type": "Service",
       name: `${service.name} en Mendoza`,
       description: service.description,
-      inLanguage: "es-AR",
+      inLanguage: pageLanguageTag,
       provider: {
         "@type": "LocalBusiness",
         name: SITE_NAME,
@@ -287,7 +291,7 @@ const combinedSchema = {
   <meta name="author" content={SITE_NAME} />
   <meta name="publisher" content={SITE_NAME} />
   <meta name="copyright" content={`© ${currentYear} ${SITE_NAME}`} />
-  <meta name="language" content="es-AR" />
+  <meta name="language" content={pageLanguageTag} />
   <meta name="revisit-after" content="7 days" />
   <meta name="rating" content="general" />
   <meta name="distribution" content="global" />
@@ -323,7 +327,7 @@ const combinedSchema = {
   <meta name="dc.coverage" content="Mendoza, Argentina" />
   <meta name="dc.type" content="Service" />
   <meta name="dc.format" content="text/html" />
-  <meta name="dc.language" content="es" />
+  <meta name="dc.language" content={dcLanguage} />
 
   <!-- Canonical URL -->
   <link rel="canonical" href={currentUrl} />
@@ -353,7 +357,7 @@ const combinedSchema = {
   {normalizedOgImageHeight && <meta property="og:image:height" content={normalizedOgImageHeight} />}
   <meta property="og:image:alt" content={metaTitle} />
   <meta property="og:site_name" content={SITE_NAME} />
-  <meta property="og:locale" content="es_AR" />
+  <meta property="og:locale" content={ogLocale} />
   {stableUpdatedTime && <meta property="og:updated_time" content={stableUpdatedTime} />}
 
   <!-- Twitter -->

--- a/src/config/i18nRoutes.ts
+++ b/src/config/i18nRoutes.ts
@@ -42,3 +42,7 @@ export function hasEnglishAlternate(pathname: string): boolean {
   if (normalized.startsWith('/en')) return EN_TO_ES_PATH[normalized] !== undefined;
   return Object.values(EN_TO_ES_PATH).includes(normalized);
 }
+
+export function resolvePageLanguage(pathname: string): 'es' | 'en' {
+  return pathname === '/en' || pathname.startsWith('/en/') ? 'en' : 'es';
+}

--- a/src/layouts/LayoutV4.astro
+++ b/src/layouts/LayoutV4.astro
@@ -12,7 +12,7 @@ import FooterV4 from '../components/v4/FooterV4.astro';
 import ContactModal from '../components/um/ContactModal.astro';
 import SEOHead from '../components/SEO/SEOHead.astro';
 import { SITE_URL } from '../config/seo';
-import { hasEnglishAlternate } from '../config/i18nRoutes';
+import { hasEnglishAlternate, resolvePageLanguage } from '../config/i18nRoutes';
 import { getDevSkinVariant } from '../utils/skinVariant';
 import '../styles/v4.css';
 
@@ -68,7 +68,7 @@ if (Astro.url.pathname !== "/") {
 
 const skinVariant = getDevSkinVariant(Astro.url, import.meta.env.DEV) ?? 'hybrid';
 const skinAttribute = skinVariant;
-const pageLang = Astro.url.pathname === '/en' || Astro.url.pathname.startsWith('/en/') ? 'en' : 'es';
+const pageLang = resolvePageLanguage(Astro.url.pathname);
 const skipLinkLabel = pageLang === 'en' ? 'Skip to main content' : 'Saltar al contenido principal';
 const shouldEmitHreflang = hasEnglishAlternate(Astro.url.pathname);
 ---

--- a/src/pages/api/umcli.json.ts
+++ b/src/pages/api/umcli.json.ts
@@ -1,14 +1,41 @@
 import type { APIRoute } from 'astro';
-import { getServicios, getCasosExito, getBlogPosts } from '../../lib/directus';
+import { getServicios, getAllAntecedentes, getBlogPosts } from '../../lib/directus';
 
-export const GET: APIRoute = async ({ request }) => {
+function normalizeServicioForUmCli(servicio: any) {
+  return {
+    ...servicio,
+    titulo: servicio?.titulo || servicio?.Titulo || servicio?.nombre || '',
+    nombre: servicio?.nombre || servicio?.Titulo || servicio?.titulo || '',
+    descripcion: servicio?.descripcion || servicio?.Descripcion || '',
+    area: servicio?.area || servicio?.Area || '',
+  };
+}
+
+function normalizeAntecedenteForUmCli(antecedente: any) {
+  const titulo = antecedente?.titulo || antecedente?.Titulo || antecedente?.Nombre || '';
+  const resumen = antecedente?.resumen || antecedente?.Descripcion || antecedente?.descripcion || '';
+  const fechaPublicacion = antecedente?.fecha_publicacion || antecedente?.Fecha || null;
+
+  return {
+    ...antecedente,
+    titulo,
+    nombre: antecedente?.nombre || antecedente?.Nombre || titulo,
+    resumen,
+    fecha_publicacion: fechaPublicacion,
+    cliente: antecedente?.cliente || antecedente?.Cliente || null,
+    area: antecedente?.area || antecedente?.Area || antecedente?.Unidad_de_negocio || null,
+  };
+}
+
+export const GET: APIRoute = async () => {
   try {
-    // Usar las colecciones correctas: 'servicios' y 'antecedentes'
-    const [servicios, antecedentes, blog_posts] = await Promise.all([
+    const [serviciosRaw, antecedentesRaw, blog_posts] = await Promise.all([
       getServicios(50),
-      getCasosExito(50), // Esto mapea a 'antecedentes' internamente
+      getAllAntecedentes(),
       getBlogPosts(50)
     ]);
+    const servicios = serviciosRaw.map(normalizeServicioForUmCli);
+    const antecedentes = antecedentesRaw.map(normalizeAntecedenteForUmCli);
 
     const payload = {
       timestamp: Date.now(),


### PR DESCRIPTION
Summary:
- align SEO language metadata with English routing
- publish full antecedentes catalog through api/umcli.json
- keep UMCLI legacy-friendly field aliases for terminal consumers

Validation:
- npm run test:ci -- __tests__/umcliApi.test.js __tests__/i18nRoutes.test.js __tests__/geoDiscoveryContracts.test.ts
- npm run typecheck
- npm run build