### PR TITLE
feat: align service templates with demo system

### DIFF
--- a/src/components/v4/FooterV4.astro
+++ b/src/components/v4/FooterV4.astro
@@ -231,17 +231,17 @@ const socialLinks = [
   }
 
   .um-footer-email {
-    display: inline-flex;
-    flex-wrap: wrap;
+    display: inline;
     min-width: 0;
     max-width: 100%;
-    align-items: baseline;
     line-height: 1.35;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
+    white-space: normal;
   }
 
   .um-footer-email span {
-    min-width: 0;
+    display: inline;
   }
 
   .um-footer-bottom {

--- a/src/data/serviceSingleDemoSystem.ts
+++ b/src/data/serviceSingleDemoSystem.ts
@@ -1,0 +1,486 @@
+export type ServiceSingleCapability = {
+  number: string;
+  title: string;
+  description: string;
+  image: string;
+  imageAlt: string;
+};
+
+export type ServiceSingleApproachStep = {
+  number: string;
+  title: string;
+  description: string;
+};
+
+export type ServiceSingleCopy = {
+  headline: string;
+  paragraph: string;
+  capabilitiesIntro: string;
+  approachHeading: string;
+  approachIntro: string;
+};
+
+export const serviceSingleDemoCopy: Record<number, ServiceSingleCopy> = {
+  101: {
+    headline: 'Redes que sostienen la operación crítica.',
+    paragraph: 'Cableado estructurado, fibra óptica, LAN/WAN, WiFi corporativo y conmutación gestionada, con documentación y evidencia técnica para infraestructura que no puede detenerse.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, implementa, certifica y sostiene cada capa de red para operaciones que no pueden detenerse.',
+    approachHeading: 'De la medición a la red certificada.',
+    approachIntro: 'Cada obra de red se entrega medida, etiquetada y documentada. Lo que instalamos, lo podemos probar.',
+  },
+  102: {
+    headline: 'Seguridad electrónica para proteger activos críticos.',
+    paragraph: 'Videovigilancia IP, control de accesos, intrusión y monitoreo, con documentación y evidencia técnica para operaciones que no pueden detenerse.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, implementa, documenta y sostiene cada frente de protección para operaciones que no pueden detenerse.',
+    approachHeading: 'De la auditoría de riesgo al monitoreo continuo.',
+    approachIntro: 'Un mismo equipo releva, diseña, instala y opera la seguridad del sitio. Sin proveedores cruzados ni responsabilidades difusas.',
+  },
+  103: {
+    headline: 'Telecomunicaciones para conectar lo crítico.',
+    paragraph: 'Radioenlaces, telefonía IP, conectividad redundante e infraestructura de sitio, con documentación y evidencia técnica para operaciones que no pueden quedar incomunicadas.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, implementa, documenta y sostiene cada vínculo de comunicación para operaciones que no pueden detenerse.',
+    approachHeading: 'Del estudio de enlace al vínculo sostenido.',
+    approachIntro: 'Conectamos sitios donde otros no llegan: estudio de señal, montaje en altura y monitoreo continuo del vínculo.',
+  },
+  104: {
+    headline: 'Software a medida para tu operación real.',
+    paragraph: 'Aplicaciones, integraciones y automatización diseñadas sobre el proceso concreto de cada empresa, con datos, trazabilidad y soporte para que el sistema acompañe la operación.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, desarrolla, documenta y sostiene cada sistema sobre el proceso real de la operación.',
+    approachHeading: 'Del proceso real al sistema que lo ordena.',
+    approachIntro: 'No empezamos por la tecnología, empezamos por cómo trabaja el equipo. El software se adapta a la operación, no al revés.',
+  },
+  105: {
+    headline: 'Soporte 24/7 para que nada se detenga.',
+    paragraph: 'Mesa de ayuda, monitoreo continuo, mantenimiento preventivo y respuesta en sitio con acuerdos de servicio, para operaciones que necesitan continuidad y evidencia.',
+    capabilitiesIntro: 'Un mismo equipo monitorea, previene, responde y documenta cada incidente para operaciones que no pueden detenerse.',
+    approachHeading: 'Del incidente resuelto a la falla evitada.',
+    approachIntro: 'No esperamos a que algo se rompa. Monitoreamos, anticipamos y, cuando hace falta, estamos en sitio dentro del SLA.',
+  },
+  106: {
+    headline: 'Consultoría IT con criterio de terreno.',
+    paragraph: 'Diagnóstico, arquitectura, roadmap e inversión basados en 22 años de obras reales, para decidir infraestructura con datos, riesgos claros y evidencia.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, planifica y acompaña cada decisión de infraestructura con criterio técnico y evidencia.',
+    approachHeading: 'Del relevamiento a la decisión respaldada.',
+    approachIntro: 'No vendemos un informe genérico. Auditamos el sitio, ordenamos riesgos y entregamos un plan que se puede ejecutar y medir.',
+  },
+  107: {
+    headline: 'Detección de incendios para proteger personas y activos.',
+    paragraph: 'Ingeniería, paneles, sensores y alarmas integradas con monitoreo, con documentación y evidencia técnica para instalaciones que no pueden quedar desprotegidas.',
+    capabilitiesIntro: 'Un mismo equipo diseña, implementa, integra, documenta y sostiene cada sistema de detección para instalaciones que no pueden detenerse.',
+    approachHeading: 'Del estudio de riesgo a la respuesta inmediata.',
+    approachIntro: 'Cada sistema se diseña sobre el riesgo real del sitio, se prueba zona por zona y se sostiene con mantenimiento y monitoreo.',
+  },
+  108: {
+    headline: 'Eléctricos para IT que garantizan continuidad.',
+    paragraph: 'UPS, tableros, tendido, puesta a tierra y respaldo energético dedicados a infraestructura tecnológica, con documentación y evidencia técnica para que nada se apague.',
+    capabilitiesIntro: 'Un mismo equipo releva, diseña, implementa, documenta y sostiene cada instalación eléctrica que alimenta la infraestructura crítica.',
+    approachHeading: 'Del cálculo de cargas al respaldo garantizado.',
+    approachIntro: 'La energía es el cimiento de todo lo demás. La diseñamos con redundancia, la probamos bajo carga y la monitoreamos en continuo.',
+  },
+};
+
+export const serviceSingleDemoCapabilities: Record<number, ServiceSingleCapability[]> = {
+  101: [
+    {
+      number: '01',
+      title: 'Cableado estructurado',
+      description: 'Diseño, tendido y certificación de cobre y fibra para datacenter, edificios y plantas.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/0792af63-ai-generated-1781790816373.png',
+      imageAlt: 'Cableado estructurado conectado a un patch panel gigabit ethernet',
+    },
+    {
+      number: '02',
+      title: 'Redes LAN / WAN',
+      description: 'Arquitectura, segmentación y enlaces entre sedes para operaciones distribuidas.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/e83893ba-ai-generated-1781790818341.png',
+      imageAlt: 'Switch de red empresarial con puertos y LEDs de estado',
+    },
+    {
+      number: '03',
+      title: 'Fibra óptica',
+      description: 'Backbone, fusión, medición y tendido para troncales de alta capacidad y baja latencia.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/9767f994-ai-generated-1781790820504.png',
+      imageAlt: 'Conectores de fibra óptica con hilos luminosos',
+    },
+    {
+      number: '04',
+      title: 'WiFi corporativo',
+      description: 'Relevamiento de cobertura, controladoras, roaming y redes separadas por uso.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/4eb08d1a-ai-generated-1781790829128.png',
+      imageAlt: 'Access point WiFi empresarial montado en cielorraso',
+    },
+    {
+      number: '05',
+      title: 'Switching y routing',
+      description: 'Conmutación gestionada, VLANs, QoS y ruteo para tráfico crítico y continuidad.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ebf2dea8-ai-generated-1781790833997.png',
+      imageAlt: 'Switches y router empresariales montados en rack con LEDs',
+    },
+    {
+      number: '06',
+      title: 'Documentación y certificación',
+      description: 'Dossier por proyecto: diagramas, mediciones, etiquetado y evidencia técnica.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ffb25574-ai-generated-1781790838183.png',
+      imageAlt: 'Certificador de cableado mostrando resultado PASS sobre dossier técnico',
+    },
+  ],
+  102: [
+    {
+      number: '01',
+      title: 'Videovigilancia IP (CCTV)',
+      description: 'Cámaras IP, grabación, analítica de video y verificación remota para cubrir perímetros y activos críticos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/d319f77f-ai-generated-1781790891017.png',
+      imageAlt: 'Cámara de videovigilancia IP profesional en primer plano',
+    },
+    {
+      number: '02',
+      title: 'Control de accesos',
+      description: 'Lectores, credenciales, molinetes y registro de quién entra, cuándo y a qué zona.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/7e3cd73b-ai-generated-1781790894665.png',
+      imageAlt: 'Lector de control de accesos con credencial RFID en puerta',
+    },
+    {
+      number: '03',
+      title: 'Detección de intrusión',
+      description: 'Sensores perimetrales e interiores, paneles de alarma y protocolos de respuesta ante eventos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/e5f3c9da-ai-generated-1781790893371.png',
+      imageAlt: 'Sensor de movimiento PIR y teclado de alarma de intrusión',
+    },
+    {
+      number: '04',
+      title: 'Monitoreo y operación 24/7',
+      description: 'Estación de monitoreo continuo, atención de incidentes y continuidad operativa en sitio.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/0363f585-ai-generated-1781790905608.png',
+      imageAlt: 'Estación de monitoreo CCTV con joystick PTZ frente a muro de monitores',
+    },
+    {
+      number: '05',
+      title: 'Detección de incendios',
+      description: 'Ingeniería, paneles, sensores y alarmas integradas para proteger activos y personas.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/250695f3-ai-generated-1781790904600.png',
+      imageAlt: 'Detector de humo y avisador de incendio en primer plano',
+    },
+    {
+      number: '06',
+      title: 'Documentación y evidencia',
+      description: 'Dossier por proyecto: alcance, protocolo, responsables y evidencia técnica para auditoría o licitación.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ff6df555-ai-generated-1781790907125.png',
+      imageAlt: 'Dossier de seguridad con planos CCTV y tablet mostrando cámaras',
+    },
+  ],
+  103: [
+    {
+      number: '01',
+      title: 'Radioenlaces y vínculos',
+      description: 'Enlaces punto a punto y multipunto para conectar sedes, plantas y sitios remotos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/cfa4e82e-ai-generated-1781789280675.png',
+      imageAlt: 'Antenas de radioenlace de microondas montadas en torre de telecomunicaciones al atardecer',
+    },
+    {
+      number: '02',
+      title: 'Telefonía IP (VoIP)',
+      description: 'Centrales, troncales SIP, planes de numeración y movilidad para equipos distribuidos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/f7abd3b0-ai-generated-1781789284197.png',
+      imageAlt: 'Teléfono IP y gateway de telefonía SIP en sala de equipos',
+    },
+    {
+      number: '03',
+      title: 'Conectividad e internet',
+      description: 'Vínculos dedicados, redundancia de enlaces y balanceo para continuidad operativa.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/0e52972c-ai-generated-1781789286002.png',
+      imageAlt: 'Panel de fibra óptica con enlaces redundantes y conectividad en sala de red',
+    },
+    {
+      number: '04',
+      title: 'Infraestructura de sitio',
+      description: 'Torres, mástiles, energía y acometidas para puntos de telecomunicación críticos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/5d6e14a6-ai-generated-1781789307371.png',
+      imageAlt: 'Base de torre de telecomunicaciones con gabinetes de energía en sitio remoto',
+    },
+    {
+      number: '05',
+      title: 'Integración y gestión',
+      description: 'Interconexión con redes existentes, segmentación y QoS para tráfico prioritario.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/1752ae26-ai-generated-1781789311306.png',
+      imageAlt: 'Técnico gestionando tráfico y QoS de red en estación de operaciones',
+    },
+    {
+      number: '06',
+      title: 'Documentación y evidencia',
+      description: 'Dossier por proyecto: enlaces, mediciones de señal, responsables y trazabilidad.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/4d90c1ed-ai-generated-1781789313927.png',
+      imageAlt: 'Dossier técnico de telecomunicaciones con mediciones de señal y tablet',
+    },
+  ],
+  104: [
+    {
+      number: '01',
+      title: 'Aplicaciones a medida',
+      description: 'Sistemas web y de gestión diseñados sobre el proceso real de cada operación.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/af4d1184-ai-generated-1781790967471.png',
+      imageAlt: 'Laptop mostrando una aplicación de gestión web a medida',
+    },
+    {
+      number: '02',
+      title: 'Integraciones',
+      description: 'Conexión entre sistemas, equipos en sitio, sensores y plataformas existentes.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/9e98f59f-ai-generated-1781790967009.png',
+      imageAlt: 'Monitor mostrando un diagrama de integración entre sistemas y APIs',
+    },
+    {
+      number: '03',
+      title: 'Portales y backoffice',
+      description: 'Paneles, reportería y flujos para administrar operación, evidencia y usuarios.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/1787e4ce-ai-generated-1781790968832.png',
+      imageAlt: 'Monitor mostrando un panel de administración backoffice',
+    },
+    {
+      number: '04',
+      title: 'Automatización',
+      description: 'Tareas, alertas y procesos automáticos para reducir trabajo manual y errores.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/9f2dd251-ai-generated-1781790978194.png',
+      imageAlt: 'Monitor mostrando un constructor de flujos de automatización',
+    },
+    {
+      number: '05',
+      title: 'Datos y trazabilidad',
+      description: 'Registro, auditoría y tableros para decisiones basadas en evidencia.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/6fd5df1d-ai-generated-1781790977806.png',
+      imageAlt: 'Monitor mostrando un tablero de analítica y auditoría',
+    },
+    {
+      number: '06',
+      title: 'Mantenimiento evolutivo',
+      description: 'Soporte, mejoras y nuevas funciones para que el software acompañe la operación.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/d1524519-ai-generated-1781790980410.png',
+      imageAlt: 'Laptop con editor de código fuente en desarrollo',
+    },
+  ],
+  105: [
+    {
+      number: '01',
+      title: 'Mesa de ayuda',
+      description: 'Atención de incidentes, tickets y seguimiento para usuarios y operaciones.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/b6ad1321-ai-generated-1781791038314.png',
+      imageAlt: 'Headset de mesa de ayuda junto a monitor con tablero de tickets',
+    },
+    {
+      number: '02',
+      title: 'Soporte en sitio',
+      description: 'Técnicos que se presentan donde está el problema, en Cuyo y Patagonia.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/4bacd5d7-ai-generated-1781791038748.png',
+      imageAlt: 'Maletín de herramientas de técnico de campo con laptop y tester',
+    },
+    {
+      number: '03',
+      title: 'Monitoreo continuo',
+      description: 'Vigilancia de red, equipos y servicios para anticipar fallas antes del impacto.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ce00fdfb-ai-generated-1781791039646.png',
+      imageAlt: 'Pantallas de monitoreo continuo con estado de red y uptime',
+    },
+    {
+      number: '04',
+      title: 'Mantenimiento preventivo',
+      description: 'Rutinas programadas para sostener disponibilidad y extender vida útil.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/92bd0682-ai-generated-1781791082900.png',
+      imageAlt: 'Manos de técnico realizando mantenimiento en rack de servidores',
+    },
+    {
+      number: '05',
+      title: 'Acuerdos de servicio (SLA)',
+      description: 'Tiempos de respuesta y resolución comprometidos por escrito.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/bf2b52b0-ai-generated-1781791082485.png',
+      imageAlt: 'Documento de acuerdo de nivel de servicio SLA firmado',
+    },
+    {
+      number: '06',
+      title: 'Documentación y evidencia',
+      description: 'Registro de incidentes, intervenciones y resultados para auditoría y mejora.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/8e20575b-ai-generated-1781791051074.png',
+      imageAlt: 'Tablet con registro de incidentes junto a planillas de mantenimiento',
+    },
+  ],
+  106: [
+    {
+      number: '01',
+      title: 'Diagnóstico de infraestructura',
+      description: 'Relevamiento del estado real de red, seguridad, energía y sistemas.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/f95b77d5-ai-generated-1781791134827.png',
+      imageAlt: 'Tablet con checklist de diagnóstico de infraestructura junto a rack de red',
+    },
+    {
+      number: '02',
+      title: 'Arquitectura y diseño',
+      description: 'Definición técnica de soluciones acorde a la operación y el presupuesto.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/d32ec6d1-ai-generated-1781791135929.png',
+      imageAlt: 'Laptop con diagrama de arquitectura de red sobre planos técnicos',
+    },
+    {
+      number: '03',
+      title: 'Roadmap e inversión',
+      description: 'Plan por etapas con prioridades, riesgos y necesidades de inversión.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/a60c168c-ai-generated-1781791141074.png',
+      imageAlt: 'Plan de roadmap e inversión IT impreso con fases y línea de tiempo',
+    },
+    {
+      number: '04',
+      title: 'Pliegos y licitaciones',
+      description: 'Especificaciones técnicas y soporte documental para procesos formales.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/56b99a8d-ai-generated-1781791176952.png',
+      imageAlt: 'Dossier de especificaciones técnicas con secciones y sello de validación',
+    },
+    {
+      number: '05',
+      title: 'Continuidad y riesgo',
+      description: 'Análisis de puntos críticos, redundancia y planes de contingencia.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/e33ffc45-ai-generated-1781791146847.png',
+      imageAlt: 'Monitor con tablero de análisis de riesgo y matriz de contingencia',
+    },
+    {
+      number: '06',
+      title: 'Acompañamiento de proyecto',
+      description: 'Dirección técnica y control durante la ejecución, con evidencia.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/00b8d12a-ai-generated-1781791151763.png',
+      imageAlt: 'Casco de ingeniería sobre planos técnicos enrollados',
+    },
+  ],
+  107: [
+    {
+      number: '01',
+      title: 'Ingeniería y diseño',
+      description: 'Proyecto de detección según normativa, riesgo y características del sitio.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/8a7bff1e-ai-generated-1781791231291.png',
+      imageAlt: 'Planos de ingeniería de detección de incendios con zonificación',
+    },
+    {
+      number: '02',
+      title: 'Paneles y centrales',
+      description: 'Centrales de incendio, zonificación y lógica de alarma para cada instalación.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/64c5d967-ai-generated-1781791230027.png',
+      imageAlt: 'Central de alarma de incendios roja con indicadores de zona',
+    },
+    {
+      number: '03',
+      title: 'Sensores y detectores',
+      description: 'Detección de humo, temperatura y llama distribuida según el área protegida.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/cf10ca1a-ai-generated-1781791233792.png',
+      imageAlt: 'Detectores de humo, temperatura y llama en fila',
+    },
+    {
+      number: '04',
+      title: 'Alarma y notificación',
+      description: 'Avisadores, sirenas e integración con monitoreo para respuesta inmediata.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ca1d4e74-ai-generated-1781791242575.png',
+      imageAlt: 'Avisador de incendio rojo con luz estroboscópica en pared',
+    },
+    {
+      number: '05',
+      title: 'Integración y monitoreo',
+      description: 'Conexión con seguridad electrónica, accesos y estación de monitoreo 24/7.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/d0fec213-ai-generated-1781791242881.png',
+      imageAlt: 'Estación de monitoreo de incendios con estado de zonas y seguridad integrada',
+    },
+    {
+      number: '06',
+      title: 'Documentación y evidencia',
+      description: 'Dossier por proyecto: planos, pruebas, mantenimiento y trazabilidad.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/766ee2f2-ai-generated-1781791246321.png',
+      imageAlt: 'Dossier de protección contra incendios con certificados y planos',
+    },
+  ],
+  108: [
+    {
+      number: '01',
+      title: 'Energía ininterrumpida (UPS)',
+      description: 'Respaldo, autonomía y protección eléctrica para equipos que no pueden apagarse.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/9954c7ae-ai-generated-1781791300405.png',
+      imageAlt: 'UPS montado en rack con display de estado de batería y carga',
+    },
+    {
+      number: '02',
+      title: 'Tableros y distribución',
+      description: 'Tableros, protecciones y distribución dedicada para cargas críticas de IT.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/ce35c182-ai-generated-1781791301821.png',
+      imageAlt: 'Tablero eléctrico con interruptores y circuitos etiquetados',
+    },
+    {
+      number: '03',
+      title: 'Tendido eléctrico',
+      description: 'Canalizaciones, acometidas y circuitos para racks, datacenter y sitios técnicos.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/621314f6-ai-generated-1781791305714.png',
+      imageAlt: 'Canalizaciones y cableado eléctrico hacia un rack técnico',
+    },
+    {
+      number: '04',
+      title: 'Puesta a tierra',
+      description: 'Sistemas de tierra y protección contra sobretensiones para equipos sensibles.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/dfe49e83-ai-generated-1781791317761.png',
+      imageAlt: 'Barra de puesta a tierra de cobre con conexiones y protección contra sobretensiones',
+    },
+    {
+      number: '05',
+      title: 'Respaldo y continuidad',
+      description: 'Grupos electrógenos, transferencia y esquemas de redundancia energética.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/7a470db0-ai-generated-1781791315725.png',
+      imageAlt: 'Grupo electrógeno industrial junto a tablero de transferencia automática',
+    },
+    {
+      number: '06',
+      title: 'Documentación y evidencia',
+      description: 'Dossier por proyecto: unifilares, mediciones, mantenimiento y trazabilidad.',
+      image: 'https://storage.googleapis.com/ployai/d4da483b-5503-417b-b1d2-011899258577/user/e411de55-ai-generated-1781791317361.png',
+      imageAlt: 'Dossier con diagrama unifilar eléctrico y mediciones',
+    },
+  ],
+};
+
+export const serviceSingleDemoApproachSteps: Record<number, ServiceSingleApproachStep[]> = {
+  101: [
+    { number: '01', title: 'Relevamiento de red', description: 'Medimos cobertura, puntos de demanda y cuellos de botella en el sitio.' },
+    { number: '02', title: 'Diseño y certificación', description: 'Proyectamos topología, cableado y enlaces con normas y mediciones.' },
+    { number: '03', title: 'Tendido e implementación', description: 'Instalamos cobre, fibra y equipos sin cortar la operación existente.' },
+    { number: '04', title: 'Monitoreo y soporte', description: 'Vigilamos el tráfico, documentamos y respondemos ante cualquier falla.' },
+  ],
+  102: [
+    { number: '01', title: 'Relevamiento de riesgo', description: 'Recorremos el sitio, mapeamos perímetros, accesos y puntos ciegos.' },
+    { number: '02', title: 'Diseño e ingeniería', description: 'Proyectamos CCTV, accesos, intrusión y detección como un solo sistema.' },
+    { number: '03', title: 'Implementación', description: 'Instalamos y configuramos en sitio sin frenar la operación del cliente.' },
+    { number: '04', title: 'Monitoreo y evidencia', description: 'Operamos 24/7, documentamos cada intervención y dejamos trazabilidad.' },
+  ],
+  103: [
+    { number: '01', title: 'Estudio de enlace', description: 'Analizamos línea de vista, distancias y demanda de tráfico entre sitios.' },
+    { number: '02', title: 'Diseño del vínculo', description: 'Definimos radioenlaces, redundancia y telefonía según la operación.' },
+    { number: '03', title: 'Montaje en sitio', description: 'Instalamos torres, antenas y equipos, incluso en sitios remotos.' },
+    { number: '04', title: 'Medición y monitoreo', description: 'Verificamos señal, documentamos y sostenemos el vínculo 24/7.' },
+  ],
+  104: [
+    { number: '01', title: 'Mapa del proceso', description: 'Entendemos cómo trabaja el equipo hoy y dónde se pierde tiempo o control.' },
+    { number: '02', title: 'Diseño funcional', description: 'Definimos flujos, datos e integraciones sobre el proceso real, no genérico.' },
+    { number: '03', title: 'Desarrollo e integración', description: 'Construimos, conectamos los sistemas existentes y validamos con usuarios.' },
+    { number: '04', title: 'Evolución continua', description: 'Mantenemos, medimos y sumamos funciones a medida que crece la operación.' },
+  ],
+  105: [
+    { number: '01', title: 'Onboarding del parque', description: 'Relevamos equipos, servicios críticos y puntos de falla de la operación.' },
+    { number: '02', title: 'Monitoreo y alertas', description: 'Vigilamos en continuo para detectar el problema antes que el usuario.' },
+    { number: '03', title: 'Respuesta y resolución', description: 'Atendemos remoto o en sitio, dentro de los tiempos del SLA acordado.' },
+    { number: '04', title: 'Prevención y reporte', description: 'Mantenimiento programado y reportes con evidencia de cada intervención.' },
+  ],
+  106: [
+    { number: '01', title: 'Relevamiento técnico', description: 'Auditamos el estado real de red, seguridad, energía y sistemas en sitio.' },
+    { number: '02', title: 'Análisis de riesgo', description: 'Identificamos puntos críticos, brechas y dependencias de la operación.' },
+    { number: '03', title: 'Roadmap e inversión', description: 'Priorizamos por impacto y costo, con etapas y plan de inversión claro.' },
+    { number: '04', title: 'Dirección técnica', description: 'Acompañamos la ejecución y validamos resultados con evidencia.' },
+  ],
+  107: [
+    { number: '01', title: 'Estudio de riesgo', description: 'Evaluamos el sitio, las áreas a proteger y la normativa aplicable.' },
+    { number: '02', title: 'Ingeniería del sistema', description: 'Diseñamos centrales, zonificación y sensores para detección temprana.' },
+    { number: '03', title: 'Instalación y pruebas', description: 'Montamos paneles, sensores y alarmas, y probamos cada zona.' },
+    { number: '04', title: 'Mantenimiento y monitoreo', description: 'Sostenemos el sistema con pruebas periódicas y respuesta 24/7.' },
+  ],
+  108: [
+    { number: '01', title: 'Relevamiento de cargas', description: 'Medimos consumo, criticidad y riesgos eléctricos de la infraestructura.' },
+    { number: '02', title: 'Diseño eléctrico', description: 'Proyectamos UPS, tableros, tierra y redundancia para cargas críticas.' },
+    { number: '03', title: 'Montaje y puesta en marcha', description: 'Instalamos y energizamos sin interrumpir lo que ya está operando.' },
+    { number: '04', title: 'Mantenimiento y monitoreo', description: 'Verificamos autonomía, medimos y sostenemos el respaldo 24/7.' },
+  ],
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ const sectorLinks = [
 
 const proofMetrics = [
   ['8', 'servicios IT', 'red, seguridad, software, energía y soporte'],
-  [proofCountShort, 'antecedentes', `${proofCountExact} proyectos reales`],
+  [proofCountShort, 'antecedentes', `${proofCountExact} proyectos técnicos`],
   ['22+', 'años', 'de trayectoria técnica en infraestructura'],
   ['24/7', 'soporte', 'operación y monitoreo continuo']
 ];
@@ -268,7 +268,7 @@ const homeStructuredData = [
           </div>
           <div class="um-evidence-head__side">
             <p>
-              {proofCountExact} proyectos reales en el catálogo respaldan nuestra forma de trabajar: alcance técnico, evidencia y continuidad posterior.
+              {proofCountExact} proyectos técnicos en el catálogo respaldan nuestra forma de trabajar: alcance, evidencia y continuidad posterior.
             </p>
             <a href="/antecedentes">Ver todos los antecedentes</a>
           </div>
@@ -1253,8 +1253,14 @@ const homeStructuredData = [
         align-items: stretch;
       }
 
-      .um-btn {
+      .um-hero-actions :global(.um-btn-primary),
+      .um-hero-actions :global(.um-btn-secondary) {
+        box-sizing: border-box;
         width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        justify-content: center;
+        white-space: normal;
       }
 
       .um-hero-board {
@@ -2244,9 +2250,14 @@ const homeStructuredData = [
     }
 
     @media (max-width: 820px) {
+      :global(html),
+      :global(body) {
+        overflow-x: clip;
+      }
+
       .um-home-hero {
         min-height: auto;
-        overflow-x: hidden;
+        overflow-x: clip;
       }
 
       .um-hero-content {
@@ -2325,10 +2336,18 @@ const homeStructuredData = [
 
       .um-hero-actions {
         width: 100%;
+        min-width: 0;
+        max-width: 100%;
       }
 
-      .um-hero-actions .um-btn {
+      .um-hero-actions :global(.um-btn-primary),
+      .um-hero-actions :global(.um-btn-secondary) {
+        box-sizing: border-box;
         width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        justify-content: center;
+        white-space: normal;
       }
 
       .um-hero-mobile-photo {

--- a/src/pages/servicios/[id]/[slug].astro
+++ b/src/pages/servicios/[id]/[slug].astro
@@ -25,6 +25,11 @@ import { generateSlug } from '../../../utils/slugUtils.js';
 import { getServicioById } from '../../../utils/directusHelpers';
 import { getDirectusImageUrl } from '../../../lib/directus.ts';
 import { getServiceVisualSpec } from '../../../data/serviceVisualSystem';
+import {
+  serviceSingleDemoApproachSteps,
+  serviceSingleDemoCapabilities,
+  serviceSingleDemoCopy,
+} from '../../../data/serviceSingleDemoSystem';
 import { editorialImageDimensions } from '../../../data/editorialImageSystem';
 import {
   plainTextFromHtml,
@@ -73,23 +78,14 @@ if (slug !== expectedSlug) {
 const productos = servicio.productos || [];
 const visual = getServiceVisualSpec(id);
 const serviceImage = visual?.image || getDirectusImageUrl(servicio.Imagen);
-const serviceHeroTitles: Record<number, string> = {
-  101: 'Redes y conectividad para operación continua',
-  102: 'Seguridad electrónica para activos críticos',
-  103: 'Comunicaciones estables para sedes exigentes',
-  104: 'Software operativo para procesos reales',
-  105: 'Soporte 24/7 para continuidad operativa',
-  106: 'Arquitectura IT para decidir con evidencia',
-  107: 'Detección de incendios para infraestructura crítica',
-  108: 'Energía confiable para sistemas IT'
-};
+const demoCopy = serviceSingleDemoCopy[Number(id)];
 const serviceDetailPath = `/servicios/${id}/${expectedSlug}`;
 const datasheetHref = getDatasheetPublicPath(expectedSlug);
 const replicaProd = isReplicaIdenticalCopy();
 const cmsTitle = cmsServiceTitle(servicio.Titulo);
 const cmsSubtitulo = readServiceSubtitulo(servicio);
 const editorialHeroTitle =
-  serviceHeroTitles[Number(id)] || visual?.shortName || cmsTitle || servicio.Titulo;
+  (!replicaProd && demoCopy?.headline) || visual?.shortName || cmsTitle || servicio.Titulo;
 const serviceHeroTitle = resolveReplicaH1(serviceDetailPath, editorialHeroTitle);
 const serviceBreadcrumbLabel = visual?.shortName || cmsTitle;
 const serviceCtaTitle = replicaProd
@@ -98,13 +94,17 @@ const serviceCtaTitle = replicaProd
     ? `Convertir ${visual.shortName.toLowerCase()} en un alcance verificable`
     : 'Convertir este servicio en un alcance verificable';
 const descriptionSectionTitle = replicaProd ? 'Descripción del Servicio' : 'Alcance operativo';
-const processSectionTitle = replicaProd ? 'Nuestro Proceso' : 'Método de implementación';
+const processSectionTitle = replicaProd ? 'Nuestro Proceso' : demoCopy?.approachHeading || 'Método de implementación';
 const sidebarInfoTitle = replicaProd ? 'Información del Servicio' : 'Metadata del servicio';
-const hasCommercialProducts = productos.some(
-  (producto: any) =>
-    ['producto', 'productos'].includes(String(producto.categoria_comercial || '').toLowerCase()) ||
-    Boolean(producto.tipo_producto)
+const isCommercialProduct = (producto: any) => (
+  ['producto', 'productos'].includes(String(producto.categoria_comercial || '').toLowerCase()) ||
+  ['producto', 'productos'].includes(String(producto.categoria_informacion || '').toLowerCase()) ||
+  Boolean(producto.tipo_producto) ||
+  Boolean(producto.slug_producto) ||
+  Boolean(producto.url_producto)
 );
+const commercialProducts = productos.filter(isCommercialProduct);
+const hasCommercialProducts = commercialProducts.length > 0;
 const productsSectionKicker = replicaProd ? '' : hasCommercialProducts ? 'Producto' : 'Equipamiento';
 const productsSectionTitle = replicaProd
   ? 'Productos y Soluciones'
@@ -132,13 +132,6 @@ if (pageTitle.length > 60) {
 }
 const serviceBodySource = servicio.Descripcion?.replace(/\\/g, '\n') || '';
 const serviceDescriptionHtml = await renderEditorialBody(serviceBodySource);
-const solutionBodies = servicio.Soluciones?.length
-  ? await Promise.all(
-      servicio.Soluciones.map((solucion: { descripcion?: string }) =>
-        renderEditorialBody(solucion.descripcion || '')
-      )
-    )
-  : [];
 const rawDesc = stripBannedLedgerPhrases(plainTextFromHtml(serviceBodySource, 500));
 const pageDescription = rawDesc.length > 155 ? rawDesc.slice(0, 155) + '...' :
   rawDesc.length > 0 && rawDesc.length < 120 ? `${rawDesc} Servicios profesionales de ULTIMA MILLA en Mendoza, Cuyo y Patagonia.`.slice(0, 155) :
@@ -147,13 +140,77 @@ const bodyPlainLead = plainTextFromHtml(serviceBodySource, 120);
 const heroLead = serviceHeroLead(
   cmsSubtitulo,
   replicaProd ? undefined : visual?.proof,
-  pageDescription,
+  !replicaProd && demoCopy?.paragraph ? demoCopy.paragraph : pageDescription,
   bodyPlainLead,
 );
 const porQueElegirnos = sanitizeServiceBulletList(servicio.por_que_elegirnos || []);
 const showGenericProcess =
   !replicaProd || porQueElegirnos.length === 0;
-const displayStats = sanitizeServiceStats(servicio.stats || []);
+const displayStats = sanitizeServiceStats(servicio.stats || []).filter(
+  (stat: any) => String(stat?.label || '').trim() && String(stat?.value || '').trim(),
+);
+const serviceBriefItems = [
+  {
+    label: 'Necesidad',
+    value: visual?.proof || 'Continuidad operativa verificable',
+  },
+  {
+    label: 'Método',
+    value: 'Relevamiento, diseño, ejecución y prueba técnica',
+  },
+  {
+    label: 'Salida',
+    value: hasCommercialProducts ? 'Producto, implementación y soporte' : 'Implementación con evidencia técnica',
+  },
+];
+const resolveServiceMedia = (image: unknown) => {
+  const value = String(image || '').trim();
+  if (!value) return serviceImage;
+  if (value.startsWith('/') || /^https?:\/\//i.test(value)) return value;
+  return getDirectusImageUrl(value) || serviceImage;
+};
+const demoCapabilities = serviceSingleDemoCapabilities[Number(id)] || [];
+const cmsCapabilityFallback = servicio.Soluciones || [];
+const serviceCapabilityItems = (demoCapabilities.length ? demoCapabilities : cmsCapabilityFallback)
+  .slice(0, 6)
+  .map((item: any, index: number) => {
+    const title = sanitizeEditorialText(
+      item.title || item.titulo || item.nombre || item.headline || `Capacidad ${index + 1}`
+    );
+    const description =
+      plainTextFromHtml(item.description || item.descripcion || item.servicio_asociado || item.headline || '', 170) ||
+      visual?.proof ||
+      pageDescription;
+    return {
+      number: item.number || String(index + 1).padStart(2, '0'),
+      title,
+      description,
+      image: resolveServiceMedia(item.imagen || item.image),
+      imageAlt: item.imageAlt || `${title} - ${visual?.shortName || cmsTitle}`,
+    };
+  });
+const serviceApproachSteps = serviceSingleDemoApproachSteps[Number(id)] || [
+  {
+    number: '01',
+    title: 'Relevamiento',
+    description: 'Medimos sitio, dependencias, riesgos y prioridades antes de definir alcance.',
+  },
+  {
+    number: '02',
+    title: 'Diseño e ingeniería',
+    description: 'Proyectamos arquitectura, materiales, plazos y responsables con criterio operativo.',
+  },
+  {
+    number: '03',
+    title: 'Implementación',
+    description: 'Ejecutamos en sitio con mínima interrupción y control técnico de cada etapa.',
+  },
+  {
+    number: '04',
+    title: 'Evidencia y soporte',
+    description: 'Entregamos pruebas verificables, documentación útil y continuidad posterior.',
+  },
+];
 const canonicalUrl = `${siteUrl}/servicios/${id}/${slug}`;
 const serviceStrategicLinkGroups = buildServiceStrategicLinkGroups({
   currentPath: serviceDetailPath,
@@ -176,6 +233,13 @@ const serviceStructuredData = {
   "name": seoTitleBase,
   "description": pageDescription,
   "url": canonicalUrl,
+  "mainEntityOfPage": canonicalUrl,
+  "significantLink": [
+    `${siteUrl}/servicios`,
+    `${siteUrl}/antecedentes`,
+    `${siteUrl}/sectores`,
+    `${siteUrl}/contacto`,
+  ],
   "image": serviceImage.startsWith('http') ? serviceImage : `${siteUrl}${serviceImage}`,
   "provider": {
     "@type": "Organization",
@@ -189,11 +253,11 @@ const serviceStructuredData = {
     { "@type": "AdministrativeArea", "name": "Patagonia" }
   ],
   ...(servicio.area && { "serviceType": servicio.area }),
-  ...(productos.length > 0 && {
+  ...(commercialProducts.length > 0 && {
     "hasOfferCatalog": {
       "@type": "OfferCatalog",
       "name": `Productos de ${servicio.Titulo}`,
-      "itemListElement": productos.map((p: any) => ({
+      "itemListElement": commercialProducts.map((p: any) => ({
         "@type": "Offer",
         "itemOffered": {
           "@type": "Service",
@@ -215,24 +279,6 @@ const servicePageStructuredData = [
   }),
 ];
 
-// SVG icon paths para soluciones
-const iconPaths = {
-  'monitor': '<rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>',
-  'headphones': '<path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>',
-  'cloud': '<path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>',
-  'shield': '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>',
-  'cable': '<path d="M4 9a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2"/><path d="M6 9v12"/><path d="M14 15a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2"/><path d="M18 13v-2"/><path d="M6 13h8"/>',
-  'zap': '<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>',
-  'radio': '<circle cx="12" cy="12" r="2"/><path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"/>',
-  'wifi': '<path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/>',
-  'server': '<rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/>',
-  'globe': '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',
-  'code': '<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>',
-  'database': '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>',
-  'smartphone': '<rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/>',
-  'cpu': '<rect x="4" y="4" width="16" height="16" rx="2" ry="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/>',
-  'flame': '<path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>'
-};
 ---
 
 <LayoutV4
@@ -293,13 +339,63 @@ const iconPaths = {
   </section>
 
   <!-- STATS BAR - Componente V4 -->
-  {displayStats.length > 0 && (
+  {displayStats.length > 1 && (
     <StatsBar stats={displayStats} />
   )}
 
   <!-- MAIN CONTENT -->
   <section class="service-detail-main">
     <div class="um-container">
+      <div class="service-executive-brief" aria-label="Resumen ejecutivo del servicio">
+        <div class="service-executive-brief__head">
+          <span>Resumen ejecutivo</span>
+          <h2>Del diagnóstico al alcance verificable.</h2>
+        </div>
+        <dl class="service-executive-brief__ledger">
+          {serviceBriefItems.map((item) => (
+            <div>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {serviceCapabilityItems.length > 0 && (
+        <section class="service-capabilities-showcase" aria-labelledby="service-capabilities-title">
+          <header class="service-capabilities-showcase__head">
+            <span aria-hidden="true"></span>
+            <p>Alcance del servicio</p>
+            <h2 id="service-capabilities-title">Qué cubre {visual?.shortName || cmsTitle}.</h2>
+            <p>
+              {demoCopy?.capabilitiesIntro || 'Un mismo equipo releva, diseña, implementa y sostiene cada frente técnico con evidencia verificable.'}
+            </p>
+          </header>
+
+          <div class="service-capability-grid" aria-label={`Capacidades de ${visual?.shortName || cmsTitle}`}>
+            {serviceCapabilityItems.map((item) => (
+              <article class="service-capability-card">
+                <div class="service-capability-card__media">
+                  <img
+                    src={item.image}
+                    alt={item.imageAlt}
+                    loading="lazy"
+                    decoding="async"
+                    width={editorialImageDimensions.width}
+                    height={editorialImageDimensions.height}
+                  />
+                  <span>{item.number}</span>
+                </div>
+                <div class="service-capability-card__copy">
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+
       <div class="service-detail-main__grid">
 
         <!-- Main Content -->
@@ -312,62 +408,6 @@ const iconPaths = {
               <p>Alcance técnico definido bajo relevamiento de sitio y criterios operativos verificables.</p>
             )}
           </div>
-
-          <!-- Soluciones que Ofrecemos (si existen en formato JS) -->
-          {servicio.Soluciones && servicio.Soluciones.length > 0 && (
-            <div class="mb-8 sm:mb-12">
-              <h3 class="service-detail-subtitle">Soluciones que ofrecemos</h3>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
-                {servicio.Soluciones.map((solucion, solutionIndex) => (
-                  <div class="service-solution-card">
-                    <div>
-                      <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" set:html={iconPaths[solucion.icon] || iconPaths['globe']} />
-                    </div>
-                    <h4 class="font-bold text-um-dark mb-2">{solucion.titulo}</h4>
-                    {solutionBodies[solutionIndex] ? (
-                      <div class="text-base text-um-gray editorial-body editorial-body--compact" set:html={solutionBodies[solutionIndex]} />
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {showGenericProcess && (
-            <>
-              <h3 class="service-detail-subtitle">{processSectionTitle}</h3>
-              <div class="service-process-list">
-                <div>
-                  <span>01</span>
-                  <div>
-                    <h4 class="font-bold text-um-dark">Relevamiento</h4>
-                    <p class="text-um-gray">Análisis completo de su infraestructura actual y requerimientos futuros.</p>
-                  </div>
-                </div>
-                <div>
-                  <span>02</span>
-                  <div>
-                    <h4 class="font-bold text-um-dark">Diseño</h4>
-                    <p class="text-um-gray">Propuesta técnica con planos, materiales y cronograma detallado.</p>
-                  </div>
-                </div>
-                <div>
-                  <span>03</span>
-                  <div>
-                    <h4 class="font-bold text-um-dark">Implementación</h4>
-                    <p class="text-um-gray">Ejecución por técnicos especializados con mínima interrupción operativa.</p>
-                  </div>
-                </div>
-                <div>
-                  <span>04</span>
-                  <div>
-                    <h4 class="font-bold text-um-dark">Evidencia técnica</h4>
-                    <p class="text-um-gray">Testing completo con equipos especializados y entrega de resultados verificables.</p>
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
 
           <!-- Por Qué Elegirnos -->
           {porQueElegirnos.length > 0 && (
@@ -441,8 +481,45 @@ const iconPaths = {
     </div>
   </section>
 
+  {showGenericProcess && (
+    <section class="service-approach-band" aria-labelledby="service-approach-title">
+      <div class="um-container service-approach-band__grid">
+        <figure class="service-approach-band__media">
+          <img
+            src={serviceImage}
+            alt={visual?.imageAlt || servicio.Titulo}
+            loading="lazy"
+            decoding="async"
+            width={editorialImageDimensions.width}
+            height={editorialImageDimensions.height}
+          />
+          <figcaption>{visual?.shortName || cmsTitle} · Mendoza, Cuyo y Patagonia</figcaption>
+        </figure>
+
+        <div class="service-approach-band__copy">
+          <span class="service-approach-band__rule" aria-hidden="true"></span>
+          <p class="service-approach-band__eyebrow">Cómo trabajamos</p>
+          <h2 id="service-approach-title">{processSectionTitle}</h2>
+          <p>
+            {demoCopy?.approachIntro || 'Nadie hereda un problema a medias: el mismo equipo conecta diagnóstico, ingeniería, implementación, prueba y soporte.'}
+          </p>
+
+          <ol class="service-approach-steps">
+            {serviceApproachSteps.map((step) => (
+              <li>
+                <span>{step.number}</span>
+                <h3>{step.title}</h3>
+                <p>{step.description}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  )}
+
   <!-- PRODUCTOS Y EQUIPAMIENTO - Usando componente ProductCard V4 -->
-  {productos.length > 0 && (
+  {commercialProducts.length > 0 && (
     <section class="service-products-section">
       <div class="um-container">
         <div class="service-products-head">
@@ -454,7 +531,7 @@ const iconPaths = {
         </div>
 
         <div class="service-products-list">
-          {productos.map((producto, index) => (
+          {commercialProducts.map((producto, index) => (
             <ProductCard
               titulo={producto.titulo || producto.nombre || 'Equipamiento'}
               descripcion={producto.descripcion || ''}
@@ -469,7 +546,7 @@ const iconPaths = {
               serviceHref={`/servicios/${id}/${slug}`}
               ctaLabel={producto.slug_producto === 'cctv-ai-integrado' ? 'Ver producto' : [102, 107].includes(Number(id)) ? 'Solicitar relevamiento' : 'Cotizar solución'}
               ctaHref={producto.url_producto || (producto.slug_producto === 'cctv-ai-integrado' ? '/cctvai/' : '/contacto')}
-              showActions={producto.slug_producto === 'cctv-ai-integrado' || shouldShowProductCardActions({ index, total: productos.length })}
+              showActions={producto.slug_producto === 'cctv-ai-integrado' || shouldShowProductCardActions({ index, total: commercialProducts.length })}
             />
           ))}
         </div>
@@ -511,7 +588,7 @@ const iconPaths = {
   .service-detail-hero {
     position: relative;
     overflow: hidden;
-    min-height: clamp(360px, 44vh, 470px);
+    min-height: clamp(400px, 50vh, 540px);
     background: #080808;
     color: #fff;
     max-width: 100%;
@@ -527,13 +604,13 @@ const iconPaths = {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    filter: saturate(0.82) contrast(1.12) brightness(0.72);
+    filter: saturate(1.04) contrast(1.08) brightness(0.86);
   }
 
   .service-detail-hero__wash {
     background:
-      linear-gradient(90deg, rgba(8,8,8,0.94) 0%, rgba(8,8,8,0.86) 38%, rgba(8,8,8,0.56) 72%, rgba(8,8,8,0.28) 100%),
-      linear-gradient(0deg, rgba(8,8,8,0.9) 0%, rgba(8,8,8,0.22) 72%);
+      linear-gradient(90deg, rgba(8,8,8,0.94) 0%, rgba(8,8,8,0.84) 34%, rgba(8,8,8,0.38) 68%, rgba(8,8,8,0.08) 100%),
+      linear-gradient(0deg, rgba(8,8,8,0.82) 0%, rgba(8,8,8,0.1) 68%);
   }
 
   .service-detail-hero__content {
@@ -697,7 +774,80 @@ const iconPaths = {
 
   .service-detail-main {
     background: #fff;
-    padding: clamp(44px, 5vw, 70px) 0 clamp(8px, 1.4vw, 18px);
+    padding: clamp(28px, 3.2vw, 44px) 0 clamp(8px, 1.4vw, 18px);
+  }
+
+  .service-executive-brief {
+    display: grid;
+    grid-template-columns: minmax(240px, 0.34fr) minmax(0, 0.66fr);
+    gap: clamp(24px, 4vw, 56px);
+    margin-bottom: clamp(34px, 4vw, 56px);
+    padding: clamp(24px, 3.2vw, 38px);
+    background: #050505;
+    color: #fff;
+  }
+
+  .service-executive-brief__head {
+    min-width: 0;
+  }
+
+  .service-executive-brief__head span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #DC2626;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .service-executive-brief__head span::before {
+    content: "";
+    width: 34px;
+    height: 2px;
+    background: #DC2626;
+  }
+
+  .service-executive-brief__head h2 {
+    max-width: 440px;
+    margin-top: 0.9rem;
+    color: #fff !important;
+    font-size: clamp(1.55rem, 2vw, 2.15rem);
+    font-weight: 600;
+    line-height: 1.12;
+    text-wrap: balance;
+  }
+
+  .service-executive-brief__ledger {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
+    margin: 0;
+    background: rgba(255,255,255,0.18);
+  }
+
+  .service-executive-brief__ledger div {
+    min-width: 0;
+    padding: clamp(16px, 2vw, 22px);
+    background: #101010;
+  }
+
+  .service-executive-brief__ledger dt {
+    color: rgba(255,255,255,0.64);
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-transform: uppercase;
+  }
+
+  .service-executive-brief__ledger dd {
+    margin: 0.65rem 0 0;
+    color: #fff !important;
+    font-size: clamp(1.02rem, 1.1vw, 1.12rem);
+    font-weight: 600;
+    line-height: 1.42;
+    overflow-wrap: anywhere;
   }
 
   .service-detail-main__grid {
@@ -745,79 +895,261 @@ const iconPaths = {
     line-height: 1.78;
   }
 
-  .service-solution-card {
+  .service-capabilities-showcase {
+    margin-bottom: clamp(44px, 5.4vw, 76px);
+    scroll-margin-top: 96px;
+  }
+
+  .service-capabilities-showcase__head {
     display: grid;
-    grid-template-columns: 48px minmax(0, 1fr);
-    gap: 0.95rem 1rem;
-    border: 0;
-    border-radius: 0;
-    padding: 0.85rem 0;
-    background: #fff;
+    max-width: 760px;
+    margin-bottom: clamp(28px, 3.8vw, 46px);
   }
 
-  .service-solution-card + .service-solution-card {
-    margin-top: 0.75rem;
+  .service-capabilities-showcase__head > span {
+    width: 56px;
+    height: 2px;
+    background: #DC2626;
   }
 
-  .service-solution-card > div {
-    grid-row: 1 / 3;
-    width: 44px;
-    height: 44px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 0;
-    border-radius: 4px;
-    border: 0;
-    background: #f4f5f6;
-    color: var(--um-red);
-  }
-
-  .service-solution-card > div svg {
-    color: var(--um-red);
-  }
-
-  .service-solution-card h4,
-  .service-process-list h4 {
-    font-size: 1.08rem;
+  .service-capabilities-showcase__head p:first-of-type {
+    margin: 1.15rem 0 0;
+    color: var(--um-muted);
+    font-size: 1rem;
+    font-weight: 700;
     line-height: 1.25;
+    text-transform: uppercase;
   }
 
-  .service-solution-card p,
-  .service-process-list p,
+  .service-capabilities-showcase__head h2 {
+    margin-top: 0.85rem;
+    color: #111;
+    font-size: clamp(1.8rem, 2.42vw, 2.72rem);
+    font-weight: 600;
+    line-height: 1.14;
+    text-wrap: balance;
+  }
+
+  .service-capabilities-showcase__head p:last-of-type {
+    max-width: 650px;
+    margin: 1.1rem 0 0;
+    color: var(--um-muted);
+    font-size: clamp(1rem, 1.08vw, 1.1rem);
+    line-height: 1.68;
+  }
+
+  .service-capability-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: clamp(20px, 2vw, 32px) clamp(18px, 2vw, 30px);
+  }
+
+  .service-capability-card {
+    min-width: 0;
+    background: #fff;
+    color: #111;
+  }
+
+  .service-capability-card__media {
+    position: relative;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    background: #111;
+  }
+
+  .service-capability-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(0.94) contrast(1.04);
+  }
+
+  .service-capability-card__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0,0,0,0.32) 0%, transparent 46%);
+    pointer-events: none;
+  }
+
+  .service-capability-card__media span {
+    position: absolute;
+    top: 14px;
+    left: 14px;
+    z-index: 1;
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    background: #fff;
+    color: #DC2626;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .service-capability-card__copy {
+    padding: clamp(16px, 1.7vw, 20px) 0 0;
+  }
+
+  .service-capability-card__copy h3 {
+    color: #111;
+    font-size: clamp(1.16rem, 1.28vw, 1.42rem);
+    font-weight: 600;
+    line-height: 1.12;
+    text-wrap: balance;
+  }
+
+  .service-capability-card__copy p,
   .service-why li span,
   .service-info-card {
     font-size: 1rem;
     line-height: 1.62;
   }
 
-  .service-process-list {
-    display: grid;
-    gap: clamp(16px, 2.2vw, 22px);
-    margin-bottom: clamp(18px, 2.5vw, 30px);
-    border-top: 0;
-    background: transparent;
+  .service-capability-card__copy p {
+    margin-top: 0.65rem;
+    color: var(--um-muted);
   }
 
-  .service-process-list > div {
-    display: grid;
-    grid-template-columns: 44px minmax(0, 1fr);
-    gap: 1rem;
-    align-items: start;
-    padding: 0;
-    background: transparent;
-    border-bottom: 0;
+  .service-approach-band {
+    background: #080808;
+    color: #fff;
+    padding: clamp(64px, 7.4vw, 104px) 0;
+    scroll-margin-top: 96px;
   }
 
-  .service-process-list > div > div {
+  .service-approach-band__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.44fr) minmax(0, 0.56fr);
+    gap: clamp(36px, 5vw, 76px);
+    align-items: stretch;
+  }
+
+  .service-approach-band__media {
+    position: relative;
+    min-height: clamp(390px, 36vw, 540px);
+    margin: 0;
+    overflow: hidden;
+    background: #111;
+  }
+
+  .service-approach-band__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(0.92) contrast(1.06);
+  }
+
+  .service-approach-band__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(0deg, rgba(8,8,8,0.82) 0%, rgba(8,8,8,0.08) 62%),
+      linear-gradient(90deg, rgba(8,8,8,0.5) 0%, transparent 42%);
+  }
+
+  .service-approach-band__media figcaption {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: clamp(18px, 2.4vw, 26px);
+    color: rgba(255,255,255,0.86);
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .service-approach-band__media figcaption::before,
+  .service-approach-band__rule {
+    content: "";
+    width: 56px;
+    height: 2px;
+    background: #DC2626;
+    flex: 0 0 auto;
+  }
+
+  .service-approach-band__copy {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     min-width: 0;
   }
 
-  .service-process-list span {
+  .service-approach-band__rule {
+    display: block;
+  }
+
+  .service-approach-band__eyebrow {
+    margin: 1.15rem 0 0;
+    color: rgba(255,255,255,0.62);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .service-approach-band h2 {
+    max-width: 560px;
+    margin-top: 1rem;
+    color: #fff !important;
+    font-size: clamp(1.75rem, 2.35vw, 2.52rem);
+    font-weight: 600;
+    line-height: 1.08;
+    text-wrap: balance;
+  }
+
+  .service-approach-band__copy > p:not(.service-approach-band__eyebrow) {
+    max-width: 540px;
+    margin-top: 1.2rem;
+    color: rgba(255,255,255,0.7);
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+
+  .service-approach-steps {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: clamp(26px, 3vw, 40px) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .service-approach-steps li {
+    min-width: 0;
+    border-top: 1px solid rgba(255,255,255,0.16);
+    padding: clamp(18px, 1.8vw, 24px) clamp(18px, 2vw, 28px) clamp(18px, 1.8vw, 24px) 0;
+  }
+
+  .service-approach-steps li:nth-child(even) {
+    border-left: 1px solid rgba(255,255,255,0.16);
+    padding-left: clamp(18px, 2vw, 28px);
+  }
+
+  .service-approach-steps span {
     color: #DC2626;
     font-size: 1rem;
     font-weight: 700;
-    line-height: 1.25;
+  }
+
+  .service-approach-steps h3 {
+    margin-top: 0.65rem;
+    color: #fff;
+    font-size: clamp(1.08rem, 1.2vw, 1.28rem);
+    font-weight: 600;
+    line-height: 1.18;
+  }
+
+  .service-approach-steps p {
+    margin-top: 0.55rem;
+    color: rgba(255,255,255,0.66);
+    font-size: 1rem;
+    line-height: 1.56;
   }
 
   .service-why {
@@ -843,6 +1175,11 @@ const iconPaths = {
   .service-info-card:first-child {
     position: sticky;
     top: 104px;
+    max-height: calc(100vh - 128px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(17,17,17,0.28) transparent;
   }
 
   .service-info-card--dossier {
@@ -1070,8 +1407,13 @@ const iconPaths = {
 
   @media (max-width: 1120px) {
     .service-detail-hero__grid,
-    .service-detail-main__grid {
+    .service-detail-main__grid,
+    .service-approach-band__grid {
       grid-template-columns: 1fr;
+    }
+
+    .service-capability-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .service-info-card:first-child {
@@ -1155,6 +1497,45 @@ const iconPaths = {
       gap: 32px;
     }
 
+    .service-capabilities-showcase {
+      margin-bottom: 38px;
+      scroll-margin-top: 76px;
+    }
+
+    .service-capability-grid,
+    .service-approach-steps {
+      grid-template-columns: 1fr;
+    }
+
+    .service-capability-card__media,
+    .service-approach-band__media {
+      aspect-ratio: 16 / 10;
+      min-height: 0;
+    }
+
+    .service-approach-band {
+      padding: 56px 0 64px;
+      scroll-margin-top: 76px;
+    }
+
+    .service-approach-steps li,
+    .service-approach-steps li:nth-child(even) {
+      border-left: 0;
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .service-executive-brief {
+      grid-template-columns: 1fr;
+      gap: 18px;
+      margin-bottom: 34px;
+      padding: 20px 16px;
+    }
+
+    .service-executive-brief__ledger {
+      grid-template-columns: 1fr;
+    }
+
     .service-products-section {
       padding-top: 24px;
     }
@@ -1178,6 +1559,11 @@ const iconPaths = {
 
     .service-info-card--dossier {
       padding: 0;
+    }
+
+    .service-info-ledger div {
+      grid-template-columns: 1fr;
+      gap: 0.35rem;
     }
   }
 </style>

--- a/src/pages/servicios/index.astro
+++ b/src/pages/servicios/index.astro
@@ -56,6 +56,12 @@ const servicesStrategicLinkGroups = buildServiceStrategicLinkGroups({
     `${cctvAiProduct.title} ${cctvAiProduct.description}`,
   ].join(' '),
 });
+const servicesIndexSignificantLinks = [
+  'https://www.ultimamilla.com.ar/antecedentes',
+  'https://www.ultimamilla.com.ar/sectores',
+  'https://www.ultimamilla.com.ar/contacto',
+  ...servicios.slice(0, 8).map((servicio) => `https://www.ultimamilla.com.ar${servicio.href}`),
+];
 
 const structuredData = [
   {
@@ -63,7 +69,13 @@ const structuredData = [
     '@type': 'CollectionPage',
     name: 'Servicios IT integrales ULTIMA MILLA',
     description: 'Servicios IT integrales: redes, telecomunicaciones, seguridad electrónica, software, soporte, consultoría, detección de incendios y eléctricos para IT.',
-    url: 'https://www.ultimamilla.com.ar/servicios'
+    url: 'https://www.ultimamilla.com.ar/servicios',
+    significantLink: servicesIndexSignificantLinks,
+    hasPart: servicios.slice(0, 8).map((servicio) => ({
+      '@type': 'WebPage',
+      name: servicio.visual.shortName,
+      url: `https://www.ultimamilla.com.ar${servicio.href}`,
+    })),
   },
   {
     '@context': 'https://schema.org',
@@ -145,7 +157,6 @@ const serviceIconPaths: Record<string, string> = {
         </p>
         <div class="services-actions services-actions--intents">
           <a href="/contacto" class="um-btn-primary">Solicitar diagnóstico</a>
-          <a href="/contacto" class="um-btn-secondary services-secondary-dark">Solicitar relevamiento</a>
           <a href="/antecedentes" class="um-btn-secondary services-secondary-dark">Ver antecedentes</a>
         </div>
         <dl class="services-hero__proofline" aria-label="Prueba institucional">
@@ -169,8 +180,8 @@ const serviceIconPaths: Record<string, string> = {
           <img src={servicesIndexImage} alt="Infraestructura IT operada por ULTIMA MILLA" loading="eager" fetchpriority="high" decoding="async" width={editorialImageDimensions.width} height={editorialImageDimensions.height} />
         </div>
         <div class="services-proof-note">
-          <strong>Diagnóstico, implementación y soporte dentro de una misma cadena operativa.</strong>
-          <p>Acá importa ver cómo se sostiene el servicio en terreno, no repetir indicadores.</p>
+          <strong>Diagnóstico, implementación, evidencia y soporte dentro de una misma cadena operativa.</strong>
+          <p>El servicio debe poder verificarse por alcance, sector, antecedente y continuidad posterior.</p>
         </div>
       </aside>
     </div>
@@ -190,33 +201,33 @@ const serviceIconPaths: Record<string, string> = {
       </div>
 
       <div class="services-dossier">
-        <aside class="services-dossier__folio" aria-label="Criterio operativo de servicios">
-          <div class="services-dossier__image">
-            <img
-              src={servicios[1]?.visual.image || servicios[0]?.visual.image}
-              alt={servicios[1]?.visual.imageAlt || 'Infraestructura IT operativa de ULTIMA MILLA'}
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
-          <div class="services-dossier__note">
-            <span>criterio de diseño</span>
-            <h3>Continuidad operativa primero.</h3>
-            <p>
-              Se priorizan alcance, riesgo, integración y soporte posterior. Cada servicio debe
-              poder vincularse a un antecedente, un responsable y una evidencia técnica.
-            </p>
-          </div>
-        </aside>
+        <div class="services-dossier__brief services-dossier__folio" aria-label="Criterio operativo de servicios">
+          <span>criterio de diseño</span>
+          <strong>Continuidad operativa primero.</strong>
+          <p>
+            Se priorizan alcance, riesgo, integración y soporte posterior. Cada servicio debe
+            poder vincularse a un antecedente, un responsable y una evidencia técnica.
+          </p>
+        </div>
 
-        <div class="services-dossier__list" aria-label="Frentes de servicios IT">
+        <div class="services-dossier__list services-dossier__list--visual" aria-label="Frentes de servicios IT">
           {servicios.map((servicio, index) => (
             <a
               href={servicio.href}
-              class="um-click-surface service-dossier-item"
+              class="um-click-surface service-dossier-item service-dossier-item--visual"
               style={`--service-accent:${servicio.visual.accent};`}
             >
               <span class="service-dossier-item__num">{String(index + 1).padStart(2, '0')}</span>
+              <span class="service-dossier-item__media" aria-hidden="true">
+                <img
+                  src={servicio.visual.image}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  width={editorialImageDimensions.width}
+                  height={editorialImageDimensions.height}
+                />
+              </span>
               <span class="service-dossier-item__icon" aria-hidden="true">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8" set:html={serviceIconPaths[servicio.visual.icon] || serviceIconPaths.network} />
               </span>
@@ -518,36 +529,22 @@ const serviceIconPaths: Record<string, string> = {
 
   .services-dossier {
     display: grid;
-    grid-template-columns: minmax(286px, 0.32fr) minmax(0, 0.68fr);
-    gap: clamp(22px, 3.8vw, 44px);
+    grid-template-columns: 1fr;
+    gap: clamp(18px, 2.8vw, 30px);
     align-items: start;
   }
 
-  .services-dossier__folio {
-    position: sticky;
-    top: 104px;
-    border: 0;
-    background: #fff;
+  .services-dossier__brief {
+    display: grid;
+    grid-template-columns: minmax(180px, 0.28fr) minmax(240px, 0.28fr) minmax(0, 0.44fr);
+    gap: clamp(14px, 2.4vw, 28px);
+    align-items: center;
+    padding: clamp(18px, 2.2vw, 26px) clamp(18px, 2.4vw, 28px);
+    border-top: 1px solid var(--um-line);
+    border-bottom: 1px solid var(--um-line);
   }
 
-  .services-dossier__image {
-    aspect-ratio: 16 / 10;
-    overflow: hidden;
-    background: #111;
-  }
-
-  .services-dossier__image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    filter: saturate(0.92) contrast(1.04);
-  }
-
-  .services-dossier__note {
-    padding: clamp(18px, 2vw, 22px) 0 0;
-  }
-
-  .services-dossier__note span {
+  .services-dossier__brief span {
     display: block;
     color: var(--um-red);
     font-size: 1rem;
@@ -556,17 +553,17 @@ const serviceIconPaths: Record<string, string> = {
     text-transform: uppercase;
   }
 
-  .services-dossier__note h3 {
-    margin-top: 12px;
+  .services-dossier__brief strong {
     color: var(--skin-text);
-    font-size: clamp(1.35rem, 1.85vw, 1.95rem);
+    font-family: var(--um-font-display);
+    font-size: clamp(1.28rem, 1.52vw, 1.62rem);
     line-height: 1.12;
     font-weight: 600;
     text-wrap: balance;
   }
 
-  .services-dossier__note p {
-    margin-top: 12px;
+  .services-dossier__brief p {
+    margin: 0;
     color: var(--skin-muted);
     font-size: 1rem;
     line-height: 1.58;
@@ -574,57 +571,94 @@ const serviceIconPaths: Record<string, string> = {
 
   .services-dossier__list {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    scroll-margin-top: 96px;
     border: 0;
     background: transparent;
-    gap: 1px;
+    gap: clamp(12px, 1.45vw, 18px);
   }
 
   .service-dossier-item {
-    display: grid;
-    grid-template-columns: 34px 42px minmax(0, 1fr);
-    grid-template-areas:
-      "num icon body"
-      ". . signal";
-    gap: 0 14px;
-    min-height: 166px;
-    padding: clamp(18px, 2vw, 23px);
+    position: relative;
+    display: flex;
+    min-height: 100%;
+    flex-direction: column;
     border: 0;
-    background: var(--skin-panel);
+    background: #fff;
     color: var(--skin-text);
     transition: background-color 180ms ease;
   }
 
-  .service-dossier-item:hover,
+  @media (hover: hover) {
+    .service-dossier-item:hover {
+      background: color-mix(in srgb, var(--skin-panel, #fff) 88%, var(--um-red) 12%);
+    }
+  }
+
   .service-dossier-item:focus-visible {
-    background: color-mix(in srgb, var(--skin-panel) 92%, var(--um-red) 8%);
+    outline: 3px solid color-mix(in srgb, var(--um-red) 72%, #fff 28%);
+    outline-offset: 3px;
   }
 
   .service-dossier-item__num {
-    grid-area: num;
+    position: absolute;
+    left: 14px;
+    top: 14px;
+    z-index: 2;
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    background: var(--skin-panel, #fff);
     color: var(--um-red);
     font-size: 1rem;
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1;
+  }
+
+  .service-dossier-item__media {
+    position: relative;
+    display: block;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    background: #111;
+  }
+
+  .service-dossier-item__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0.34) 0%, transparent 42%),
+      linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, transparent 54%);
+    pointer-events: none;
+  }
+
+  .service-dossier-item__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(0.92) contrast(1.05);
   }
 
   .service-dossier-item__icon {
-    grid-area: icon;
     display: grid;
-    width: 34px;
-    height: 34px;
+    width: 42px;
+    height: 42px;
+    margin: clamp(16px, 1.8vw, 22px) clamp(16px, 1.8vw, 22px) 0;
     place-items: center;
+    background: color-mix(in srgb, var(--service-accent, var(--um-red)) 12%, var(--skin-panel, #fff) 88%);
     color: var(--service-accent, var(--um-red));
   }
 
   .service-dossier-item__icon svg {
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
   }
 
   .service-dossier-item__body {
-    grid-area: body;
     min-width: 0;
+    padding: clamp(14px, 1.8vw, 20px) clamp(16px, 1.8vw, 22px) 0;
   }
 
   .service-dossier-item__body > span {
@@ -637,10 +671,10 @@ const serviceIconPaths: Record<string, string> = {
 
   .service-dossier-item__body strong {
     display: block;
-    margin-top: 7px;
+    margin-top: 9px;
     color: var(--skin-text);
     font-family: var(--um-font-display);
-    font-size: clamp(1.12rem, 1.22vw, 1.28rem);
+    font-size: clamp(1.18rem, 1.34vw, 1.5rem);
     line-height: 1.12;
     font-weight: 600;
     text-wrap: balance;
@@ -656,12 +690,11 @@ const serviceIconPaths: Record<string, string> = {
   }
 
   .service-dossier-item__signal {
-    grid-area: signal;
-    align-self: start;
+    align-self: stretch;
     width: fit-content;
-    margin-top: 12px;
+    margin: auto clamp(16px, 1.8vw, 22px) 0;
     border-top: 2px solid var(--um-red);
-    padding-top: 10px;
+    padding: 12px 0 clamp(16px, 1.8vw, 22px);
     color: var(--skin-text);
     font-size: 1rem;
     font-weight: 700;
@@ -1149,23 +1182,56 @@ const serviceIconPaths: Record<string, string> = {
     .services-final-cta div div {
       justify-content: flex-start;
     }
+
+    .services-dossier__brief {
+      grid-template-columns: 1fr;
+      align-items: start;
+    }
+
+    .services-dossier__list {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 
   @media (max-width: 640px) {
+    :global(html),
+    :global(body) {
+      overflow-x: clip;
+    }
+
     .services-hero {
       padding-top: 34px;
       padding-bottom: 30px;
+      max-width: 100%;
+      overflow-x: clip;
     }
 
     .services-breadcrumb {
       display: none;
     }
 
-    .services-hero h1 {
+    .services-hero__grid,
+    .services-dossier-head,
+    .services-dossier__brief,
+    .services-dossier__list,
+    .services-product-feature,
+    .services-intent-ctas {
+      min-width: 0;
       max-width: 100%;
-      font-size: clamp(2.125rem, 8.3vw, 2.22rem) !important;
+    }
+
+    .services-hero h1 {
+      max-width: calc(100vw - 32px);
+      font-size: clamp(2rem, 8.3vw, 2.22rem) !important;
       line-height: 1.1 !important;
-      text-wrap: balance !important;
+      overflow-wrap: anywhere;
+      text-wrap: wrap !important;
+    }
+
+    .services-dossier-head h2 {
+      max-width: calc(100vw - 32px);
+      overflow-wrap: anywhere;
+      text-wrap: wrap;
     }
 
     .service-row h3 {
@@ -1194,14 +1260,22 @@ const serviceIconPaths: Record<string, string> = {
 
     .services-actions {
       margin-top: 16px;
-    }
-
-    .services-actions .um-btn-primary {
       width: 100%;
-      justify-content: center;
+      min-width: 0;
+      max-width: 100%;
     }
 
-    .services-actions .services-secondary-dark {
+    .services-actions :global(.um-btn-primary),
+    .services-actions :global(.um-btn-secondary) {
+      box-sizing: border-box;
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
+      justify-content: center;
+      white-space: normal;
+    }
+
+    .services-actions :global(.services-secondary-dark) {
       display: none;
     }
 
@@ -1214,6 +1288,15 @@ const serviceIconPaths: Record<string, string> = {
     .services-intent-ctas {
       grid-template-columns: 1fr;
     }
+
+        .services-dossier__list {
+          order: 0;
+          scroll-margin-top: 76px;
+        }
+
+        .services-dossier__folio {
+          order: 1;
+        }
 
     .services-products-band {
       margin-top: 34px;
@@ -1286,24 +1369,13 @@ const serviceIconPaths: Record<string, string> = {
       word-break: normal;
     }
 
-    .services-dossier__folio {
-      position: static;
-      order: 1;
-    }
-
-    .services-dossier__list {
-      order: 0;
-    }
-
     .service-dossier-item {
       min-height: auto;
-      padding: 24px 0;
       border-right: 0;
-      grid-template-columns: auto minmax(0, 1fr);
-      grid-template-areas:
-        "num body"
-        "icon body"
-        "signal signal";
+    }
+
+    .service-dossier-item__media {
+      aspect-ratio: 16 / 10;
     }
 
     .service-row {


### PR DESCRIPTION
## Summary
- Align Home, Services index, and service single templates with the demo-style service system.
- Add explicit editorial copy/capabilities/approach data for service singles 101-108.
- Keep commercial products precise: only real product entries render in service singles.
- Fix mobile alignment/overflow hardening for service CTAs, service proofline, sidebar ledger, and footer email wrapping.

## Validation
- npm run typecheck
- npm run audit:css
- npm test (33 suites, 261 tests)
- npm run build
- Local production preview smoke: Home, /servicios, and service singles 101-108 all 200 with expected H1/product behavior.
- Chrome CDP layout audit at 390x900 and 1440x1200 for Home, /servicios, and service 102: overflow 0, no offscreen elements.
- Production preflight: https://www.ultimamilla.com.ar/, /servicios, and service 102 return HTTP 200.
- Directus production health via server-local read-only curl: {"status":"ok"}.

## Production path
No manual server changes. This PR targets develop; production deployment remains develop -> master -> GitHub Actions per repository rules.