### PR TITLE
test: harden production release audits

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -80,6 +80,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Download build artifacts
         id: download-artifact
         uses: actions/download-artifact@v8
@@ -248,6 +253,12 @@ jobs:
             exit 1
           fi
           echo "✅ All smoke tests passed"
+
+      - name: SEO and GEO release audit
+        run: node scripts/seo-audit.mjs --base-url https://www.ultimamilla.com.ar
+
+      - name: UMCLI release contract audit
+        run: node scripts/umcli-contract-audit.mjs --base-url https://www.ultimamilla.com.ar
 
       - name: Send deployment notification
         if: always()

--- a/__tests__/geoDiscoveryContracts.test.ts
+++ b/__tests__/geoDiscoveryContracts.test.ts
@@ -128,6 +128,22 @@ describe('GEO discovery and commercial hub contracts', () => {
     }
   });
 
+  test('the SEO audit gate enforces locale metadata on public English routes', () => {
+    const auditSource = fs.readFileSync(path.join(repoRoot, 'scripts/seo-audit.mjs'), 'utf8');
+
+    for (const route of ['/en', '/en/services', '/en/about', '/en/contacto']) {
+      expect(auditSource).toContain(route);
+    }
+
+    expect(auditSource).toContain("htmlLang: 'en'");
+    expect(auditSource).toContain("metaLanguage: 'en'");
+    expect(auditSource).toContain("dcLanguage: 'en'");
+    expect(auditSource).toContain("ogLocale: 'en_US'");
+    expect(auditSource).toContain("attrsForMeta(html, 'property', 'og:locale')");
+    expect(auditSource).toContain("attrsForMeta(html, 'name', 'dc.language')");
+    expect(auditSource).toContain("attrsForMeta(html, 'name', 'language')");
+  });
+
   test('llms-full lists the discovery endpoints and core commercial indexes explicitly', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'src/pages/llms-full.txt.ts'), 'utf8');
 

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -75,6 +75,15 @@ describe('Production runtime configuration contracts', () => {
     expect(workflow).not.toContain('TOTAL_IMGS=$((DIRECTUS_IMGS + LOCAL_IMGS))');
   });
 
+  test('production deploy runs SEO locale and UMCLI release contract audits against www', () => {
+    const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
+
+    expect(workflow).toContain('SEO and GEO release audit');
+    expect(workflow).toContain('UMCLI release contract audit');
+    expect(workflow).toContain('node scripts/seo-audit.mjs --base-url https://www.ultimamilla.com.ar');
+    expect(workflow).toContain('node scripts/umcli-contract-audit.mjs --base-url https://www.ultimamilla.com.ar');
+  });
+
   test('production health check matches the live www canonical redirect policy', () => {
     const workflow = fs.readFileSync(path.join(process.cwd(), '.github/workflows/production-deploy.yml'), 'utf8');
 

--- a/__tests__/umcliReleaseAuditContracts.test.js
+++ b/__tests__/umcliReleaseAuditContracts.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('UMCLI release audit contracts', () => {
+  test('production UMCLI audit cross-checks GEO totals and legacy aliases', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'scripts/umcli-contract-audit.mjs'), 'utf8');
+
+    expect(source).toContain('/api/umcli.json');
+    expect(source).toContain('/geo/image-evidence.json');
+    expect(source).toContain('totalServicios');
+    expect(source).toContain('totalAntecedentes');
+    expect(source).toContain('totalCasosExito');
+    expect(source).toContain('totalBlogPosts');
+    expect(source).toContain('blog_posts');
+    expect(source).toContain('titulo');
+    expect(source).toContain('nombre');
+    expect(source).toContain('descripcion');
+    expect(source).toContain('resumen');
+    expect(source).toContain('fecha_publicacion');
+    expect(source).toContain('cliente');
+    expect(source).toContain('area');
+    expect(source).toContain('servicios.length === stats.totalServicios');
+    expect(source).toContain('antecedentes.length === stats.totalAntecedentes');
+    expect(source).toContain('stats.totalAntecedentes === expectedAntecedentes');
+    expect(source).toContain('stats.totalCasosExito === expectedAntecedentes');
+  });
+});

--- a/scripts/seo-audit.mjs
+++ b/scripts/seo-audit.mjs
@@ -5,13 +5,14 @@ const DEFAULT_CANONICAL_BASE_URL = 'https://www.ultimamilla.com.ar';
 const NON_CANONICAL_APEX_URL = 'https://ultimamilla.com.ar';
 
 const CORE_HTML_PATHS = ['/', '/servicios', '/antecedentes', '/blog', '/contacto', '/certificaciones'];
