### PR TITLE
release: seo geo metadata cleanup

### DIFF
--- a/__tests__/seoMetaPolicy.test.ts
+++ b/__tests__/seoMetaPolicy.test.ts
@@ -34,6 +34,57 @@ describe('human SEO metatag policy', () => {
     expect(meta.description.length).toBeLessThanOrEqual(SEO_META_LIMITS.description);
   });
 
+  test('keeps real client context visible for repeated case titles', () => {
+    const hospital = buildCaseSeoMeta({
+      title: 'Asistencia técnica SDI',
+      client: 'Hospital A Italo Perrupato',
+      identifier: 3216,
+    });
+    const cela = buildCaseSeoMeta({
+      title: 'Asistencia técnica SDI',
+      client: 'Cela SA',
+      identifier: 3303,
+    });
+
+    expect(hospital.title).toContain('Hospital A Italo');
+    expect(cela.title).toContain('Cela SA');
+    expect(hospital.title).not.toBe(cela.title);
+    expect(hospital.title.length).toBeLessThanOrEqual(SEO_META_LIMITS.title);
+  });
+
+  test('preserves differentiating context when the base case title is long', () => {
+    const meta = buildCaseSeoMeta({
+      title: 'Reparación de Central de detección de incendio Firewarden 100X.',
+      client: 'Allex S.A',
+      identifier: 3134,
+    });
+
+    expect(meta.title).toContain('Allex S.A');
+    expect(meta.title.length).toBeLessThanOrEqual(SEO_META_LIMITS.title);
+  });
+
+  test('uses the public case code when the client already repeats the title', () => {
+    const meta = buildCaseSeoMeta({
+      title: 'Conectividad & Redes: Insumo de red - Municipalidad de Gral San Martín',
+      client: 'Municipalidad de Gral San Martín',
+      identifier: 3159,
+    });
+
+    expect(meta.title).toContain('UM-3159');
+    expect(meta.title.length).toBeLessThanOrEqual(SEO_META_LIMITS.title);
+  });
+
+  test('expands short case descriptions with useful operational context', () => {
+    const meta = buildCaseSeoMeta({
+      title: "alojamietno y ss's para guaymallén",
+      description: 'Ejecución integral de alojamietno y ss',
+    });
+
+    expect(meta.description.length).toBeGreaterThanOrEqual(SEO_META_LIMITS.minimumDescription);
+    expect(meta.description).toContain('ULTIMA MILLA');
+    expect(meta.description.length).toBeLessThanOrEqual(SEO_META_LIMITS.description);
+  });
+
   test('humanizes CMS case-card descriptions without changing the real title', () => {
     const meta = buildCaseSeoMeta({
       title: 'Diagnóstico de Infraestructura IT',

--- a/src/pages/antecedentes/[id]/[slug].astro
+++ b/src/pages/antecedentes/[id]/[slug].astro
@@ -366,11 +366,19 @@ const compactCaseTitle = (value: unknown, client?: unknown): string => {
 // SEO
 const siteUrl = 'https://www.ultimamilla.com.ar';
 const canonicalUrl = toCanonicalUrl(`/antecedentes/${id}/${slugFromUrl}`);
+const caseSeoDescriptionSource = [
+  antecedente.displayDescription || caseBodySource,
+  caseRecordSummary,
+  caseCalloutText,
+  scopeItems[0],
+].filter(Boolean).join('. ');
 const caseSeo = buildCaseSeoMeta({
   title: antecedente.displayTitle || antecedente.Titulo || antecedente.Nombre,
-  description: antecedente.displayDescription || caseBodySource,
+  description: caseSeoDescriptionSource,
+  client: displayClientName || antecedente.Cliente,
   area: antecedente.Area || antecedente.Unidad_de_negocio,
   date: antecedente.Fecha,
+  identifier: id,
 });
 const metaDescription = caseSeo.description;
 const structuredImageUrl = publicImageUrl(caseSeoImageUrl) || toCanonicalUrl(DEFAULT_IMAGE_URL);

--- a/src/utils/seoMetaPolicy.ts
+++ b/src/utils/seoMetaPolicy.ts
@@ -32,6 +32,8 @@ export interface CaseSeoMetaInput {
   description?: unknown;
   area?: unknown;
   date?: unknown;
+  client?: unknown;
+  identifier?: unknown;
 }
 
 export interface BlogSeoMetaInput {
@@ -111,6 +113,69 @@ export function buildHumanSeoTitle(rawTitle: unknown, options: BuildSeoTitleOpti
   return `${compactTitle}${suffix}`.slice(0, maxLength).trim();
 }
 
+function normalizeForSeoComparison(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es-AR')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function appearsInsideTitle(title: string, context: string): boolean {
+  const normalizedTitle = normalizeForSeoComparison(title);
+  const normalizedContext = normalizeForSeoComparison(context);
+  return Boolean(
+    normalizedContext.length > 8
+    && normalizedTitle.includes(normalizedContext),
+  );
+}
+
+function uniqueContextParts(parts: string[]): string[] {
+  const seen = new Set<string>();
+  return parts.filter((part) => {
+    const key = normalizeForSeoComparison(part);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildCaseSeoTitle(input: CaseSeoMetaInput): string {
+  const title = cleanSeoText(input.title) || 'Antecedente técnico';
+  const client = cleanSeoText(input.client);
+  const area = cleanSeoText(input.area);
+  const year = cleanSeoText(input.date).match(/\b(20\d{2}|19\d{2})\b/)?.[1] || '';
+  const identifier = cleanSeoText(input.identifier);
+  const caseCode = identifier ? `UM-${identifier}` : '';
+  const clientIsGeneric = /cliente\s+confidencial/i.test(client);
+  const clientRepeatsTitle = client ? appearsInsideTitle(title, client) : false;
+  const areaRepeatsTitle = area ? appearsInsideTitle(title, area) : false;
+  const contextParts = uniqueContextParts([
+    client && !clientIsGeneric && !clientRepeatsTitle ? client : '',
+    clientIsGeneric && caseCode ? `Confidencial ${caseCode}` : '',
+    !areaRepeatsTitle && !client && caseCode ? area : '',
+    clientRepeatsTitle && caseCode ? caseCode : '',
+    !client && !area && caseCode && year ? year : '',
+    !client && !area && !year ? caseCode : '',
+  ].filter(Boolean));
+
+  if (contextParts.length === 0) return buildHumanSeoTitle(title);
+
+  const siteName = SITE_NAME;
+  const maxLength = SEO_META_LIMITS.title;
+  const suffix = ` | ${siteName}`;
+  const available = Math.max(24, maxLength - suffix.length);
+  const minBaseLength = Math.min(28, Math.max(20, Math.floor(available * 0.46)));
+  const maxContextLength = Math.max(14, available - minBaseLength - 3);
+  const context = trimAtWordBoundary(contextParts.join(' · '), maxContextLength);
+  const baseLength = Math.max(18, available - context.length - 3);
+  const compactTitle = trimAtWordBoundary(title, baseLength);
+
+  return `${compactTitle} · ${context}${suffix}`.slice(0, maxLength).trim();
+}
+
 export function buildHumanSeoDescription(
   primary: unknown,
   fallbackParts: unknown[] = [],
@@ -140,16 +205,18 @@ export function buildHumanSeoDescription(
 export function buildCaseSeoMeta(input: CaseSeoMetaInput) {
   const title = cleanSeoText(input.title) || 'Antecedente técnico';
   const area = cleanSeoText(input.area);
+  const client = cleanSeoText(input.client);
   const year = cleanSeoText(input.date).match(/\b(20\d{2}|19\d{2})\b/)?.[1] || '';
   const sourceDescription = humanizeCaseDescriptionTemplate(cleanSeoText(input.description));
   const description = buildHumanSeoDescription(sourceDescription, [
     title,
+    client ? `Proyecto para ${client}` : '',
     area ? `Trabajo relacionado con ${area}` : '',
     year ? `Registro del proyecto en ${year}` : '',
   ]);
 
   return {
-    title: buildHumanSeoTitle(title),
+    title: buildCaseSeoTitle(input),
     description,
   };
 }


### PR DESCRIPTION
## Summary
- Release SEO/GEO metadata cleanup for antecedente detail pages
- Fixes repeated case title tags by preserving real client/context in SEO titles
- Expands short case descriptions using existing page context

## Validation
- PR #141 passed GitHub PR checks
- Local: npm run typecheck, npm run audit:css, npm run lint, npm run build, npm run test:ci

## Production checks after merge
- Run production SEO/GEO audit
- Crawl sitemap metadata for duplicate titles and short descriptions
- Validate Directus internal health and representative Directus-backed pages