### PR TITLE
release: publish evidence template polish

### DIFF
--- a/__tests__/visualInformationHubContracts.test.js
+++ b/__tests__/visualInformationHubContracts.test.js
@@ -204,6 +204,8 @@ describe('Information hub visual contracts', () => {
     expect(titleBlock).toMatch(/overflow-wrap:\s*normal;/);
     expect(titleBlock).toMatch(/word-break:\s*normal;/);
     expect(titleBlock).toMatch(/hyphens:\s*none;/);
+    expect(evidenceRow).toMatch(/@media \(max-width:\s*520px\)\s*\{[\s\S]*\.evidence-case-row\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\);/);
+    expect(evidenceRow).toMatch(/@media \(max-width:\s*520px\)\s*\{[\s\S]*\.evidence-case-row__copy\s*\{[\s\S]*align-self:\s*start;/);
   });
 
   test('home secondary evidence rows remove repeated sector metadata to prevent compressed words', () => {
@@ -304,6 +306,19 @@ describe('Information hub visual contracts', () => {
     expect(titleBuilder).not.toMatch(/afterColon\.slice/);
     expect(titleBuilder).not.toContain('trimEnd()}…');
     expect(blogSingle).toContain('<h1 class="article-title">{articleTitle}</h1>');
+  });
+
+  test('blog single shows an editorial cover image before article prose', () => {
+    const blogSingle = read('src/pages/blog/[slug].astro');
+    const metaIndex = blogSingle.indexOf('class="author-row"');
+    const coverIndex = blogSingle.indexOf('class="article-cover"');
+    const proseIndex = blogSingle.indexOf('class="prose"');
+
+    expect(blogSingle).toContain('blogPostImageAlt');
+    expect(coverIndex).toBeGreaterThan(metaIndex);
+    expect(proseIndex).toBeGreaterThan(coverIndex);
+    expect(blogSingle).toMatch(/\.article-cover\s*\{[\s\S]*aspect-ratio:\s*16\s*\/\s*9;/);
+    expect(blogSingle).toMatch(/\.article-cover img\s*\{[\s\S]*object-fit:\s*cover;/);
   });
 
   test('blog index stays readable without a duplicated featured banner or repeated header CTAs', () => {

--- a/src/components/templates/AntecedentesTemplateEditorial.astro
+++ b/src/components/templates/AntecedentesTemplateEditorial.astro
@@ -467,7 +467,7 @@ const archiveText = isLandingPage
     color: #0b0b0b;
     font-size: 1rem;
     font-weight: 600;
-    line-height: 1.2;
+    line-height: 1.2 !important;
     text-decoration: underline;
     text-decoration-color: transparent;
     text-decoration-thickness: 2px;
@@ -517,7 +517,8 @@ const archiveText = isLandingPage
     min-width: 0;
     border-radius: 6px;
     background: #0b0b0b;
-    box-shadow: 0 18px 46px rgba(15, 23, 42, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: none;
   }
 
   .ante-dossier__image-wall figure {
@@ -554,7 +555,7 @@ const archiveText = isLandingPage
     border-left: 3px solid var(--um-red);
     border-radius: 4px;
     background: var(--ante-page);
-    box-shadow: 0 10px 26px rgba(15, 23, 42, 0.045);
+    box-shadow: none;
   }
 
   .ante-dossier__proof span {
@@ -593,7 +594,7 @@ const archiveText = isLandingPage
     margin-top: clamp(14px, 2vw, 20px);
     color: var(--ante-text);
     font-family: var(--um-font-display);
-    font-size: clamp(2.05rem, 2.45vw, 2.65rem);
+    font-size: clamp(2.5rem, 3vw, 3rem);
     font-weight: var(--um-weight-title, 600);
     line-height: 1.1;
     letter-spacing: 0;
@@ -807,7 +808,7 @@ const archiveText = isLandingPage
     color: var(--ante-text);
     font-size: 1rem;
     font-weight: var(--um-weight-title, 600);
-    line-height: 1.2;
+    line-height: 1.2 !important;
     white-space: nowrap;
     text-decoration: none;
     transition: color 180ms ease;
@@ -899,8 +900,9 @@ const archiveText = isLandingPage
     font-family: var(--um-font-display);
     font-size: clamp(1.85rem, 2.55vw, 2.7rem);
     font-weight: var(--um-weight-title, 600);
-    line-height: 1.12;
+    line-height: 1.2;
     letter-spacing: 0;
+    min-height: 1.2em;
     text-wrap: balance;
   }
 
@@ -926,7 +928,7 @@ const archiveText = isLandingPage
     border-radius: 6px;
     background: #fff;
     color: #111;
-    box-shadow: 0 18px 46px rgba(15, 23, 42, 0.06);
+    box-shadow: none;
   }
 
   .ante-dossier__feature figure,
@@ -1066,7 +1068,7 @@ const archiveText = isLandingPage
     border-radius: 6px;
     background: #fff;
     color: #111;
-    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.045);
+    box-shadow: none;
     overflow: hidden;
   }
 
@@ -1170,7 +1172,7 @@ const archiveText = isLandingPage
     background: #fff;
     padding: clamp(14px, 1.8vw, 20px);
     color: #111;
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
+    box-shadow: none;
     transition:
       background-color 180ms ease,
       border-color 180ms ease;
@@ -1323,7 +1325,7 @@ const archiveText = isLandingPage
     background: linear-gradient(90deg, #ffffff 0%, #f7f8f9 100%);
     border: 1px solid #e3e6ea;
     border-radius: 6px;
-    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.045);
+    box-shadow: none;
   }
 
   .ante-dossier__empty a {
@@ -1605,7 +1607,13 @@ const archiveText = isLandingPage
 
     .ante-dossier__archive-intro h1 {
       max-width: 100%;
-      font-size: clamp(1.82rem, 6.4vw, 2.08rem);
+      font-size: clamp(2rem, 7vw, 2.32rem);
+    }
+
+    .ante-dossier__section-head h2,
+    .ante-dossier__archive-head h2,
+    .ante-dossier__empty h2 {
+      line-height: 1.2 !important;
     }
 
     .ante-dossier__archive-intro aside {
@@ -1695,6 +1703,12 @@ const archiveText = isLandingPage
     .ante-dossier__secondary dl {
       grid-template-columns: 1fr;
       gap: 12px;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .ante-dossier h2 {
+      line-height: 1.24 !important;
     }
   }
 </style>

--- a/src/components/um/EvidenceCaseRow.astro
+++ b/src/components/um/EvidenceCaseRow.astro
@@ -87,7 +87,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
     color: inherit;
     text-decoration: none;
     box-sizing: border-box;
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.045);
+    box-shadow: none;
     transition:
       background-color 180ms ease,
       border-color 180ms ease;
@@ -99,7 +99,7 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
 
   .evidence-case-row:hover {
     border-color: color-mix(in srgb, var(--um-red) 34%, #e3e6ea);
-    background: color-mix(in srgb, #fff 94%, var(--um-red) 6%);
+    background: color-mix(in srgb, #ffffff 94%, var(--um-red) 6%);
   }
 
   .evidence-case-row:focus-visible {
@@ -314,6 +314,31 @@ const visibleMetrics = (metrics || []).filter((m) => m?.value && m?.label).slice
     .evidence-case-row__action {
       grid-column: 1 / -1;
       justify-self: start;
+    }
+  }
+
+  @media (max-width: 520px) {
+    .evidence-case-row {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .evidence-case-row__number,
+    .evidence-case-row__thumb,
+    .evidence-case-row__copy,
+    .evidence-case-row__meta-group,
+    .evidence-case-row__action {
+      grid-column: 1;
+      grid-row: auto;
+    }
+
+    .evidence-case-row__thumb {
+      min-width: 0;
+      min-height: 160px;
+      aspect-ratio: 16 / 9;
+    }
+
+    .evidence-case-row__copy {
+      align-self: start;
     }
   }
 </style>

--- a/src/components/um/IntentLinkGraph.astro
+++ b/src/components/um/IntentLinkGraph.astro
@@ -130,7 +130,7 @@ const actionLabel = (href: string) => {
     margin-top: 0.75rem;
     color: #111827;
     font-size: clamp(1.75rem, 2.6vw, 2.65rem);
-    line-height: 1.08;
+    line-height: 1.16;
     font-weight: 600;
     letter-spacing: 0;
     text-wrap: balance;

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -374,12 +374,23 @@ const caseSeo = buildCaseSeoMeta({
 });
 const metaDescription = caseSeo.description;
 const structuredImageUrl = publicImageUrl(caseSeoImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL);
-const caseDossierFacts = [
-  { label: 'Tipo', value: caseRecordLabel },
-  displayClientName ? { label: 'Organización', value: displayClientName } : null,
-  antecedente.Area ? { label: 'Vertical', value: cleanDisplayText(antecedente.Area) } : null,
-  caseDateLabel ? { label: 'Fecha', value: caseDateLabel } : null,
-].filter(Boolean) as Array<{ label: string; value: string }>;
+const caseExecutiveItems = [
+  {
+    label: 'Contexto',
+    value: truncateEditorialText(
+      [displayClientName, antecedente.Area].filter(Boolean).join(' · ') || caseRecordLabel,
+      120,
+    ),
+  },
+  {
+    label: 'Alcance',
+    value: truncateEditorialText(scopeItems[0] || caseCalloutText || caseRecordSummary, 135),
+  },
+  {
+    label: 'Lectura',
+    value: truncateEditorialText(caseRecordSummary, 135),
+  },
+];
 const caseStrategicLinkGroups = buildCaseStrategicLinkGroups({
   currentPath: `/antecedentes/${id}/${slugFromUrl}`,
   title: caseHeadline,
@@ -507,14 +518,20 @@ const antecedentePageStructuredData = [
     </div>
   </section>
 
-  <section class="case-proof-strip" aria-label="Ficha rápida del antecedente">
-    <div class="um-container case-proof-strip__grid">
-      {caseDossierFacts.map((fact) => (
-        <div>
-          <span>{fact.label}</span>
-          <strong>{fact.value}</strong>
-        </div>
-      ))}
+  <section class="case-executive-brief" aria-label="Resumen ejecutivo del antecedente">
+    <div class="um-container case-executive-brief__grid">
+      <div class="case-executive-brief__head">
+        <span>Resumen ejecutivo</span>
+        <h2>Qué mirar antes de entrar al detalle técnico.</h2>
+      </div>
+      <dl class="case-executive-brief__ledger">
+        {caseExecutiveItems.map((item) => (
+          <div>
+            <dt>{item.label}</dt>
+            <dd>{item.value}</dd>
+          </div>
+        ))}
+      </dl>
     </div>
   </section>
 
@@ -788,7 +805,6 @@ const antecedentePageStructuredData = [
 <style>
   /* Escala editorial única — detalle antecedente (cuerpo 18px, sección ~1.11×) */
   .case-detail-hero,
-  .case-proof-strip,
   .case-detail-main.case-detail,
   .case-related,
   .case-detail-footer-cta {
@@ -847,7 +863,7 @@ const antecedentePageStructuredData = [
 
   .case-detail-hero__grid {
     display: grid;
-    grid-template-columns: minmax(0, 0.58fr) minmax(340px, 0.42fr);
+    grid-template-columns: minmax(0, 0.52fr) minmax(380px, 0.48fr);
     gap: clamp(26px, 4.2vw, 56px);
     align-items: start;
   }
@@ -939,19 +955,19 @@ const antecedentePageStructuredData = [
 
   .case-detail-dossier {
     overflow: hidden;
-    width: min(100%, 480px);
+    width: min(100%, 540px);
     justify-self: end;
-    border: 0;
+    border: 1px solid rgba(17, 17, 17, 0.12);
     background: #fff;
     box-shadow: none;
   }
 
   .case-detail-dossier__media {
-    aspect-ratio: 16 / 9;
+    aspect-ratio: 16 / 10;
     width: 100%;
     max-width: 100%;
     margin: 0;
-    min-height: 190px;
+    min-height: 280px;
     overflow: hidden;
     background: #111;
   }
@@ -962,7 +978,7 @@ const antecedentePageStructuredData = [
     height: 100%;
     object-fit: cover;
     object-position: center;
-    filter: saturate(0.92) contrast(1.05);
+    filter: saturate(1.04) contrast(1.06);
   }
 
   .case-detail-dossier__body {
@@ -1034,52 +1050,80 @@ const antecedentePageStructuredData = [
     text-transform: none;
   }
 
-  .case-proof-strip {
-    background: #f5f5f5;
-    color: #111;
-    border-top: 1px solid #e4e6e9;
+  .case-detail-main {
+    padding: clamp(42px, 5.5vw, 72px) 0;
+    background: #fff;
+  }
+
+  .case-executive-brief {
+    background: #fff;
     border-bottom: 1px solid #e4e6e9;
   }
 
-  .case-proof-strip__grid {
+  .case-executive-brief__grid {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: clamp(10px, 1.4vw, 16px);
-    background: transparent;
-    padding-block: clamp(14px, 2vw, 20px);
+    grid-template-columns: minmax(240px, 0.32fr) minmax(0, 0.68fr);
+    gap: clamp(24px, 4.5vw, 62px);
+    padding-block: clamp(28px, 4vw, 48px);
   }
 
-  .case-proof-strip__grid div {
+  .case-executive-brief__head span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #DC2626;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .case-executive-brief__head span::before {
+    content: "";
+    width: 34px;
+    height: 2px;
+    background: #DC2626;
+  }
+
+  .case-executive-brief__head h2 {
+    max-width: 440px;
+    margin-top: 0.9rem;
+    color: #111;
+    font-size: clamp(1.45rem, 1.8vw, 2rem);
+    font-weight: 600;
+    line-height: 1.14;
+    text-wrap: balance;
+  }
+
+  .case-executive-brief__ledger {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
+    margin: 0;
+    background: #dfe3e7;
+  }
+
+  .case-executive-brief__ledger div {
     min-width: 0;
-    border-left: 3px solid #DC2626;
-    background: #fff;
-    padding: clamp(14px, 1.6vw, 18px) clamp(14px, 1.8vw, 20px);
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+    padding: clamp(16px, 2vw, 22px);
+    background: #f7f8f9;
   }
 
-  .case-proof-strip__grid span {
-    display: block;
+  .case-executive-brief__ledger dt {
     color: #5f6670;
     font-size: 1rem;
     font-weight: 700;
     line-height: 1.25;
-    letter-spacing: 0.04em;
     text-transform: uppercase;
   }
 
-  .case-proof-strip__grid strong {
-    display: block;
-    margin-top: 8px;
+  .case-executive-brief__ledger dd {
+    margin: 0.65rem 0 0;
     color: #111;
-    font-size: clamp(1.02rem, 1.12vw, 1.16rem);
-    font-weight: 700;
-    line-height: 1.35;
+    font-size: clamp(1.02rem, 1.08vw, 1.12rem);
+    font-weight: 600;
+    line-height: 1.45;
     overflow-wrap: anywhere;
-  }
-
-  .case-detail-main {
-    padding: clamp(42px, 5.5vw, 72px) 0;
-    background: #fff;
   }
 
   .case-detail-main__grid {
@@ -1193,27 +1237,34 @@ const antecedentePageStructuredData = [
 
   .case-gallery-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1rem, 2vw, 1.35rem);
   }
 
   .case-gallery-frame {
     margin: 0;
-    min-height: 260px;
+    min-height: 300px;
     padding: 0;
-    border: 0;
+    border: 1px solid rgba(17, 17, 17, 0.12);
     border-radius: 0;
-    background: #f3f4f6;
+    background: #111;
+    box-shadow: none;
     overflow: hidden;
+  }
+
+  .case-gallery-frame:first-child {
+    grid-column: span 2;
+    min-height: 380px;
   }
 
   .case-gallery-image {
     width: 100%;
     height: 100%;
-    min-height: 260px;
+    min-height: 300px;
     object-fit: cover;
     object-position: center;
     display: block;
+    filter: saturate(1.04) contrast(1.04);
   }
 
   .case-info-card {
@@ -1623,14 +1674,14 @@ const antecedentePageStructuredData = [
       position: static;
     }
 
-    .case-proof-strip__grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+    .case-executive-brief__grid,
+    .case-executive-brief__ledger {
+      grid-template-columns: 1fr;
     }
   }
 
   @media (max-width: 640px) {
     .case-detail-hero,
-    .case-proof-strip,
     .case-detail-main.case-detail,
     .case-related,
     .case-detail-footer-cta {
@@ -1638,16 +1689,16 @@ const antecedentePageStructuredData = [
       --case-body-line: 1.66;
       --case-section: clamp(1.12rem, 5.2vw, 1.28rem);
       --case-hero-excerpt: 1.0625rem;
-      --case-meta-label: 0.875rem;
-      --case-meta-value: 0.96875rem;
-      --case-sidebar-label: 0.875rem;
+      --case-meta-label: 1rem;
+      --case-meta-value: 1rem;
+      --case-sidebar-label: 1rem;
       --case-sidebar-value: 1rem;
       --case-card-title: 1.02rem;
     }
 
     .case-detail-hero__copy h1 {
       max-width: 100%;
-      font-size: clamp(1.82rem, 6.15vw, 2.08rem);
+      font-size: clamp(2.125rem, 7vw, 2.45rem);
       line-height: 1.1;
     }
 
@@ -1667,7 +1718,7 @@ const antecedentePageStructuredData = [
       width: 100%;
       min-width: 0;
       min-height: 48px;
-      font-size: 0.98rem;
+      font-size: 1rem;
     }
   }
 
@@ -1692,11 +1743,11 @@ const antecedentePageStructuredData = [
 
     .case-detail-label {
       margin-bottom: 0.7rem;
-      font-size: 0.95rem;
+      font-size: 1rem;
     }
 
     .case-detail-hero__copy h1 {
-      font-size: clamp(1.82rem, 6.15vw, 2.08rem);
+      font-size: clamp(2.125rem, 7vw, 2.45rem);
       line-height: 1.1;
     }
 
@@ -1713,12 +1764,17 @@ const antecedentePageStructuredData = [
       min-height: 0;
     }
 
+    .case-gallery-frame:first-child {
+      grid-column: auto;
+      min-height: 300px;
+    }
+
     .case-detail-dossier__body {
       padding: 16px 0 0;
     }
 
     .case-detail-dossier__body > span {
-      font-size: 0.86rem;
+      font-size: 1rem;
     }
 
     .case-detail-dossier__body > strong {
@@ -1730,13 +1786,9 @@ const antecedentePageStructuredData = [
       padding: 0.85rem;
     }
 
-    .case-proof-strip__grid {
-      grid-template-columns: 1fr;
-      padding-block: 10px;
-    }
-
-    .case-proof-strip__grid div {
-      padding: 12px 14px;
+    .case-executive-brief__grid {
+      gap: 18px;
+      padding-block: 26px;
     }
 
     .case-detail-main {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,7 +3,7 @@ import LayoutV4 from '../../layouts/LayoutV4.astro';
 import BlogTOC from '../../components/blog/BlogTOC.astro';
 import IntentLinkGraph from '../../components/um/IntentLinkGraph.astro';
 import { fetchBlogPost, fetchBlogListing } from '../../utils/getBlogData';
-import { blogImageUrl, blogPostImageUrl } from '../../utils/blogHelpers';
+import { blogImageUrl, blogPostImageAlt, blogPostImageUrl } from '../../utils/blogHelpers';
 import { addHeadingIds, getCategoryLabel, formatBlogDate, extractFaqSchema } from '../../utils/blogUtils';
 import { isReplicaIdenticalCopy, resolveReplicaH1 } from '../../utils/replicaProdCopy';
 import { resolveCanonicalBlogSlug } from '../../data/seoRedirects';
@@ -52,6 +52,7 @@ const normalizedContent = normalizeArticleContent(post.contenido || '');
 const { html: contentHtml, headings } = await addHeadingIds(normalizedContent);
 const faqSchema = extractFaqSchema(contentHtml);
 const imgUrl = blogPostImageUrl(post);
+const imgAlt = blogPostImageAlt(post);
 const socialImg = post.social_image ? blogImageUrl(post.social_image) : imgUrl;
 const label = getCategoryLabel(post.categoria);
 const date = formatBlogDate(post.fecha_publicacion);
@@ -208,6 +209,12 @@ const articlePageStructuredData = [
           <p class="author-meta">ULTIMA MILLA · {label} · {date} · {post.tiempo_lectura} min de lectura</p>
         </div>
 
+        {imgUrl && (
+          <figure class="article-cover">
+            <img src={imgUrl} alt={imgAlt} loading="eager" decoding="async" />
+          </figure>
+        )}
+
         <hr class="article-divider" />
 
         <div class="prose" set:html={contentHtml} />
@@ -274,10 +281,10 @@ const articlePageStructuredData = [
 
   .article-layout {
     display: grid;
-    grid-template-columns: minmax(188px, 236px) minmax(0, 792px);
-    gap: clamp(30px, 4.6vw, 60px);
+    grid-template-columns: minmax(160px, 204px) minmax(0, 792px);
+    gap: clamp(24px, 4vw, 52px);
     align-items: start;
-    max-width: 1128px;
+    max-width: 1088px;
     margin: 0 auto;
   }
 
@@ -360,6 +367,24 @@ const articlePageStructuredData = [
     border: none;
     border-top: 1px solid var(--um-line);
     margin: 0 0 24px;
+  }
+
+  .article-cover {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    max-height: 360px;
+    margin: 0 0 26px;
+    overflow: hidden;
+    background: #f4f6f8;
+  }
+
+  .article-cover img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: cover;
+    object-position: center;
+    color: transparent;
   }
 
   /* Prev/next nav */


### PR DESCRIPTION
## Summary
- publish UI/UX evidence-template polish from develop
- keeps Directus-backed runtime contracts and production smoke validation in scope

## Included commits
- ca3c6590 fix: polish evidence templates for release
- b86d72f4 Merge pull request #135

## Validation before release
- PR #135 CI passed: lint, build, tests
- npm run build locally on clean worktree
- npm run audit:css locally: 0 findings
- Jest visual/runtime/directus contracts locally: 51 passed
- strict visual audit on antecedentes variants locally: 15 checks, 0 failures
- Directus production release audit OK against https://www.ultimamilla.com.ar

## Production safety
No manual server edits. Merge to master should trigger the configured production workflow.