+const ENGLISH_HTML_PATHS = ['/en', '/en/services', '/en/about', '/en/contacto'];
 const GEO_COMMERCIAL_HUB_PATHS = [
   '/servicios-it-empresas-mendoza',
   '/presupuesto-servicios-it-empresas',
   '/proyectos-ingenieria-it-mendoza',
   '/servicios-it-empresas-argentina',
 ];
-const REQUIRED_PATHS = [...CORE_HTML_PATHS, ...GEO_COMMERCIAL_HUB_PATHS];
+const REQUIRED_PATHS = [...CORE_HTML_PATHS, ...ENGLISH_HTML_PATHS, ...GEO_COMMERCIAL_HUB_PATHS];
 
 const GEO_RESOURCE_PATHS = [
   '/geo/brand-facts.json',
@@ -58,6 +59,24 @@ function contentFromTag(tag) {
   return tag.match(/\scontent=["']([^"']+)["']/i)?.[1] || '';
 }
 
+function expectedLocaleContract(path) {
+  if (path === '/en' || path.startsWith('/en/')) {
+    return {
+      htmlLang: 'en',
+      metaLanguage: 'en',
+      dcLanguage: 'en',
+      ogLocale: 'en_US',
+    };
+  }
+
+  return {
+    htmlLang: 'es',
+    metaLanguage: 'es-AR',
+    dcLanguage: 'es',
+    ogLocale: 'es_AR',
+  };
+}
+
 async function fetchText(url, failures) {
   try {
     const response = await fetch(url, { redirect: 'follow' });
@@ -74,19 +93,28 @@ async function auditPage(baseUrl, canonicalBaseUrl, path, failures) {
   const html = await fetchText(url, failures);
   if (!html) return;
 
+  const localeContract = expectedLocaleContract(path);
+  const htmlLang = html.match(/<html[^>]+lang=["']([^"']+)["'][^>]*>/i)?.[1] || '';
   const title = textBetween(html, /<title>([^<]+)<\/title>/i);
   const description = contentFromTag(attrsForMeta(html, 'name', 'description'));
+  const language = contentFromTag(attrsForMeta(html, 'name', 'language'));
+  const dcLanguage = contentFromTag(attrsForMeta(html, 'name', 'dc.language'));
   const robots = contentFromTag(attrsForMeta(html, 'name', 'robots'));
   const canonical = html.match(/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["'][^>]*>/i)?.[1] || '';
   const ogImage = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["'][^>]*>/i)?.[1] || '';
+  const ogLocale = contentFromTag(attrsForMeta(html, 'property', 'og:locale'));
   const jsonLdBlocks = [...html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
 
+  assert(htmlLang === localeContract.htmlLang, `${path} html lang expected ${localeContract.htmlLang} but got ${htmlLang || '(missing)'}`, failures);
   assert(title.length > 0, `${path} missing <title>`, failures);
   assert(title.length <= 75, `${path} title too long (${title.length})`, failures);
   assert(description.length >= 70, `${path} meta description too short (${description.length})`, failures);
   assert(description.length <= 170, `${path} meta description too long (${description.length})`, failures);
+  assert(language === localeContract.metaLanguage, `${path} meta language expected ${localeContract.metaLanguage} but got ${language || '(missing)'}`, failures);
+  assert(dcLanguage === localeContract.dcLanguage, `${path} dc.language expected ${localeContract.dcLanguage} but got ${dcLanguage || '(missing)'}`, failures);
   assert(canonical.startsWith(canonicalBaseUrl), `${path} canonical does not start with ${canonicalBaseUrl}: ${canonical}`, failures);
   assert(!canonical.startsWith(NON_CANONICAL_APEX_URL), `${path} canonical leaks apex domain: ${canonical}`, failures);
+  assert(ogLocale === localeContract.ogLocale, `${path} og:locale expected ${localeContract.ogLocale} but got ${ogLocale || '(missing)'}`, failures);
   assert(robots.includes('index') || path === '/404', `${path} robots meta missing index directive`, failures);
   assert(ogImage.startsWith(canonicalBaseUrl), `${path} og:image is not absolute canonical URL: ${ogImage}`, failures);
   assert(jsonLdBlocks.length > 0, `${path} missing JSON-LD`, failures);

--- a/scripts/umcli-contract-audit.mjs
+++ b/scripts/umcli-contract-audit.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE_URL = 'https://www.ultimamilla.com.ar';
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || fallback : fallback;
+}
+
+function assert(condition, message, failures) {
+  if (!condition) failures.push(message);
+}
+
+async function fetchJson(url, failures) {
+  try {
+    const response = await fetch(url, { redirect: 'follow' });
+    assert(response.ok, `${url} returned ${response.status}`, failures);
+    if (!response.ok) return null;
+    return response.json();
+  } catch (error) {
+    failures.push(`${url} fetch failed: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+function hasLegacyAliases(record, fields) {
+  if (!record || typeof record !== 'object') return false;
+  return fields.every((field) => typeof record[field] === 'string' && record[field].length > 0);
+}
+
+async function main() {
+  const baseUrl = argValue('--base-url', DEFAULT_BASE_URL).replace(/\/$/, '');
+  const failures = [];
+
+  const umcli = await fetchJson(new URL('/api/umcli.json', baseUrl).toString(), failures);
+  const imageEvidence = await fetchJson(new URL('/geo/image-evidence.json', baseUrl).toString(), failures);
+
+  if (!umcli || !imageEvidence) {
+    console.error(JSON.stringify({ ok: false, baseUrl, failures }, null, 2));
+    process.exit(1);
+  }
+
+  const stats = umcli?.data?.estadisticas ?? {};
+  const servicios = umcli?.data?.servicios ?? [];
+  const antecedentes = umcli?.data?.antecedentes ?? [];
+  const blogPosts = umcli?.data?.blog_posts ?? umcli?.data?.blogPosts ?? [];
+  const expectedAntecedentes = imageEvidence?.coverage?.totalAntecedentes;
+
+  assert(umcli.success === true, '/api/umcli.json did not return success=true', failures);
+  assert(Number.isInteger(stats.totalServicios) && stats.totalServicios > 0, 'umcli totalServicios must be a positive integer', failures);
+  assert(Number.isInteger(stats.totalAntecedentes) && stats.totalAntecedentes > 0, 'umcli totalAntecedentes must be a positive integer', failures);
+  assert(Number.isInteger(stats.totalCasosExito) && stats.totalCasosExito > 0, 'umcli totalCasosExito must be a positive integer', failures);
+  assert(Number.isInteger(stats.totalBlogPosts) && stats.totalBlogPosts > 0, 'umcli totalBlogPosts must be a positive integer', failures);
+  assert(servicios.length === stats.totalServicios, `umcli servicios length ${servicios.length} does not match totalServicios ${stats.totalServicios}`, failures);
+  assert(antecedentes.length === stats.totalAntecedentes, `umcli antecedentes length ${antecedentes.length} does not match totalAntecedentes ${stats.totalAntecedentes}`, failures);
+  assert(Array.isArray(umcli?.data?.blog_posts) || Array.isArray(umcli?.data?.blogPosts), 'umcli is missing blog_posts/blogPosts array', failures);
+  assert(blogPosts.length === stats.totalBlogPosts, `umcli blogPosts length ${blogPosts.length} does not match totalBlogPosts ${stats.totalBlogPosts}`, failures);
+  assert(stats.totalAntecedentes === expectedAntecedentes, `umcli totalAntecedentes ${stats.totalAntecedentes} does not match GEO image-evidence totalAntecedentes ${expectedAntecedentes}`, failures);
+  assert(stats.totalCasosExito === expectedAntecedentes, `umcli totalCasosExito ${stats.totalCasosExito} does not match GEO image-evidence totalAntecedentes ${expectedAntecedentes}`, failures);
+  assert(hasLegacyAliases(servicios[0], ['titulo', 'nombre', 'descripcion', 'area']), 'first UMCLI service is missing legacy aliases titulo/nombre/descripcion/area', failures);
+  assert(hasLegacyAliases(antecedentes[0], ['titulo', 'nombre', 'resumen', 'fecha_publicacion', 'cliente', 'area']), 'first UMCLI antecedente is missing legacy aliases titulo/nombre/resumen/fecha_publicacion/cliente/area', failures);
+
+  if (failures.length > 0) {
+    console.error(JSON.stringify({ ok: false, baseUrl, failures }, null, 2));
+    process.exit(1);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    baseUrl,
+    totals: {
+      totalServicios: stats.totalServicios,
+      totalAntecedentes: stats.totalAntecedentes,
+      totalCasosExito: stats.totalCasosExito,
+      totalBlogPosts: stats.totalBlogPosts,
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- extend the production SEO audit to validate locale metadata on the English routes
- add a production UMCLI contract audit that cross-checks public totals against GEO evidence
- wire both audits into the production deploy workflow

## Validation
- npm run test:ci -- __tests__/geoDiscoveryContracts.test.ts __tests__/runtimeConfigContracts.test.js __tests__/umcliReleaseAuditContracts.test.js
- node scripts/seo-audit.mjs --base-url https://www.ultimamilla.com.ar
- node scripts/umcli-contract-audit.mjs --base-url https://www.ultimamilla.com.ar