### PR TITLE
release: add directus production release audit

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -260,6 +260,9 @@ jobs:
       - name: UMCLI release contract audit
         run: node scripts/umcli-contract-audit.mjs --base-url https://www.ultimamilla.com.ar
 
+      - name: Directus integration release audit
+        run: node scripts/directus-release-audit.mjs --base-url https://www.ultimamilla.com.ar
+
       - name: Send deployment notification
         if: always()
         run: |

--- a/__tests__/directusReleaseAuditContracts.test.js
+++ b/__tests__/directusReleaseAuditContracts.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Directus release audit contracts', () => {
+  test('production Directus audit validates health, articles and CLI search endpoints', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'scripts/directus-release-audit.mjs'), 'utf8');
+
+    expect(source).toContain('/api/monitoring/health');
+    expect(source).toContain('/api/get-articles');
+    expect(source).toContain('/api/cli/query-real-only');
+    expect(source).toContain('/api/cli/query-directus');
+    expect(source).toContain('directus_real_data_only');
+    expect(source).toContain('directus_real_data');
+    expect(source).toContain("QUERY_FIXTURE = 'mendoza'");
+    expect(source).toContain("health.services?.directus === 'online'");
+    expect(source).toContain("health.services?.astro === 'online'");
+    expect(source).toContain('articles.data?.[0]?.slug');
+    expect(source).toContain('articles.data?.[0]?.titulo');
+    expect(source).toContain('cliDirectus.total_found');
+    expect(source).toContain('isCanonicalUrl(result.url, baseUrl)');
+  });
+});

--- a/__tests__/runtimeConfigContracts.test.js
+++ b/__tests__/runtimeConfigContracts.test.js
@@ -80,8 +80,10 @@ describe('Production runtime configuration contracts', () => {
 
     expect(workflow).toContain('SEO and GEO release audit');
     expect(workflow).toContain('UMCLI release contract audit');
+    expect(workflow).toContain('Directus integration release audit');
     expect(workflow).toContain('node scripts/seo-audit.mjs --base-url https://www.ultimamilla.com.ar');
     expect(workflow).toContain('node scripts/umcli-contract-audit.mjs --base-url https://www.ultimamilla.com.ar');
+    expect(workflow).toContain('node scripts/directus-release-audit.mjs --base-url https://www.ultimamilla.com.ar');
   });
 
   test('production health check matches the live www canonical redirect policy', () => {

--- a/scripts/directus-release-audit.mjs
+++ b/scripts/directus-release-audit.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+const DEFAULT_BASE_URL = 'https://www.ultimamilla.com.ar';
+const QUERY_FIXTURE = 'mendoza';
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || fallback : fallback;
+}
+
+function assert(condition, message, failures) {
+  if (!condition) failures.push(message);
+}
+
+async function fetchJson(url, failures, options = {}) {
+  try {
+    const response = await fetch(url, { redirect: 'follow', ...options });
+    assert(response.ok, `${url} returned ${response.status}`, failures);
+    if (!response.ok) return null;
+    return response.json();
+  } catch (error) {
+    failures.push(`${url} fetch failed: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+function isCanonicalUrl(value, baseUrl) {
+  return typeof value === 'string' && value.startsWith(baseUrl);
+}
+
+async function main() {
+  const baseUrl = argValue('--base-url', DEFAULT_BASE_URL).replace(/\/$/, '');
+  const failures = [];
+
+  const health = await fetchJson(new URL('/api/monitoring/health', baseUrl).toString(), failures);
+  const articles = await fetchJson(new URL('/api/get-articles', baseUrl).toString(), failures);
+  const cliRealOnly = await fetchJson(new URL('/api/cli/query-real-only', baseUrl).toString(), failures, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: QUERY_FIXTURE }),
+  });
+  const cliDirectus = await fetchJson(new URL('/api/cli/query-directus', baseUrl).toString(), failures, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: QUERY_FIXTURE }),
+  });
+
+  if (!health || !articles || !cliRealOnly || !cliDirectus) {
+    console.error(JSON.stringify({ ok: false, baseUrl, failures }, null, 2));
+    process.exit(1);
+  }
+
+  assert(health.success === true, 'health endpoint did not return success=true', failures);
+  assert(health.status === 'healthy', `health endpoint status expected healthy but got ${health.status}`, failures);
+  assert(health.services?.astro === 'online', `health endpoint astro expected online but got ${health.services?.astro}`, failures);
+  assert(health.services?.directus === 'online', `health endpoint directus expected online but got ${health.services?.directus}`, failures);
+
+  assert(articles.success === true, 'get-articles did not return success=true', failures);
+  assert(Array.isArray(articles.data), 'get-articles data is not an array', failures);
+  assert((articles.data?.length ?? 0) > 0, 'get-articles returned no articles', failures);
+  assert(typeof articles.data?.[0]?.slug === 'string' && articles.data[0].slug.length > 0, 'first article is missing slug', failures);
+  assert(typeof articles.data?.[0]?.titulo === 'string' && articles.data[0].titulo.length > 0, 'first article is missing titulo', failures);
+
+  assert(Array.isArray(cliRealOnly.results), 'cli/query-real-only results is not an array', failures);
+  assert((cliRealOnly.results?.length ?? 0) > 0, 'cli/query-real-only returned no results for mendoza', failures);
+  assert(cliRealOnly.meta?.source === 'directus_real_data_only', `cli/query-real-only meta.source expected directus_real_data_only but got ${cliRealOnly.meta?.source}`, failures);
+  assert(cliRealOnly.results.every((result) => isCanonicalUrl(result.url, baseUrl)), 'cli/query-real-only returned non-canonical URLs', failures);
+
+  assert(Array.isArray(cliDirectus.results), 'cli/query-directus results is not an array', failures);
+  assert((cliDirectus.results?.length ?? 0) > 0, 'cli/query-directus returned no results for mendoza', failures);
+  assert(cliDirectus.meta?.source === 'directus_real_data', `cli/query-directus meta.source expected directus_real_data but got ${cliDirectus.meta?.source}`, failures);
+  assert((cliDirectus.total_found ?? 0) > 0, `cli/query-directus total_found expected > 0 but got ${cliDirectus.total_found}`, failures);
+  assert((cliDirectus.total_servicios ?? 0) > 0 || (cliDirectus.total_antecedentes ?? 0) > 0, 'cli/query-directus returned no servicio/antecedente counts', failures);
+  assert(cliDirectus.results.every((result) => isCanonicalUrl(result.url, baseUrl)), 'cli/query-directus returned non-canonical URLs', failures);
+
+  if (failures.length > 0) {
+    console.error(JSON.stringify({ ok: false, baseUrl, failures }, null, 2));
+    process.exit(1);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    baseUrl,
+    query: QUERY_FIXTURE,
+    summaries: {
+      articles: articles.data.length,
+      cliRealOnly: cliRealOnly.results.length,
+      cliDirectus: cliDirectus.results.length,
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
Summary:
- add a production Directus integration audit for health, get-articles and CLI search endpoints
- run it in Production Deploy after SEO/GEO and UMCLI release audits
- keep the audit tied to real public production behavior for the mendoza fixture

Validation:
- npm run test:ci -- __tests__/runtimeConfigContracts.test.js __tests__/directusReleaseAuditContracts.test.js
- node scripts/directus-release-audit.mjs --base-url https://www.ultimamilla.com.ar